### PR TITLE
feat: add Herdr skill and persist MCP keys

### DIFF
--- a/.claude.example/settings.local.example.json
+++ b/.claude.example/settings.local.example.json
@@ -24,7 +24,6 @@
   "env": {
     "ENABLE_TOOL_SEARCH": "auto:5",
     "ANTHROPIC_BASE_URL": "https://example.com/v1",
-    "ANTHROPIC_AUTH_TOKEN": "replace-with-your-token-in-settings.local.json",
     "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-4-8",
     "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-sonnet-4-6",
     "ANTHROPIC_DEFAULT_HAIKU_MODEL": "claude-haiku-4-5",

--- a/README.md
+++ b/README.md
@@ -109,7 +109,6 @@ target-project/
 │   ├── .repo-pattern.json
 │   └── .repo-pattern.lock.json
 ```
-```
 
 `repo-pattern` preserves an existing root `CLAUDE.md` and keeps machine-local values out of git.
 
@@ -122,7 +121,7 @@ target-project/
 * `.claude/settings.json` keeps `hooks: {}` and disables commit attribution by default; interactive setup can turn it on or use a custom trailer.
 * No vendored ECC skills, commands, hooks, scripts, or rules are installed unless explicitly requested.
 * Karpathy-inspired Claude Code guidelines are included in `.claude/CLAUDE.md` from `multica-ai/andrej-karpathy-skills` (MIT).
-* Optional external skills are user opt-in only: `--with-skill taste`, `--with-skill document-specialist`, `--with-skill ui-ux-pro-max`, `--with-skill impeccable`, `--with-skill huashu-design`, `--with-skill nextjs-pattern`, `--with-skill fastapi-pattern`, or interactive setup.
+* Optional external skills are user opt-in only: `--with-skill taste`, `--with-skill document-specialist`, `--with-skill ui-ux-pro-max`, `--with-skill impeccable`, `--with-skill huashu-design`, `--with-skill nextjs-pattern`, `--with-skill fastapi-pattern`, `--with-skill herdr`, or interactive setup.
 
 ## External guidance and skills
 
@@ -136,6 +135,7 @@ target-project/
 | `huashu-design` | Optional `.claude/skills/` install via `--with-skill huashu-design` (multimedia scripts may need Playwright/Python/ffmpeg; install can take \~10 minutes, so opt in deliberately) | https://github.com/alchaincyf/huashu-design/ | MIT |
 | `nextjs-pattern` | Optional `.claude/skills/` install via `--with-skill nextjs-pattern` | https://github.com/NegiKirin/nextjs-pattern/ | MIT |
 | `fastapi-pattern` | Optional `.claude/skills/` install via `--with-skill fastapi-pattern` | https://github.com/NegiKirin/fastapi-pattern/ | MIT |
+| `herdr` | Optional `.claude/skills/` install via `--with-skill herdr`; control commands require `HERDR_ENV=1` inside Herdr | https://github.com/ogulcancelik/herdr/ | AGPL-3.0-or-later or commercial |
 
 ## Learn more
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -59,3 +59,9 @@ Optional skills are not bundled with repo-pattern. When explicitly selected by t
 
 - Source: https://github.com/NegiKirin/fastapi-pattern/
 - License: MIT
+
+### Herdr
+
+- Source: https://github.com/ogulcancelik/herdr/
+- License: AGPL-3.0-or-later or commercial
+- Copyright (c) 2025 Ogulcan Celik and contributors

--- a/docs/repo-pattern/setup-guide.md
+++ b/docs/repo-pattern/setup-guide.md
@@ -85,7 +85,7 @@ For scripts or CI, use the non-interactive path:
 node scripts/repo-pattern.mjs setup --target ~/Code/my-app --profile web --yes
 ```
 
-Setup first checks `claude --version`, then uses a library-backed terminal wizard. It can auto-detect ECC rules or let you choose rule packs by type, asks for selected MCP API keys/relative paths when needed, then asks for Anthropic provider/model values and writes them to the target's gitignored `.claude/settings.local.json`.
+Setup first checks `claude --version`, then uses a library-backed terminal wizard. It can auto-detect ECC rules or let you choose rule packs by type, asks for selected MCP API keys/relative paths when needed, then asks for Anthropic provider/model values and writes reusable local values to the target's gitignored `.claude/settings.local.json`. `CONTEXT7_API_KEY` and `TAVILY_API_KEY` are reused on later setup/MCP runs; `ANTHROPIC_AUTH_TOKEN` is never persisted.
 
 Keys:
 
@@ -111,9 +111,9 @@ For non-interactive scripts, use `setup --yes`.
 4. Write `.claude/CLAUDE.md` if missing.
 5. Write `.claude/settings.json` from `.claude.example/settings.example.json`.
 6. In interactive setup, ask whether commit attribution is off, on, or custom.
-7. During `setup`, write gitignored `.claude/settings.local.json` from prompted provider/model values.
+7. During `setup`, write gitignored `.claude/settings.local.json` from prompted provider/model values, excluding `ANTHROPIC_AUTH_TOKEN`.
 8. Read MCP profiles and server definitions from `repo-pattern`.
-9. In interactive mode, ask for selected MCP API keys and relative paths when placeholders require them.
+9. In interactive mode, reuse persisted `CONTEXT7_API_KEY`/`TAVILY_API_KEY` values or ask for missing MCP API keys and relative paths when placeholders require them.
 10. Generate `.mcp.json` from the selected profile.
 11. Write `.repo-pattern/.repo-pattern.json` from `.repo-pattern.example.json`.
 12. Create `.repo-pattern/.gitignore` with `*`.
@@ -169,7 +169,8 @@ repo-pattern setup --with-skill impeccable --yes
 repo-pattern setup --with-skill huashu-design --yes
 repo-pattern setup --with-skill nextjs-pattern --yes
 repo-pattern setup --with-skill fastapi-pattern --yes
-repo-pattern setup --with-skills taste,document-specialist,ui-ux-pro-max,impeccable,huashu-design,nextjs-pattern,fastapi-pattern --yes
+repo-pattern setup --with-skill herdr --yes
+repo-pattern setup --with-skills taste,document-specialist,ui-ux-pro-max,impeccable,huashu-design,nextjs-pattern,fastapi-pattern,herdr --yes
 ```
 
 Available optional skills:
@@ -181,6 +182,7 @@ Available optional skills:
 - `huashu-design` — `.claude/skills/` copy from https://github.com/alchaincyf/huashu-design/ (MIT; scripts may need Playwright, Python, and ffmpeg).
 - `nextjs-pattern` — `.claude/skills/` copy from https://github.com/NegiKirin/nextjs-pattern/ (MIT).
 - `fastapi-pattern` — `.claude/skills/` copy from https://github.com/NegiKirin/fastapi-pattern/ (MIT).
+- `herdr` — `.claude/skills/` copy from https://github.com/ogulcancelik/herdr/ (AGPL-3.0-or-later or commercial; control commands require `HERDR_ENV=1` inside a running Herdr session).
 
 ---
 
@@ -206,7 +208,7 @@ or regenerate later:
 node scripts/repo-pattern.mjs mcp --target /path/to/project --profile <profile>
 ```
 
-Interactive `setup` and `mcp` ask for selected MCP placeholders such as `CONTEXT7_API_KEY` and `TAVILY_API_KEY`. The filesystem MCP server uses the target project root (`.`) as its allowed directory. Other MCP paths, when prompted, must be relative (`src`, `packages/api`); absolute machine paths and `..` are rejected. With `--yes` or non-TTY runs, unresolved secret placeholders stay in `.mcp.json` and the CLI prints the values to fill later.
+Interactive `setup` asks for selected MCP placeholders such as `CONTEXT7_API_KEY` and `TAVILY_API_KEY`; entered keys are saved in gitignored `.claude/settings.local.json` and reused by later `setup` and `mcp` runs. `ANTHROPIC_AUTH_TOKEN` is never saved there or in repo-pattern setup state. The filesystem MCP server uses the target project root (`.`) as its allowed directory. Other MCP paths, when prompted, must be relative (`src`, `packages/api`); absolute machine paths and `..` are rejected. With `--yes` or non-TTY runs, unresolved secret placeholders stay in `.mcp.json` and the CLI prints the values to fill later.
 
 ---
 
@@ -470,13 +472,14 @@ Local preferences and Anthropic provider/model values should go in:
 
 ```text
 ANTHROPIC_BASE_URL
-ANTHROPIC_AUTH_TOKEN
 ANTHROPIC_DEFAULT_OPUS_MODEL
 ANTHROPIC_DEFAULT_SONNET_MODEL
 ANTHROPIC_DEFAULT_HAIKU_MODEL
+CONTEXT7_API_KEY (when selected)
+TAVILY_API_KEY (when selected)
 ```
 
-Do not commit that file; `setup` adds it to `.gitignore`.
+`ANTHROPIC_AUTH_TOKEN` is not requested or persisted by setup; provide it through your shell environment or another secret manager. Do not commit `.claude/settings.local.json`; `setup` adds `.claude/` to `.gitignore`.
 
 ## 12. Repo-pattern commands
 

--- a/scripts/lib/mcp.mjs
+++ b/scripts/lib/mcp.mjs
@@ -10,6 +10,11 @@ const SECRET_HELP_URLS = {
   CONTEXT7_API_KEY: "https://context7.com/dashboard",
   TAVILY_API_KEY: "https://app.tavily.com/home"
 };
+const PERSISTED_MCP_VALUES = new Set(Object.keys(SECRET_HELP_URLS));
+
+export function persistedMcpValues(values = {}) {
+  return Object.fromEntries(Object.entries(values).filter(([name]) => PERSISTED_MCP_VALUES.has(name)));
+}
 
 export async function listAvailableMcpServers(sourceRoot) {
   const serverDir = path.join(sourceRoot, "mcp", "servers");
@@ -89,7 +94,8 @@ function replacePlaceholders(value, values) {
 }
 
 export function applyMcpValues(mcpServers, values = {}) {
-  return replacePlaceholders(mcpServers, values);
+  const { ANTHROPIC_AUTH_TOKEN: _ignored, ...safeValues } = values;
+  return replacePlaceholders(mcpServers, safeValues);
 }
 
 export async function readMcpConfig({ sourceRoot, profile = "web", mcpServers: selectedServers = null }) {

--- a/scripts/lib/provision.mjs
+++ b/scripts/lib/provision.mjs
@@ -1,7 +1,7 @@
 import path from "node:path";
 import { auditProject, printAudit } from "./audit.mjs";
 import { cleanupProject } from "./cleanup.mjs";
-import { generateMcp } from "./mcp.mjs";
+import { generateMcp, persistedMcpValues } from "./mcp.mjs";
 import { setupEcc } from "./ecc.mjs";
 import { doctorProject } from "./doctor.mjs";
 import { applyEccRules } from "./rules.mjs";
@@ -86,17 +86,20 @@ export async function updateClaudeAttribution({ sourceRoot, target, attributionC
   await appendGitignoreLine(target, ".claude/", { dryRun });
 }
 
-async function writeLocalSettings({ sourceRoot, target, localSettingsEnv, dryRun }) {
+export function applyLocalSettings(settings, localSettingsEnv, mcpValues = {}) {
+  const env = Object.fromEntries(Object.entries({
+    ...(settings.env || {}),
+    ...localSettingsEnv,
+    ...mcpValues
+  }).filter(([name]) => name !== "ANTHROPIC_AUTH_TOKEN"));
+  return { ...settings, env };
+}
+
+async function writeLocalSettings({ sourceRoot, target, localSettingsEnv, mcpValues, dryRun }) {
   if (!localSettingsEnv) return;
   if (isTracked(target, ".claude/settings.local.json")) throw new Error(".claude/settings.local.json is tracked. Untrack it before writing local provider settings.");
   const template = await readJson(path.join(sourceRoot, ".claude.example", "settings.local.example.json"), {});
-  await writeJson(path.join(target, ".claude", "settings.local.json"), {
-    ...template,
-    env: {
-      ...(template.env || {}),
-      ...localSettingsEnv
-    }
-  }, { dryRun });
+  await writeJson(path.join(target, ".claude", "settings.local.json"), applyLocalSettings(template, localSettingsEnv, mcpValues), { dryRun });
   await appendGitignoreLine(target, ".claude/", { dryRun });
 }
 
@@ -131,7 +134,7 @@ export async function provisionProject({ sourceRoot, target, profile = "web", mc
   await writeClaudeSettings({ sourceRoot, target, attributionConfig, dryRun });
   await appendGitignoreLine(target, ".claude/", { dryRun });
 
-  await writeLocalSettings({ sourceRoot, target, localSettingsEnv, dryRun });
+  await writeLocalSettings({ sourceRoot, target, localSettingsEnv, mcpValues: persistedMcpValues(mcpValues), dryRun });
 
   await ensureRepoPatternGitignore(target, { dryRun });
   await writeJson(repoConfigPath(target), await repoPatternConfig(sourceRoot, profile), { dryRun });

--- a/scripts/lib/setup.mjs
+++ b/scripts/lib/setup.mjs
@@ -3,10 +3,10 @@ import path from "node:path";
 import { promisify } from "node:util";
 import { auditProject, printAudit } from "./audit.mjs";
 import { detectProject } from "./project-detect.mjs";
-import { provisionProject, updateClaudeAttribution } from "./provision.mjs";
+import { applyLocalSettings, provisionProject, updateClaudeAttribution } from "./provision.mjs";
 import { doctorProject } from "./doctor.mjs";
-import { collectMcpValues, generateMcp, listAvailableMcpServers, readMcpConfig } from "./mcp.mjs";
-import { askConfirm, askPassword, askText, isInteractive, printBox, printLogo, printSummary, selectMany, selectOne, style } from "./prompt.mjs";
+import { collectMcpValues, generateMcp, listAvailableMcpServers, persistedMcpValues, readMcpConfig } from "./mcp.mjs";
+import { askConfirm, askText, isInteractive, printBox, printLogo, printSummary, selectMany, selectOne, style } from "./prompt.mjs";
 import { ECC_RULE_PACKS, selectEccRules } from "./ecc-rules.mjs";
 import { ensureRepoPatternGitignore, isTracked, readJson, readRepoLock, repoLockPath, writeJson } from "./fs-utils.mjs";
 import { applyOptionalSkills, OPTIONAL_SKILLS } from "./skills.mjs";
@@ -38,19 +38,18 @@ function validateUrl(value) {
 
 const LOCAL_SETTINGS_FIELDS = [
   ["ANTHROPIC_BASE_URL", "https://example.com/v1", askText, validateUrl],
-  ["ANTHROPIC_AUTH_TOKEN", "", askPassword, null],
   ["ANTHROPIC_DEFAULT_OPUS_MODEL", "claude-opus-4-8", askText, validateRequired],
   ["ANTHROPIC_DEFAULT_SONNET_MODEL", "claude-sonnet-4-6", askText, validateRequired],
   ["ANTHROPIC_DEFAULT_HAIKU_MODEL", "claude-haiku-4-5", askText, validateRequired]
 ];
-const SECRET_LOCAL_SETTINGS = new Set(["ANTHROPIC_AUTH_TOKEN"]);
+const RETRY_SECRET_LOCAL_SETTINGS = new Set(["ANTHROPIC_AUTH_TOKEN", "CONTEXT7_API_KEY", "TAVILY_API_KEY"]);
 
 function setupLockPath(target) {
   return repoLockPath(target);
 }
 
-function safeLocalSettingsEnv(localSettingsEnv = {}) {
-  return Object.fromEntries(Object.entries(localSettingsEnv).filter(([name]) => !SECRET_LOCAL_SETTINGS.has(name)));
+function safeRetryLocalSettingsEnv(localSettingsEnv = {}) {
+  return Object.fromEntries(Object.entries(localSettingsEnv).filter(([name]) => !RETRY_SECRET_LOCAL_SETTINGS.has(name)));
 }
 
 export function setupRetryOptions({ action, mcpConfig, mcpValues = {}, ruleConfig, optionalSkills, localSettingsEnv, attributionConfig, dryRun }) {
@@ -58,13 +57,13 @@ export function setupRetryOptions({ action, mcpConfig, mcpValues = {}, ruleConfi
     action,
     profile: mcpConfig.profile,
     mcpServers: mcpConfig.mcpServers,
-    mcpValueNames: Object.keys(mcpValues),
+    mcpValueNames: Object.keys(persistedMcpValues(mcpValues)),
     migrate: action === "migrate",
     applyRules: ruleConfig.applyRules,
     ruleMode: ruleConfig.ruleMode,
     rules: ruleConfig.rules,
     optionalSkills,
-    localSettingsEnv: safeLocalSettingsEnv(localSettingsEnv),
+    localSettingsEnv: safeRetryLocalSettingsEnv(localSettingsEnv),
     attributionConfig,
     dryRun
   };
@@ -87,6 +86,13 @@ async function writeSetupStatus(target, setup, { dryRun = false } = {}) {
 async function currentLocalSettingsEnv(target) {
   const settings = await readJson(path.join(target, ".claude", "settings.local.json"), {});
   return settings.env || {};
+}
+
+async function writeLocalMcpValues(target, mcpValues, { dryRun = false } = {}) {
+  const file = path.join(target, ".claude", "settings.local.json");
+  if (isTracked(target, ".claude/settings.local.json")) throw new Error(".claude/settings.local.json is tracked. Untrack it before writing local MCP values.");
+  const settings = await readJson(file, {});
+  await writeJson(file, applyLocalSettings(settings, {}, persistedMcpValues(mcpValues)), { dryRun });
 }
 
 function retryRows(setup) {
@@ -161,9 +167,9 @@ async function chooseMcpConfig(sourceRoot, profile) {
   return { profile, mcpServers };
 }
 
-async function chooseMcpValues(sourceRoot, mcpConfig) {
+async function chooseMcpValues(sourceRoot, mcpConfig, values = {}) {
   const { mcpServers } = await readMcpConfig({ sourceRoot, profile: mcpConfig.profile, mcpServers: mcpConfig.mcpServers });
-  return collectMcpValues(mcpServers);
+  return collectMcpValues(mcpServers, { values: persistedMcpValues(values) });
 }
 
 async function chooseRuleConfig(detection) {
@@ -206,7 +212,7 @@ async function chooseLocalSettingsEnv(initialValues = {}) {
   for (const [name, fallback, ask, validate] of LOCAL_SETTINGS_FIELDS) {
     env[name] = await ask(name, { initial: process.env[name] || initialValues[name] || fallback, validate });
   }
-  return env;
+  return { ...env, ...persistedMcpValues(initialValues) };
 }
 
 async function chooseAttributionConfig() {
@@ -289,8 +295,10 @@ async function handleInitialized({ sourceRoot, target, profile, dryRun }) {
     const detection = await detectProject(target);
     const chosenProfile = await chooseProfile(sourceRoot, profile, detection);
     const mcpConfig = await chooseMcpConfig(sourceRoot, chosenProfile);
-    const mcpValues = await chooseMcpValues(sourceRoot, mcpConfig);
+    const localSettingsEnv = await currentLocalSettingsEnv(target);
+    const mcpValues = await chooseMcpValues(sourceRoot, mcpConfig, localSettingsEnv);
     await generateMcp({ sourceRoot, target, profile: mcpConfig.profile, mcpServers: mcpConfig.mcpServers, mcpValues, dryRun });
+    await writeLocalMcpValues(target, mcpValues, { dryRun });
   }
   if (action === "skills") {
     const optionalSkills = await chooseOptionalSkills();
@@ -363,10 +371,11 @@ export async function setupProject({ sourceRoot, target, profile = "web", dryRun
     if (!confirmed) throw new Error("Setup cancelled.");
   }
 
-  const mcpValues = previousOptions ? {} : await chooseMcpValues(sourceRoot, mcpConfig);
+  const currentSettingsEnv = await currentLocalSettingsEnv(target);
+  const mcpValues = previousOptions ? persistedMcpValues(currentSettingsEnv) : await chooseMcpValues(sourceRoot, mcpConfig, currentSettingsEnv);
   const localSettingsEnv = previousOptions
-    ? { ...previousOptions.localSettingsEnv, ...(await currentLocalSettingsEnv(target)) }
-    : await chooseLocalSettingsEnv();
+    ? { ...previousOptions.localSettingsEnv, ...currentSettingsEnv }
+    : await chooseLocalSettingsEnv(currentSettingsEnv);
   const attributionConfig = previousOptions?.attributionConfig || await chooseAttributionConfig();
 
   if (!await confirmSummary({ action, target, mcpConfig, mcpValues, ruleConfig, optionalSkills: selectedOptionalSkills, localSettingsEnv, attributionConfig, dryRun })) {

--- a/scripts/lib/skills.mjs
+++ b/scripts/lib/skills.mjs
@@ -85,6 +85,18 @@ export const OPTIONAL_SKILLS = [
     license: "MIT",
     installedDirs: ["fastapi-pattern"],
     destName: "fastapi-pattern"
+  },
+  {
+    value: "herdr",
+    label: "herdr",
+    description: "Herdr terminal multiplexer control skill (AGPL-3.0-or-later; user opt-in only)",
+    source: "https://github.com/ogulcancelik/herdr.git",
+    revision: "9450b168c727e9e4cbee95e6edf4f11cfe6f2154",
+    license: "AGPL-3.0-or-later",
+    installedDirs: ["herdr"],
+    includePaths: ["SKILL.md"],
+    destName: "herdr",
+    partialClone: true
   }
 ];
 

--- a/scripts/repo-pattern.mjs
+++ b/scripts/repo-pattern.mjs
@@ -1,18 +1,20 @@
 #!/usr/bin/env node
+import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { auditProject, printAudit } from "./lib/audit.mjs";
 import { cleanupProject } from "./lib/cleanup.mjs";
-import { generateMcp } from "./lib/mcp.mjs";
+import { generateMcp, persistedMcpValues } from "./lib/mcp.mjs";
 import { setupEcc } from "./lib/ecc.mjs";
 import { doctorProject } from "./lib/doctor.mjs";
 import { applyEccRules } from "./lib/rules.mjs";
 import { setupProject } from "./lib/setup.mjs";
-import { invalidOptionalSkills } from "./lib/skills.mjs";
+import { invalidOptionalSkills, OPTIONAL_SKILLS } from "./lib/skills.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const sourceRoot = path.resolve(__dirname, "..");
+const optionalSkillNames = OPTIONAL_SKILLS.map((skill) => skill.value).join(", ");
 
 function requiredOptionValue(rest, index, arg) {
   const value = rest[index + 1];
@@ -66,7 +68,7 @@ function parseArgs(argv) {
 
   const invalidSkills = invalidOptionalSkills(options.optionalSkills);
   if (invalidSkills.length > 0) {
-    console.error(`Unknown optional skill(s): ${invalidSkills.join(", ")}. Available: taste, document-specialist, ui-ux-pro-max, impeccable, huashu-design, nextjs-pattern, fastapi-pattern`);
+    console.error(`Unknown optional skill(s): ${invalidSkills.join(", ")}. Available: ${optionalSkillNames}`);
     process.exit(2);
   }
 
@@ -105,10 +107,20 @@ Setup UI:
   --migrate      Take over legacy/local Claude runtime surfaces
   --force        Reapply setup over repo-pattern-managed state
   --with-rules               Opt in to repo-pattern-managed .claude/rules/ecc
-  --with-skill <name>        Opt in to external skills/plugins (taste, document-specialist, ui-ux-pro-max, impeccable, huashu-design, nextjs-pattern, fastapi-pattern)
+  --with-skill <name>        Opt in to external skills/plugins (${optionalSkillNames})
   --with-skills <a,b>        Comma-separated optional skills
   --yes                      Run setup non-interactively
 `);
