### PR TITLE
chore: release v0.1.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@negikirin/repo-pattern",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@negikirin/repo-pattern",
-      "version": "0.1.7",
+      "version": "0.1.8",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^0.11.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@negikirin/repo-pattern",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Minimal ECC-first Claude Code project setup and migrator",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- bump `@negikirin/repo-pattern` from 0.1.7 to 0.1.8
- update package lock metadata to match

## Test plan
- [x] `npm test`
- [x] `npm run pack:dry`
- [x] `git diff --check`
- [x] release diff secret scan
- [x] GitNexus change detection against `main` (low risk; no changed symbols or affected processes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)