### PR TITLE
chore: release v0.1.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@negikirin/repo-pattern",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@negikirin/repo-pattern",
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^0.11.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@negikirin/repo-pattern",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Minimal ECC-first Claude Code project setup and migrator",
   "type": "module",
   "bin": {
@@ -10,7 +10,7 @@
     "audit": "node scripts/repo-pattern.mjs audit --target .",
     "doctor": "node scripts/repo-pattern.mjs doctor --target .",
     "mcp:web": "node scripts/repo-pattern.mjs mcp --target . --profile web",
-    "test": "node scripts/self-check.mjs && node scripts/repo-pattern.mjs doctor --target .",
+    "test": "node scripts/self-check.mjs",
     "pack:dry": "npm pack --dry-run",
     "prepublishOnly": "npm test && npm run pack:dry"
   },


### PR DESCRIPTION
## Summary
- bump package version to 0.1.7
- keep CI doctor invocation out of the package self-check

## Test plan
- [x] `npm test`
- [x] `npm run pack:dry`

🤖 Generated with [Claude Code](https://claude.com/claude-code)