### PR TITLE
chore: release v0.1.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@negikirin/repo-pattern",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@negikirin/repo-pattern",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^0.11.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@negikirin/repo-pattern",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "Minimal ECC-first Claude Code project setup and migrator",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- bump package version to 0.1.6
- include setup template relocation and nested repo-pattern state
- add uv guidance when Python ECC rules are selected

## Test plan
- [x] self-check passes
- [x] clean-checkout npm test passes
- [x] npm pack --dry-run reports version 0.1.6

🤖 Generated with [Claude Code](https://claude.com/claude-code)