### PR TITLE
chore: add GitHub Packages publishing workflow and NPX usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,63 @@ Meaning:
 - show the clear-context option after accepting a plan
 - defer MCP tool loading unless tools fit within 5% of context
 
+
+## GitHub Packages release workflow
+
+This repo includes a GitHub Actions workflow at:
+
+```text
+.github/workflows/nodejs-package.yml
+```
+
+It runs on GitHub Release creation:
+
+```text
+release.created
+```
+
+The workflow:
+
+```text
+1. checks out the repo
+2. installs dependencies with npm ci
+3. runs npm test
+4. verifies package contents with npm pack --dry-run
+5. publishes to GitHub Packages
+```
+
+GitHub Packages for npm requires a scoped package name, so the workflow keeps the source package as `repo-pattern` but temporarily publishes it as:
+
+```text
+@<github-owner>/repo-pattern
+```
+
+The publish job uses `GITHUB_TOKEN` with `packages: write`.
+
+## NPX usage
+
+After publishing to npm:
+
+```bash
+npx repo-pattern init --target . --profile web
+```
+
+Other commands:
+
+```bash
+npx repo-pattern doctor --target .
+npx repo-pattern audit --target .
+npx repo-pattern mcp --target . --profile research
+npx repo-pattern rules --target .
+```
+
+Package-local development test:
+
+```bash
+npm pack
+npm exec --yes --package ./repo-pattern-0.0.2.tgz -- repo-pattern --help
+```
+
 ## Setup guide
 
 The main setup instructions are consolidated in:

--- a/docs/repo-pattern/setup-guide.md
+++ b/docs/repo-pattern/setup-guide.md
@@ -20,6 +20,59 @@ minimal Claude Code setup
 
 ---
 
+
+## GitHub Packages publishing
+
+The repository includes:
+
+```text
+.github/workflows/nodejs-package.yml
+```
+
+Create a GitHub Release to trigger publishing.
+
+The workflow publishes to GitHub Packages with:
+
+```text
+registry-url: https://npm.pkg.github.com/
+NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+Because GitHub Packages only supports scoped npm package names, the workflow temporarily changes the package name during CI to:
+
+```text
+@<github-owner>/repo-pattern
+```
+
+The source `package.json` remains:
+
+```json
+{
+  "name": "repo-pattern"
+}
+```
+
+## NPX package usage
+
+When published to npm, `repo-pattern` can be used without cloning the repository:
+
+```bash
+npx repo-pattern init --target . --profile web
+```
+
+The package exposes one CLI binary:
+
+```text
+repo-pattern
+```
+
+Local package test before publishing:
+
+```bash
+npm pack
+npm exec --yes --package ./repo-pattern-0.0.2.tgz -- repo-pattern --help
+```
+
 ## 1. One-step setup for a new project
 
 Run from the `repo-pattern` repository:

--- a/package.json
+++ b/package.json
@@ -1,21 +1,26 @@
 {
   "name": "repo-pattern",
-  "version": "2.0.0",
+  "version": "0.0.2",
   "description": "Minimal ECC-first Claude Code project initializer and migrator",
   "type": "module",
   "bin": {
     "repo-pattern": "scripts/repo-pattern.mjs"
   },
   "scripts": {
-    "doctor": "node scripts/repo-pattern.mjs doctor --target .",
     "audit": "node scripts/repo-pattern.mjs audit --target .",
-    "mcp:web": "node scripts/repo-pattern.mjs mcp --target . --profile web"
+    "doctor": "node scripts/repo-pattern.mjs doctor --target .",
+    "mcp:web": "node scripts/repo-pattern.mjs mcp --target . --profile web",
+    "test": "node scripts/repo-pattern.mjs doctor --target .",
+    "pack:dry": "npm pack --dry-run",
+    "prepublishOnly": "npm test && npm run pack:dry"
   },
   "license": "MIT",
   "keywords": [
+    "repo-pattern",
     "claude-code",
     "everything-claude-code",
     "ecc",
+    "ecc-first",
     "mcp",
     "mcp-server",
     "mcp-profiles",
@@ -29,5 +34,21 @@
     "automation",
     "nodejs",
     "javascript"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "files": [
+    "scripts/",
+    ".claude/",
+    "docs/",
+    "mcp/",
+    ".mcp.json.example",
+    ".repo-pattern.json",
+    ".repo-pattern.lock.json",
+    "CLAUDE.md",
+    "README.md",
+    "LICENSE",
+    ".github/workflows/"
   ]
 }


### PR DESCRIPTION
- Add .github/workflows/nodejs-package.yml for release publishing
- Document GitHub Packages scoped package name (@<owner>/repo-pattern)
- Add NPX usage examples to README and setup-guide
- Update package.json: version 0.0.2, test/pack:dry/prepublishOnly scripts, keywords, engines, files