+}
+
+async function currentMcpValues(target) {
+  try {
+    const settings = JSON.parse(await fs.readFile(path.join(target, ".claude", "settings.local.json"), "utf8"));
+    return persistedMcpValues(settings.env);
+  } catch (error) {
+    if (error.code === "ENOENT") return {};
+    throw error;
+  }
 }
 
 async function main() {
@@ -131,7 +143,7 @@ async function main() {
         await cleanupProject({ sourceRoot, ...options });
         break;
       case "mcp":
-        await generateMcp({ sourceRoot, target: options.target, profile: options.profile, yes: options.yes, dryRun: options.dryRun });
+        await generateMcp({ sourceRoot, target: options.target, profile: options.profile, mcpValues: await currentMcpValues(options.target), yes: options.yes, dryRun: options.dryRun });
         break;
       case "ecc":
         await setupEcc({ sourceRoot, target: options.target, dryRun: options.dryRun });

--- a/scripts/self-check.mjs
+++ b/scripts/self-check.mjs
@@ -7,16 +7,17 @@ import { fileURLToPath } from "node:url";
 import { auditProject, printAudit } from "./lib/audit.mjs";
 import { doctorProject } from "./lib/doctor.mjs";
 import { applyEccPluginSettings } from "./lib/ecc.mjs";
-import { applyMcpValues, mcpSecretPrompt, validateRelativeMcpPath } from "./lib/mcp.mjs";
-import { applyAttributionSetting, provisionProject } from "./lib/provision.mjs";
+import { applyMcpValues, mcpSecretPrompt, persistedMcpValues, validateRelativeMcpPath } from "./lib/mcp.mjs";
+import { applyAttributionSetting, applyLocalSettings, provisionProject } from "./lib/provision.mjs";
 import { printSummary, renderLogo, style } from "./lib/prompt.mjs";
 import { setupRetryOptions } from "./lib/setup.mjs";
 import { applyEccRules, formatEccCloneError } from "./lib/rules.mjs";
-import { applyOptionalSkills, applyPluginSkillSettings, expectedOptionalSkillDirs, invalidOptionalSkills, normalizeOptionalSkills } from "./lib/skills.mjs";
+import { applyOptionalSkills, applyPluginSkillSettings, expectedOptionalSkillDirs, invalidOptionalSkills, normalizeOptionalSkills, OPTIONAL_SKILLS } from "./lib/skills.mjs";
 
 const cliDir = path.dirname(fileURLToPath(import.meta.url));
 const cliPath = path.join(cliDir, "repo-pattern.mjs");
 const repoRoot = path.dirname(cliDir);
+const secretSentinel = "do-not-persist-anthropic-token";
 
 const mcpServers = {
   context7: {
@@ -60,18 +61,56 @@ assert.deepEqual(applyMcpValues(mcpServers, {
 });
 
 assert.equal(applyMcpValues(mcpServers).filesystem.args[2], ".");
+assert.deepEqual(applyMcpValues({
+  unexpected: { env: { ANTHROPIC_AUTH_TOKEN: "${ANTHROPIC_AUTH_TOKEN}" } }
+}, {
+  ANTHROPIC_AUTH_TOKEN: secretSentinel
+}), {
+  unexpected: { env: { ANTHROPIC_AUTH_TOKEN: "${ANTHROPIC_AUTH_TOKEN}" } }
+});
+assert.deepEqual(persistedMcpValues({
+  CONTEXT7_API_KEY: "context7-key",
+  TAVILY_API_KEY: "tavily-key",
+  ANTHROPIC_AUTH_TOKEN: secretSentinel,
+  OTHER_API_KEY: "other-key"
+}), {
+  CONTEXT7_API_KEY: "context7-key",
+  TAVILY_API_KEY: "tavily-key"
+});
+assert.deepEqual(applyLocalSettings({ env: {
+  EXISTING: "kept",
+  ANTHROPIC_AUTH_TOKEN: secretSentinel
+} }, {
+  ANTHROPIC_BASE_URL: "https://example.com/v1",
+  ANTHROPIC_AUTH_TOKEN: secretSentinel
+}, {
+  CONTEXT7_API_KEY: "context7-key",
+  TAVILY_API_KEY: "tavily-key"
+}), {
+  env: {
+    EXISTING: "kept",
+    ANTHROPIC_BASE_URL: "https://example.com/v1",
+    CONTEXT7_API_KEY: "context7-key",
+    TAVILY_API_KEY: "tavily-key"
+  }
+});
 assert.deepEqual(applyAttributionSetting({ hooks: {} }, { mode: "off" }), { hooks: {}, attribution: { commit: "" } });
 assert.deepEqual(applyAttributionSetting({ attribution: { commit: "" } }, { mode: "on" }), {});
 assert.deepEqual(applyAttributionSetting({ attribution: { pr: "PR" } }, { mode: "custom", commit: "Custom" }), { attribution: { pr: "PR", commit: "Custom" } });
 assert.deepEqual(setupRetryOptions({
   action: "setup",
   mcpConfig: { profile: "web", mcpServers: null },
-  mcpValues: { CONTEXT7_API_KEY: "secret" },
+  mcpValues: {
+    CONTEXT7_API_KEY: "secret",
+    ANTHROPIC_AUTH_TOKEN: secretSentinel
+  },
   ruleConfig: { applyRules: false, ruleMode: "auto", rules: [] },
   optionalSkills: ["nextjs-pattern"],
   localSettingsEnv: {
     ANTHROPIC_BASE_URL: "https://example.com/v1",
-    ANTHROPIC_AUTH_TOKEN: "secret-token"
+    ANTHROPIC_AUTH_TOKEN: secretSentinel,
+    CONTEXT7_API_KEY: "context7-key",
+    TAVILY_API_KEY: "tavily-key"
   },
   attributionConfig: { mode: "off" },
   dryRun: false
@@ -91,8 +130,9 @@ assert.deepEqual(setupRetryOptions({
 });
 assert.deepEqual(applyEccPluginSettings({ enabledPlugins: { other: false } }).enabledPlugins, { other: false, "ecc@ecc": true });
 assert.equal(applyEccPluginSettings().extraKnownMarketplaces.ecc.source.url, "https://github.com/affaan-m/ECC.git");
-assert.deepEqual(normalizeOptionalSkills(["taste", "taste", "document-specialist", "ui-ux-pro-max", "impeccable", "huashu-design", "nextjs-pattern", "fastapi-pattern"]), ["taste", "document-specialist", "ui-ux-pro-max", "impeccable", "huashu-design", "nextjs-pattern", "fastapi-pattern"]);
-assert.deepEqual(invalidOptionalSkills(["taste", "ui-ux-pro-max", "impeccable", "huashu-design", "nextjs-pattern", "fastapi-pattern", "nope"]), ["nope"]);
+const optionalSkillValues = OPTIONAL_SKILLS.map((skill) => skill.value);
+assert.deepEqual(normalizeOptionalSkills(["taste", ...optionalSkillValues]), optionalSkillValues);
+assert.deepEqual(invalidOptionalSkills([...optionalSkillValues, "nope"]), ["nope"]);
 assert.deepEqual(applyPluginSkillSettings({}, [{
   source: "https://github.com/Leonxlnx/taste-skill.git",
   plugin: { marketplace: "taste-skill", name: "taste-skill" }
@@ -132,8 +172,13 @@ assert.deepEqual(expectedOptionalSkillDirs([
     name: "fastapi-pattern",
     source: "https://github.com/NegiKirin/fastapi-pattern.git",
     revision: "3abf484af46765c01a476b2ef61bb211b2b5bab8"
+  },
+  {
+    name: "herdr",
+    source: "https://github.com/ogulcancelik/herdr.git",
+    revision: "9450b168c727e9e4cbee95e6edf4f11cfe6f2154"
   }
-]), ["fastapi-pattern", "huashu-design", "nextjs-pattern"]);
+]), ["fastapi-pattern", "herdr", "huashu-design", "nextjs-pattern"]);
 
 const skillTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-skill-"));
 const originalSkillLog = console.log;
@@ -189,6 +234,10 @@ try {
   console.log = originalSkillLog;
   await fs.rm(dryRunRootCopyTarget, { recursive: true, force: true });
 }
+
+const herdrSkill = OPTIONAL_SKILLS.find((skill) => skill.value === "herdr");
+assert.deepEqual(herdrSkill.includePaths, ["SKILL.md"]);
+assert.equal(herdrSkill.destName, "herdr");
 
 async function writeDoctorFixture(target, { appliedRules = ["typescript"], createRuleDirs = true } = {}) {
   await fs.mkdir(path.join(target, ".claude"), { recursive: true });
@@ -334,8 +383,8 @@ try {
   process.stdout.isTTY = originalStdoutIsTty;
 }
 
-function runCli(args) {
-  return spawnSync(process.execPath, [cliPath, ...args], { cwd: repoRoot, encoding: "utf8" });
+function runCli(args, cwd = repoRoot) {
+  return spawnSync(process.execPath, [cliPath, ...args], { cwd, encoding: "utf8" });
 }
 
 let result = runCli(["help"]);
@@ -362,6 +411,7 @@ assert.match(result.stdout, /impeccable/);
 assert.match(result.stdout, /huashu-design/);
 assert.match(result.stdout, /nextjs-pattern/);
 assert.match(result.stdout, /fastapi-pattern/);
+assert.match(result.stdout, /herdr/);
 
 result = runCli(["audit"]);
 assert.equal(result.status, 0);
@@ -376,6 +426,26 @@ assert.equal(result.status, 1);
 assert.match(result.stderr, /MCP profile not found: nope\. Available profiles: /);
 assert.match(result.stderr, /minimal/);
 assert.match(result.stderr, /web/);
+
+const mcpReuseTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-mcp-reuse-"));
+try {
+  await fs.mkdir(path.join(mcpReuseTarget, ".claude"), { recursive: true });
+  await fs.writeFile(path.join(mcpReuseTarget, ".claude", "settings.local.json"), JSON.stringify({
+    env: {
+      CONTEXT7_API_KEY: "persisted-context7-key",
+      TAVILY_API_KEY: "persisted-tavily-key",
+      ANTHROPIC_AUTH_TOKEN: secretSentinel
+    }
+  }), "utf8");
+  result = runCli(["mcp", "--target", mcpReuseTarget, "--profile", "research", "--yes"]);
+  assert.equal(result.status, 0, result.stderr);
+  const mcpConfigText = await fs.readFile(path.join(mcpReuseTarget, ".mcp.json"), "utf8");
+  assert.match(mcpConfigText, /persisted-context7-key/);
+  assert.match(mcpConfigText, /persisted-tavily-key/);
+  assert.equal(mcpConfigText.includes(secretSentinel), false);
+} finally {
+  await fs.rm(mcpReuseTarget, { recursive: true, force: true });
+}
 
 const packageJson = JSON.parse(await fs.readFile(path.join(repoRoot, "package.json"), "utf8"));
 const gitignore = await fs.readFile(path.join(repoRoot, ".gitignore"), "utf8");
@@ -399,8 +469,21 @@ try {
     sourceRoot: repoRoot,
     target: provisionTemplateTarget,
     profile: "minimal",
-    mcpValues: { CONTEXT7_API_KEY: "redacted-key" }
+    mcpValues: {
+      CONTEXT7_API_KEY: "redacted-key",
+      ANTHROPIC_AUTH_TOKEN: secretSentinel,
+      OTHER_API_KEY: "other-key"
+    },
+    localSettingsEnv: { ANTHROPIC_AUTH_TOKEN: secretSentinel }
   });
+  const localSettingsText = await fs.readFile(path.join(provisionTemplateTarget, ".claude", "settings.local.json"), "utf8");
+  const localSettings = JSON.parse(localSettingsText);
+  const setupLockText = await fs.readFile(path.join(provisionTemplateTarget, ".repo-pattern", ".repo-pattern.lock.json"), "utf8");
+  assert.equal(localSettings.env.CONTEXT7_API_KEY, "redacted-key");
+  assert.equal(localSettingsText.includes(secretSentinel), false);
+  assert.equal(setupLockText.includes(secretSentinel), false);
+  assert.equal("ANTHROPIC_AUTH_TOKEN" in localSettings.env, false);
+  assert.equal("OTHER_API_KEY" in localSettings.env, false);
   const repoConfig = JSON.parse(await fs.readFile(path.join(provisionTemplateTarget, ".repo-pattern", ".repo-pattern.json"), "utf8"));
   assert.equal(repoConfig.mode, "target");
   assert.equal(repoConfig.mcp.profile, "minimal");


### PR DESCRIPTION
## Summary

- add Herdr as an explicit opt-in external skill, pin its upstream revision, and document its licensing/runtime requirements
- persist only `CONTEXT7_API_KEY` and `TAVILY_API_KEY` in the target project's gitignored `.claude/settings.local.json` so later setup and MCP runs can reuse them
- stop prompting for or persisting `ANTHROPIC_AUTH_TOKEN`, filter it from local settings, retry state, and unexpected MCP value maps, and remove it from the local-settings example
- add regression coverage for Herdr registration, MCP key reuse, retry-state filtering, local-settings filtering, and generated-config secret handling

## Security

- `.claude/settings.local.json` remains ignored and is not included in this PR
- only Context7 and Tavily keys are allowlisted for local persistence
- `ANTHROPIC_AUTH_TOKEN` is excluded from generated local settings and repo-pattern retry/lock state
- no hardcoded credentials or private keys were found in the complete diff
- the selected `ANTHROPIC_DEFAULT_OPUS_MODEL` remains `claude-opus-4-8`

## Test plan

- [x] `npm test`
- [x] `npm run pack:dry`
- [x] `git diff --check`
- [x] GitNexus `detect_changes` comparison against `main`
- [x] inspect the complete `main...HEAD` history and diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)