### PR TITLE
fix: persist setup credentials securely

### DIFF
--- a/docs/repo-pattern/setup-guide.md
+++ b/docs/repo-pattern/setup-guide.md
@@ -85,7 +85,7 @@ For scripts or CI, use the non-interactive path:
 node scripts/repo-pattern.mjs setup --target ~/Code/my-app --profile web --yes
 ```
 
-Setup first checks `claude --version`, then uses a library-backed terminal wizard. It can auto-detect ECC rules or let you choose rule packs by type, asks for selected MCP API keys/relative paths when needed, then asks for Anthropic provider/model values and writes reusable local values to the target's gitignored `.claude/settings.local.json`. `CONTEXT7_API_KEY` and `TAVILY_API_KEY` are reused on later setup/MCP runs; `ANTHROPIC_AUTH_TOKEN` is never persisted.
+Setup first checks `claude --version`, then uses a library-backed terminal wizard. It can auto-detect ECC rules or let you choose rule packs by type, asks for selected MCP API keys/relative paths when needed, then asks for Anthropic provider/model values. It stores `CONTEXT7_API_KEY` and `TAVILY_API_KEY` only in the target's gitignored `.mcp.json`, and stores `ANTHROPIC_AUTH_TOKEN` with the provider/model values in gitignored `.claude/settings.local.json`. Later setup and MCP runs reuse those files.
 
 Keys:
 
@@ -111,14 +111,14 @@ For non-interactive scripts, use `setup --yes`.
 4. Write `.claude/CLAUDE.md` if missing.
 5. Write `.claude/settings.json` from `.claude.example/settings.example.json`.
 6. In interactive setup, ask whether commit attribution is off, on, or custom.
-7. During `setup`, write gitignored `.claude/settings.local.json` from prompted provider/model values, excluding `ANTHROPIC_AUTH_TOKEN`.
+7. During interactive `setup`, write `ANTHROPIC_AUTH_TOKEN` and the prompted provider/model values to gitignored `.claude/settings.local.json`; remove `CONTEXT7_API_KEY` and `TAVILY_API_KEY` from that file.
 8. Read MCP profiles and server definitions from `repo-pattern`.
-9. In interactive mode, reuse persisted `CONTEXT7_API_KEY`/`TAVILY_API_KEY` values or ask for missing MCP API keys and relative paths when placeholders require them.
-10. Generate `.mcp.json` from the selected profile.
+9. In interactive mode, reuse `CONTEXT7_API_KEY`/`TAVILY_API_KEY` from gitignored `.mcp.json` or ask for missing MCP API keys and relative paths when placeholders require them.
+10. Generate `.mcp.json` from the selected profile, storing entered Context7/Tavily keys as literal server environment values.
 11. Write `.repo-pattern/.repo-pattern.json` from `.repo-pattern.example.json`.
 12. Create `.repo-pattern/.gitignore` with `*`.
 13. Add generated setup files and basic OS/IDE noise to `.gitignore`.
-14. Write `.repo-pattern/.repo-pattern.lock.json`.
+14. Write `.repo-pattern/.repo-pattern.lock.json` without credential values.
 15. Run or attempt ECC setup flow.
 16. During `setup` with rules enabled, apply ECC rules.
 17. Run doctor.
@@ -208,7 +208,7 @@ or regenerate later:
 node scripts/repo-pattern.mjs mcp --target /path/to/project --profile <profile>
 ```
 
-Interactive `setup` asks for selected MCP placeholders such as `CONTEXT7_API_KEY` and `TAVILY_API_KEY`; entered keys are saved in gitignored `.claude/settings.local.json` and reused by later `setup` and `mcp` runs. `ANTHROPIC_AUTH_TOKEN` is never saved there or in repo-pattern setup state. The filesystem MCP server uses the target project root (`.`) as its allowed directory. Other MCP paths, when prompted, must be relative (`src`, `packages/api`); absolute machine paths and `..` are rejected. With `--yes` or non-TTY runs, unresolved secret placeholders stay in `.mcp.json` and the CLI prints the values to fill later.
+Interactive `setup` asks for selected MCP placeholders such as `CONTEXT7_API_KEY` and `TAVILY_API_KEY`, writes entered keys only as literal server environment values in gitignored `.mcp.json`, and reuses them on later `setup` and `mcp` runs. It writes `ANTHROPIC_AUTH_TOKEN` only to gitignored `.claude/settings.local.json`; the token is never substituted into MCP config or written to repo-pattern setup state. Failed setup retries recover credentials from these two files, while the lock stores only non-secret choices and MCP credential names. Setup backups exclude both credential-bearing files. The filesystem MCP server uses the target project root (`.`) as its allowed directory. Other MCP paths, when prompted, must be relative (`src`, `packages/api`); absolute machine paths and `..` are rejected. With `--yes` or non-TTY runs, unresolved secret placeholders stay in `.mcp.json` and the CLI prints the values to fill later.
 
 ---
 
@@ -471,15 +471,14 @@ Local preferences and Anthropic provider/model values should go in:
 `setup` asks for these values and writes the file for you:
 
 ```text
+ANTHROPIC_AUTH_TOKEN
 ANTHROPIC_BASE_URL
 ANTHROPIC_DEFAULT_OPUS_MODEL
 ANTHROPIC_DEFAULT_SONNET_MODEL
 ANTHROPIC_DEFAULT_HAIKU_MODEL
-CONTEXT7_API_KEY (when selected)
-TAVILY_API_KEY (when selected)
 ```
 
-`ANTHROPIC_AUTH_TOKEN` is not requested or persisted by setup; provide it through your shell environment or another secret manager. Do not commit `.claude/settings.local.json`; `setup` adds `.claude/` to `.gitignore`.
+`CONTEXT7_API_KEY` and `TAVILY_API_KEY` are stored only in gitignored `.mcp.json`, never in `.claude/settings.local.json`. Do not commit either credential file; `setup` adds `.claude/` and `.mcp.json` to `.gitignore`. Credential values are not written to repo-pattern locks, backups, tracked files, or package files.
 
 ## 12. Repo-pattern commands
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@negikirin/repo-pattern",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@negikirin/repo-pattern",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^0.11.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@negikirin/repo-pattern",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Minimal ECC-first Claude Code project setup and migrator",
   "type": "module",
   "bin": {

--- a/scripts/lib/cleanup.mjs
+++ b/scripts/lib/cleanup.mjs
@@ -10,9 +10,7 @@ export async function cleanupProject({ sourceRoot, target, dryRun = false }) {
     ".claude/hooks",
     ".claude/scripts",
     ".claude/rules",
-    ".claude/settings.json",
-    ".claude/settings.local.json",
-    ".mcp.json"
+    ".claude/settings.json"
   ], { dryRun });
 
   const removeList = [

--- a/scripts/lib/ecc.mjs
+++ b/scripts/lib/ecc.mjs
@@ -1,6 +1,6 @@
 import { execSync } from "node:child_process";
 import path from "node:path";
-import { appendGitignoreLine, ensureRepoPatternGitignore, isTracked, readJson, readRepoLock, repoLockPath, writeJson } from "./fs-utils.mjs";
+import { appendGitignoreLine, ensureRepoPatternGitignore, isTracked, readJson, readRepoLock, repoLockPath, writeJson, writePrivateJson } from "./fs-utils.mjs";
 import { printSummary } from "./prompt.mjs";
 
 const ECC_PLUGIN_ID = "ecc@ecc";
@@ -36,7 +36,11 @@ function hasEccPlugin() {
 async function writeEccLocalSettings({ target, dryRun }) {
   if (isTracked(target, ".claude/settings.local.json")) throw new Error(".claude/settings.local.json is tracked. Untrack it before writing local plugin settings.");
   const file = path.join(target, ".claude", "settings.local.json");
-  await writeJson(file, applyEccPluginSettings(await readJson(file, {})), { dryRun });
+  await writePrivateJson(file, applyEccPluginSettings, {
+    dryRun,
+    label: ".claude/settings.local.json",
+    parentLabel: ".claude"
+  });
   await appendGitignoreLine(target, ".claude/", { dryRun });
 }
 

--- a/scripts/lib/fs-utils.mjs
+++ b/scripts/lib/fs-utils.mjs
@@ -1,4 +1,5 @@
 import { execFileSync } from "node:child_process";
+import { constants } from "node:fs";
 import fs from "node:fs/promises";
 import fsSync from "node:fs";
 import path from "node:path";
@@ -62,6 +63,31 @@ export async function readJson(file, fallback = null) {
   return JSON.parse(text);
 }
 
+export async function readPrivateJson(file, fallback = null, { label = path.basename(file), parentLabel = null } = {}) {
+  const parent = path.dirname(file);
+  if (parentLabel) {
+    try {
+      if ((await fs.lstat(parent)).isSymbolicLink()) throw new Error(`${parentLabel} must not be a symlink.`);
+    } catch (error) {
+      if (error.code === "ENOENT") return fallback;
+      throw error;
+    }
+  }
+  let handle;
+  try {
+    handle = await fs.open(file, constants.O_RDONLY | constants.O_NOFOLLOW);
+  } catch (error) {
+    if (error.code === "ENOENT") return fallback;
+    if (error.code === "ELOOP") throw new Error(`${label} must not be a symlink.`);
+    throw error;
+  }
+  try {
+    return JSON.parse(await handle.readFile("utf8"));
+  } finally {
+    await handle.close();
+  }
+}
+
 export async function writeJson(file, data, { dryRun = false } = {}) {
   if (dryRun) {
     console.log(`[dry-run] write JSON ${file}`);
@@ -69,6 +95,43 @@ export async function writeJson(file, data, { dryRun = false } = {}) {
   }
   await ensureDir(path.dirname(file));
   await fs.writeFile(file, `${JSON.stringify(data, null, 2)}\n`, "utf8");
+}
+
+export async function writePrivateJson(file, data, { dryRun = false, label = path.basename(file), parentLabel = null } = {}) {
+  if (dryRun) {
+    console.log(`[dry-run] write JSON ${file}`);
+    return;
+  }
+  const parent = path.dirname(file);
+  if (parentLabel) {
+    let parentStat = null;
+    try {
+      parentStat = await fs.lstat(parent);
+    } catch (error) {
+      if (error.code !== "ENOENT") throw error;
+    }
+    if (parentStat?.isSymbolicLink()) throw new Error(`${parentLabel} must not be a symlink.`);
+  }
+  await ensureDir(parent);
+  let stat = null;
+  try {
+    stat = await fs.lstat(file);
+  } catch (error) {
+    if (error.code !== "ENOENT") throw error;
+  }
+  if (stat?.isSymbolicLink()) throw new Error(`${label} must not be a symlink.`);
+  const current = typeof data === "function"
+    ? await readPrivateJson(file, {}, { label, parentLabel })
+    : null;
+  const content = `${JSON.stringify(typeof data === "function" ? data(current) : data, null, 2)}\n`;
+  const tempDir = await fs.mkdtemp(path.join(parent, `.${path.basename(file)}-`));
+  const tempFile = path.join(tempDir, path.basename(file));
+  try {
+    await fs.writeFile(tempFile, content, { encoding: "utf8", mode: 0o600, flag: "wx" });
+    await fs.rename(tempFile, file);
+  } finally {
+    await fs.rm(tempDir, { recursive: true, force: true });
+  }
 }
 
 export async function copyRecursive(src, dest, { dryRun = false } = {}) {

--- a/scripts/lib/mcp.mjs
+++ b/scripts/lib/mcp.mjs
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { appendGitignoreLine, ensureDir, ensureRepoPatternGitignore, exists, isTracked, readJson, readRepoLock, repoLockPath, writeJson } from "./fs-utils.mjs";
+import { appendGitignoreLine, ensureDir, ensureRepoPatternGitignore, exists, isTracked, readJson, readPrivateJson, readRepoLock, repoLockPath, writeJson, writePrivateJson } from "./fs-utils.mjs";
 import { askPassword, askText, isInteractive, printSummary, style } from "./prompt.mjs";
 
 const PLACEHOLDER_RE = /^\$\{([A-Z0-9_]+)(?::-(.*))?\}$/;
@@ -14,6 +14,22 @@ const PERSISTED_MCP_VALUES = new Set(Object.keys(SECRET_HELP_URLS));
 
 export function persistedMcpValues(values = {}) {
   return Object.fromEntries(Object.entries(values).filter(([name]) => PERSISTED_MCP_VALUES.has(name)));
+}
+
+export function withoutPersistedMcpValues(values = {}) {
+  return Object.fromEntries(Object.entries(values).filter(([name]) => !PERSISTED_MCP_VALUES.has(name)));
+}
+
+export async function readGeneratedMcpValues(target) {
+  const config = await readPrivateJson(path.join(target, ".mcp.json"), {}, { label: ".mcp.json" });
+  const values = {};
+  for (const server of Object.values(config.mcpServers || {})) {
+    if (!server || typeof server !== "object" || Array.isArray(server)) throw new Error(".mcp.json contains an invalid MCP server entry.");
+    for (const [name, value] of Object.entries(server.env || {})) {
+      if (PERSISTED_MCP_VALUES.has(name) && value && !parsePlaceholder(value)) values[name] = value;
+    }
+  }
+  return values;
 }
 
 export async function listAvailableMcpServers(sourceRoot) {
@@ -186,7 +202,7 @@ export async function generateMcp({ sourceRoot, target, profile = "web", mcpServ
   const resolvedMcpServers = applyMcpValues(mcpServers, values);
 
   await ensureDir(target, { dryRun });
-  await writeJson(path.join(target, ".mcp.json"), { mcpServers: resolvedMcpServers }, { dryRun });
+  await writePrivateJson(path.join(target, ".mcp.json"), { mcpServers: resolvedMcpServers }, { dryRun, label: ".mcp.json" });
   await appendGitignoreLine(target, ".mcp.json", { dryRun });
 
   await syncEnabledMcpServers(target, profileServers, { dryRun });

--- a/scripts/lib/provision.mjs
+++ b/scripts/lib/provision.mjs
@@ -1,11 +1,12 @@
+import fs from "node:fs/promises";
 import path from "node:path";
 import { auditProject, printAudit } from "./audit.mjs";
 import { cleanupProject } from "./cleanup.mjs";
-import { generateMcp, persistedMcpValues } from "./mcp.mjs";
+import { generateMcp, withoutPersistedMcpValues } from "./mcp.mjs";
 import { setupEcc } from "./ecc.mjs";
 import { doctorProject } from "./doctor.mjs";
 import { applyEccRules } from "./rules.mjs";
-import { appendGitignoreLine, backupPaths, copyRecursive, ensureDir, ensureRepoPatternGitignore, isTracked, readJson, removePath, repoConfigPath, repoLockPath, writeJson, writeIfMissing } from "./fs-utils.mjs";
+import { appendGitignoreLine, backupPaths, copyRecursive, ensureDir, ensureRepoPatternGitignore, isTracked, readJson, removePath, repoConfigPath, repoLockPath, writeJson, writeIfMissing, writePrivateJson } from "./fs-utils.mjs";
 import { printSummary, style } from "./prompt.mjs";
 import { applyOptionalSkills } from "./skills.mjs";
 
@@ -86,25 +87,45 @@ export async function updateClaudeAttribution({ sourceRoot, target, attributionC
   await appendGitignoreLine(target, ".claude/", { dryRun });
 }
 
-export function applyLocalSettings(settings, localSettingsEnv, mcpValues = {}) {
-  const env = Object.fromEntries(Object.entries({
-    ...(settings.env || {}),
-    ...localSettingsEnv,
-    ...mcpValues
-  }).filter(([name]) => name !== "ANTHROPIC_AUTH_TOKEN"));
-  return { ...settings, env };
+export function applyLocalSettings(settings, localSettingsEnv) {
+  return {
+    ...settings,
+    env: withoutPersistedMcpValues({
+      ...(settings.env || {}),
+      ...localSettingsEnv
+    })
+  };
 }
 
-async function writeLocalSettings({ sourceRoot, target, localSettingsEnv, mcpValues, dryRun }) {
+async function rejectClaudeSymlink(target, { dryRun = false } = {}) {
+  if (dryRun) return;
+  let stat;
+  try {
+    stat = await fs.lstat(path.join(target, ".claude"));
+  } catch (error) {
+    if (error.code === "ENOENT") return;
+    throw error;
+  }
+  if (stat.isSymbolicLink()) throw new Error(".claude must not be a symlink.");
+}
+
+async function writeLocalSettings({ sourceRoot, target, localSettingsEnv, dryRun }) {
   if (!localSettingsEnv) return;
   if (isTracked(target, ".claude/settings.local.json")) throw new Error(".claude/settings.local.json is tracked. Untrack it before writing local provider settings.");
+  const claudeDir = path.join(target, ".claude");
+  await rejectClaudeSymlink(target, { dryRun });
   const template = await readJson(path.join(sourceRoot, ".claude.example", "settings.local.example.json"), {});
-  await writeJson(path.join(target, ".claude", "settings.local.json"), applyLocalSettings(template, localSettingsEnv, mcpValues), { dryRun });
+  const file = path.join(claudeDir, "settings.local.json");
+  await writePrivateJson(file, applyLocalSettings(template, localSettingsEnv), {
+    dryRun,
+    label: ".claude/settings.local.json"
+  });
   await appendGitignoreLine(target, ".claude/", { dryRun });
 }
 
 export async function provisionProject({ sourceRoot, target, profile = "web", mcpServers = null, mcpValues = {}, dryRun = false, force = false, migrate = false, localSettingsEnv = null, attributionConfig = { mode: "off" }, ruleMode = "auto", rules = null, applyRules = false, optionalSkills = [] }) {
   printSummary("Provisioning target", [["Target", target]]);
+  await rejectClaudeSymlink(target, { dryRun });
   const audit = await auditProject(target);
   printAudit(audit);
 
@@ -115,7 +136,7 @@ export async function provisionProject({ sourceRoot, target, profile = "web", mc
   if (audit.state === "LEGACY_VENDOR") {
     await cleanupProject({ sourceRoot, target, dryRun });
   } else {
-    await backupPaths(target, ["CLAUDE.md", ".claude", ".mcp.json", ".repo-pattern.json", ".repo-pattern.lock.json"], { dryRun });
+    await backupPaths(target, ["CLAUDE.md", ".claude/CLAUDE.md", ".claude/settings.json", ".claude/rules", ".claude/skills", ".claude/commands", ".claude/hooks", ".claude/scripts", ".repo-pattern.json", ".repo-pattern.lock.json"], { dryRun });
   }
 
   if (isTracked(target, ".claude/settings.json")) throw new Error(".claude/settings.json is tracked. Untrack it before writing Claude Code settings.");
@@ -134,7 +155,7 @@ export async function provisionProject({ sourceRoot, target, profile = "web", mc
   await writeClaudeSettings({ sourceRoot, target, attributionConfig, dryRun });
   await appendGitignoreLine(target, ".claude/", { dryRun });
 
-  await writeLocalSettings({ sourceRoot, target, localSettingsEnv, mcpValues: persistedMcpValues(mcpValues), dryRun });
+  await writeLocalSettings({ sourceRoot, target, localSettingsEnv, dryRun });
 
   await ensureRepoPatternGitignore(target, { dryRun });
   await writeJson(repoConfigPath(target), await repoPatternConfig(sourceRoot, profile), { dryRun });

--- a/scripts/lib/setup.mjs
+++ b/scripts/lib/setup.mjs
@@ -3,12 +3,12 @@ import path from "node:path";
 import { promisify } from "node:util";
 import { auditProject, printAudit } from "./audit.mjs";
 import { detectProject } from "./project-detect.mjs";
-import { applyLocalSettings, provisionProject, updateClaudeAttribution } from "./provision.mjs";
+import { provisionProject, updateClaudeAttribution } from "./provision.mjs";
 import { doctorProject } from "./doctor.mjs";
-import { collectMcpValues, generateMcp, listAvailableMcpServers, persistedMcpValues, readMcpConfig } from "./mcp.mjs";
-import { askConfirm, askText, isInteractive, printBox, printLogo, printSummary, selectMany, selectOne, style } from "./prompt.mjs";
+import { collectMcpValues, generateMcp, listAvailableMcpServers, persistedMcpValues, readGeneratedMcpValues, readMcpConfig } from "./mcp.mjs";
+import { askConfirm, askPassword, askText, isInteractive, printBox, printLogo, printSummary, selectMany, selectOne, style } from "./prompt.mjs";
 import { ECC_RULE_PACKS, selectEccRules } from "./ecc-rules.mjs";
-import { ensureRepoPatternGitignore, isTracked, readJson, readRepoLock, repoLockPath, writeJson } from "./fs-utils.mjs";
+import { ensureRepoPatternGitignore, isTracked, readJson, readPrivateJson, readRepoLock, repoLockPath, writeJson } from "./fs-utils.mjs";
 import { applyOptionalSkills, OPTIONAL_SKILLS } from "./skills.mjs";
 
 const execFileAsync = promisify(execFile);
@@ -37,6 +37,7 @@ function validateUrl(value) {
 }
 
 const LOCAL_SETTINGS_FIELDS = [
+  ["ANTHROPIC_AUTH_TOKEN", "", askPassword, validateRequired],
   ["ANTHROPIC_BASE_URL", "https://example.com/v1", askText, validateUrl],
   ["ANTHROPIC_DEFAULT_OPUS_MODEL", "claude-opus-4-8", askText, validateRequired],
   ["ANTHROPIC_DEFAULT_SONNET_MODEL", "claude-sonnet-4-6", askText, validateRequired],
@@ -84,15 +85,11 @@ async function writeSetupStatus(target, setup, { dryRun = false } = {}) {
 }
 
 async function currentLocalSettingsEnv(target) {
-  const settings = await readJson(path.join(target, ".claude", "settings.local.json"), {});
+  const settings = await readPrivateJson(path.join(target, ".claude", "settings.local.json"), {}, {
+    label: ".claude/settings.local.json",
+    parentLabel: ".claude"
+  });
   return settings.env || {};
-}
-
-async function writeLocalMcpValues(target, mcpValues, { dryRun = false } = {}) {
-  const file = path.join(target, ".claude", "settings.local.json");
-  if (isTracked(target, ".claude/settings.local.json")) throw new Error(".claude/settings.local.json is tracked. Untrack it before writing local MCP values.");
-  const settings = await readJson(file, {});
-  await writeJson(file, applyLocalSettings(settings, {}, persistedMcpValues(mcpValues)), { dryRun });
 }
 
 function retryRows(setup) {
@@ -206,13 +203,17 @@ async function chooseOptionalSkills(initialValues = []) {
   });
 }
 
+export function needsLocalSettingsPrompt(values = {}) {
+  return LOCAL_SETTINGS_FIELDS.some(([name, , , validate]) => validate(values[name]) !== true);
+}
+
 async function chooseLocalSettingsEnv(initialValues = {}) {
   printBox("Step 4/5 — Local Claude provider settings", ["These values are written to .claude/settings.local.json and gitignored."]);
   const env = {};
   for (const [name, fallback, ask, validate] of LOCAL_SETTINGS_FIELDS) {
     env[name] = await ask(name, { initial: process.env[name] || initialValues[name] || fallback, validate });
   }
-  return { ...env, ...persistedMcpValues(initialValues) };
+  return env;
 }
 
 async function chooseAttributionConfig() {
@@ -295,10 +296,15 @@ async function handleInitialized({ sourceRoot, target, profile, dryRun }) {
     const detection = await detectProject(target);
     const chosenProfile = await chooseProfile(sourceRoot, profile, detection);
     const mcpConfig = await chooseMcpConfig(sourceRoot, chosenProfile);
-    const localSettingsEnv = await currentLocalSettingsEnv(target);
-    const mcpValues = await chooseMcpValues(sourceRoot, mcpConfig, localSettingsEnv);
-    await generateMcp({ sourceRoot, target, profile: mcpConfig.profile, mcpServers: mcpConfig.mcpServers, mcpValues, dryRun });
-    await writeLocalMcpValues(target, mcpValues, { dryRun });
+    const mcpValues = await chooseMcpValues(sourceRoot, mcpConfig, await readGeneratedMcpValues(target));
+    await generateMcp({
+      sourceRoot,
+      target,
+      profile: mcpConfig.profile,
+      mcpServers: mcpConfig.mcpServers,
+      mcpValues,
+      dryRun
+    });
   }
   if (action === "skills") {
     const optionalSkills = await chooseOptionalSkills();
@@ -328,7 +334,17 @@ export async function setupProject({ sourceRoot, target, profile = "web", dryRun
       return;
     }
 
-    await provisionProject({ sourceRoot, target, profile, dryRun, force, migrate, applyRules, optionalSkills });
+    await provisionProject({
+      sourceRoot,
+      target,
+      profile,
+      mcpValues: await readGeneratedMcpValues(target),
+      dryRun,
+      force,
+      migrate,
+      applyRules,
+      optionalSkills
+    });
     return;
   }
 
@@ -372,10 +388,11 @@ export async function setupProject({ sourceRoot, target, profile = "web", dryRun
   }
 
   const currentSettingsEnv = await currentLocalSettingsEnv(target);
-  const mcpValues = previousOptions ? persistedMcpValues(currentSettingsEnv) : await chooseMcpValues(sourceRoot, mcpConfig, currentSettingsEnv);
-  const localSettingsEnv = previousOptions
-    ? { ...previousOptions.localSettingsEnv, ...currentSettingsEnv }
-    : await chooseLocalSettingsEnv(currentSettingsEnv);
+  const mcpValues = await chooseMcpValues(sourceRoot, mcpConfig, await readGeneratedMcpValues(target));
+  const retryLocalSettingsEnv = { ...previousOptions?.localSettingsEnv, ...currentSettingsEnv };
+  const localSettingsEnv = previousOptions && !needsLocalSettingsPrompt(retryLocalSettingsEnv)
+    ? retryLocalSettingsEnv
+    : await chooseLocalSettingsEnv(retryLocalSettingsEnv);
   const attributionConfig = previousOptions?.attributionConfig || await chooseAttributionConfig();
 
   if (!await confirmSummary({ action, target, mcpConfig, mcpValues, ruleConfig, optionalSkills: selectedOptionalSkills, localSettingsEnv, attributionConfig, dryRun })) {

--- a/scripts/lib/skills.mjs
+++ b/scripts/lib/skills.mjs
@@ -2,7 +2,7 @@ import { execFile, execFileSync } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
-import { appendGitignoreLine, backupPaths, copyRecursive, ensureDir, ensureRepoPatternGitignore, exists, isTracked, readJson, readRepoConfig, readRepoLock, removePath, repoConfigPath, repoLockPath, writeJson } from "./fs-utils.mjs";
+import { appendGitignoreLine, backupPaths, copyRecursive, ensureDir, ensureRepoPatternGitignore, exists, isTracked, readJson, readRepoConfig, readRepoLock, removePath, repoConfigPath, repoLockPath, writeJson, writePrivateJson } from "./fs-utils.mjs";
 import { isInteractive, printSummary, withSpinner } from "./prompt.mjs";
 
 const execFileAsync = promisify(execFile);
@@ -146,7 +146,11 @@ async function writePluginSkillSettings({ target, skills, dryRun }) {
   if (skills.length === 0) return;
   if (isTracked(target, ".claude/settings.local.json")) throw new Error(".claude/settings.local.json is tracked. Untrack it before writing local plugin settings.");
   const file = path.join(target, ".claude", "settings.local.json");
-  await writeJson(file, applyPluginSkillSettings(await readJson(file, {}), skills), { dryRun });
+  await writePrivateJson(file, (settings) => applyPluginSkillSettings(settings, skills), {
+    dryRun,
+    label: ".claude/settings.local.json",
+    parentLabel: ".claude"
+  });
   await appendGitignoreLine(target, ".claude/", { dryRun });
 }
 

--- a/scripts/repo-pattern.mjs
+++ b/scripts/repo-pattern.mjs
@@ -1,10 +1,9 @@
 #!/usr/bin/env node
-import fs from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { auditProject, printAudit } from "./lib/audit.mjs";
 import { cleanupProject } from "./lib/cleanup.mjs";
-import { generateMcp, persistedMcpValues } from "./lib/mcp.mjs";
+import { generateMcp, readGeneratedMcpValues } from "./lib/mcp.mjs";
 import { setupEcc } from "./lib/ecc.mjs";
 import { doctorProject } from "./lib/doctor.mjs";
 import { applyEccRules } from "./lib/rules.mjs";
@@ -113,16 +112,6 @@ Setup UI:
 `);
 }
 
-async function currentMcpValues(target) {
-  try {
-    const settings = JSON.parse(await fs.readFile(path.join(target, ".claude", "settings.local.json"), "utf8"));
-    return persistedMcpValues(settings.env);
-  } catch (error) {
-    if (error.code === "ENOENT") return {};
-    throw error;
-  }
-}
-
 async function main() {
   const options = parseArgs(process.argv.slice(2));
 
@@ -143,7 +132,7 @@ async function main() {
         await cleanupProject({ sourceRoot, ...options });
         break;
       case "mcp":
-        await generateMcp({ sourceRoot, target: options.target, profile: options.profile, mcpValues: await currentMcpValues(options.target), yes: options.yes, dryRun: options.dryRun });
+        await generateMcp({ sourceRoot, target: options.target, profile: options.profile, mcpValues: await readGeneratedMcpValues(options.target), yes: options.yes, dryRun: options.dryRun });
         break;
       case "ecc":
         await setupEcc({ sourceRoot, target: options.target, dryRun: options.dryRun });

--- a/scripts/self-check.mjs
+++ b/scripts/self-check.mjs
@@ -5,12 +5,14 @@ import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { auditProject, printAudit } from "./lib/audit.mjs";
+import { cleanupProject } from "./lib/cleanup.mjs";
 import { doctorProject } from "./lib/doctor.mjs";
-import { applyEccPluginSettings } from "./lib/ecc.mjs";
-import { applyMcpValues, mcpSecretPrompt, persistedMcpValues, validateRelativeMcpPath } from "./lib/mcp.mjs";
+import { applyEccPluginSettings, setupEcc } from "./lib/ecc.mjs";
+import { applyMcpValues, generateMcp, mcpSecretPrompt, persistedMcpValues, readGeneratedMcpValues, validateRelativeMcpPath } from "./lib/mcp.mjs";
 import { applyAttributionSetting, applyLocalSettings, provisionProject } from "./lib/provision.mjs";
+import { writePrivateJson } from "./lib/fs-utils.mjs";
 import { printSummary, renderLogo, style } from "./lib/prompt.mjs";
-import { setupRetryOptions } from "./lib/setup.mjs";
+import { needsLocalSettingsPrompt, setupRetryOptions } from "./lib/setup.mjs";
 import { applyEccRules, formatEccCloneError } from "./lib/rules.mjs";
 import { applyOptionalSkills, applyPluginSkillSettings, expectedOptionalSkillDirs, invalidOptionalSkills, normalizeOptionalSkills, OPTIONAL_SKILLS } from "./lib/skills.mjs";
 
@@ -79,19 +81,16 @@ assert.deepEqual(persistedMcpValues({
 });
 assert.deepEqual(applyLocalSettings({ env: {
   EXISTING: "kept",
-  ANTHROPIC_AUTH_TOKEN: secretSentinel
+  CONTEXT7_API_KEY: "stale-context7-key"
 } }, {
   ANTHROPIC_BASE_URL: "https://example.com/v1",
-  ANTHROPIC_AUTH_TOKEN: secretSentinel
-}, {
-  CONTEXT7_API_KEY: "context7-key",
-  TAVILY_API_KEY: "tavily-key"
+  ANTHROPIC_AUTH_TOKEN: secretSentinel,
+  TAVILY_API_KEY: "stale-tavily-key"
 }), {
   env: {
     EXISTING: "kept",
     ANTHROPIC_BASE_URL: "https://example.com/v1",
-    CONTEXT7_API_KEY: "context7-key",
-    TAVILY_API_KEY: "tavily-key"
+    ANTHROPIC_AUTH_TOKEN: secretSentinel
   }
 });
 assert.deepEqual(applyAttributionSetting({ hooks: {} }, { mode: "off" }), { hooks: {}, attribution: { commit: "" } });
@@ -128,6 +127,28 @@ assert.deepEqual(setupRetryOptions({
   attributionConfig: { mode: "off" },
   dryRun: false
 });
+assert.equal(needsLocalSettingsPrompt({ ANTHROPIC_BASE_URL: "https://example.com/v1" }), true);
+assert.equal(needsLocalSettingsPrompt({
+  ANTHROPIC_AUTH_TOKEN: " ",
+  ANTHROPIC_BASE_URL: "https://example.com/v1",
+  ANTHROPIC_DEFAULT_OPUS_MODEL: "claude-opus-4-8",
+  ANTHROPIC_DEFAULT_SONNET_MODEL: "claude-sonnet-4-6",
+  ANTHROPIC_DEFAULT_HAIKU_MODEL: "claude-haiku-4-5"
+}), true);
+assert.equal(needsLocalSettingsPrompt({
+  ANTHROPIC_AUTH_TOKEN: secretSentinel,
+  ANTHROPIC_BASE_URL: "not-a-url",
+  ANTHROPIC_DEFAULT_OPUS_MODEL: "claude-opus-4-8",
+  ANTHROPIC_DEFAULT_SONNET_MODEL: "claude-sonnet-4-6",
+  ANTHROPIC_DEFAULT_HAIKU_MODEL: "claude-haiku-4-5"
+}), true);
+assert.equal(needsLocalSettingsPrompt({
+  ANTHROPIC_AUTH_TOKEN: secretSentinel,
+  ANTHROPIC_BASE_URL: "https://example.com/v1",
+  ANTHROPIC_DEFAULT_OPUS_MODEL: "claude-opus-4-8",
+  ANTHROPIC_DEFAULT_SONNET_MODEL: "claude-sonnet-4-6",
+  ANTHROPIC_DEFAULT_HAIKU_MODEL: "claude-haiku-4-5"
+}), false);
 assert.deepEqual(applyEccPluginSettings({ enabledPlugins: { other: false } }).enabledPlugins, { other: false, "ecc@ecc": true });
 assert.equal(applyEccPluginSettings().extraKnownMarketplaces.ecc.source.url, "https://github.com/affaan-m/ECC.git");
 const optionalSkillValues = OPTIONAL_SKILLS.map((skill) => skill.value);
@@ -429,12 +450,10 @@ assert.match(result.stderr, /web/);
 
 const mcpReuseTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-mcp-reuse-"));
 try {
-  await fs.mkdir(path.join(mcpReuseTarget, ".claude"), { recursive: true });
-  await fs.writeFile(path.join(mcpReuseTarget, ".claude", "settings.local.json"), JSON.stringify({
-    env: {
-      CONTEXT7_API_KEY: "persisted-context7-key",
-      TAVILY_API_KEY: "persisted-tavily-key",
-      ANTHROPIC_AUTH_TOKEN: secretSentinel
+  await fs.writeFile(path.join(mcpReuseTarget, ".mcp.json"), JSON.stringify({
+    mcpServers: {
+      context7: { env: { CONTEXT7_API_KEY: "persisted-context7-key" } },
+      tavily: { env: { TAVILY_API_KEY: "persisted-tavily-key" } }
     }
   }), "utf8");
   result = runCli(["mcp", "--target", mcpReuseTarget, "--profile", "research", "--yes"]);
@@ -445,6 +464,64 @@ try {
   assert.equal(mcpConfigText.includes(secretSentinel), false);
 } finally {
   await fs.rm(mcpReuseTarget, { recursive: true, force: true });
+}
+
+const setupReuseTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-setup-reuse-"));
+try {
+  await fs.writeFile(path.join(setupReuseTarget, ".mcp.json"), JSON.stringify({
+    mcpServers: { context7: { env: { CONTEXT7_API_KEY: "persisted-setup-key" } } }
+  }), "utf8");
+  result = runCli(["setup", "--target", setupReuseTarget, "--profile", "minimal", "--yes"]);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(await fs.readFile(path.join(setupReuseTarget, ".mcp.json"), "utf8"), /persisted-setup-key/);
+} finally {
+  await fs.rm(setupReuseTarget, { recursive: true, force: true });
+}
+
+const privateWriteTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-private-write-"));
+try {
+  const privateWritePath = path.join(privateWriteTarget, "settings.local.json");
+  await fs.writeFile(privateWritePath, '{"env":{"kept":"value"}}\n', { mode: 0o600 });
+  await assert.rejects(
+    () => writePrivateJson(privateWritePath, { unsupported: 1n }),
+    /BigInt/
+  );
+  assert.equal(await fs.readFile(privateWritePath, "utf8"), '{"env":{"kept":"value"}}\n');
+} finally {
+  await fs.rm(privateWriteTarget, { recursive: true, force: true });
+}
+
+const mcpSymlinkTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-mcp-symlink-target-"));
+const mcpSymlinkDestination = path.join(os.tmpdir(), `repo-pattern-mcp-symlink-destination-${process.pid}`);
+console.log = () => {};
+try {
+  await fs.writeFile(mcpSymlinkDestination, "unchanged", "utf8");
+  await fs.symlink(mcpSymlinkDestination, path.join(mcpSymlinkTarget, ".mcp.json"));
+  await assert.rejects(
+    () => generateMcp({
+      sourceRoot: repoRoot,
+      target: mcpSymlinkTarget,
+      profile: "minimal",
+      mcpValues: { CONTEXT7_API_KEY: "mcp-symlink-key" },
+      yes: true
+    }),
+    /\.mcp\.json.*symlink/
+  );
+  assert.equal(await fs.readFile(mcpSymlinkDestination, "utf8"), "unchanged");
+  await assert.rejects(
+    () => readGeneratedMcpValues(mcpSymlinkTarget),
+    /\.mcp\.json.*symlink/
+  );
+  await fs.rm(path.join(mcpSymlinkTarget, ".mcp.json"));
+  await fs.writeFile(path.join(mcpSymlinkTarget, ".mcp.json"), '{"mcpServers":{"context7":null}}', "utf8");
+  await assert.rejects(
+    () => readGeneratedMcpValues(mcpSymlinkTarget),
+    /invalid MCP server entry/
+  );
+} finally {
+  console.log = originalLog;
+  await fs.rm(mcpSymlinkTarget, { recursive: true, force: true });
+  await fs.rm(mcpSymlinkDestination, { force: true });
 }
 
 const packageJson = JSON.parse(await fs.readFile(path.join(repoRoot, "package.json"), "utf8"));
@@ -474,15 +551,27 @@ try {
       ANTHROPIC_AUTH_TOKEN: secretSentinel,
       OTHER_API_KEY: "other-key"
     },
-    localSettingsEnv: { ANTHROPIC_AUTH_TOKEN: secretSentinel }
+    localSettingsEnv: {
+      ANTHROPIC_BASE_URL: "https://example.com/v1",
+      ANTHROPIC_AUTH_TOKEN: secretSentinel
+    }
   });
-  const localSettingsText = await fs.readFile(path.join(provisionTemplateTarget, ".claude", "settings.local.json"), "utf8");
+  const localSettingsPath = path.join(provisionTemplateTarget, ".claude", "settings.local.json");
+  const localSettingsText = await fs.readFile(localSettingsPath, "utf8");
   const localSettings = JSON.parse(localSettingsText);
+  assert.equal((await fs.stat(localSettingsPath)).mode & 0o777, 0o600);
   const setupLockText = await fs.readFile(path.join(provisionTemplateTarget, ".repo-pattern", ".repo-pattern.lock.json"), "utf8");
-  assert.equal(localSettings.env.CONTEXT7_API_KEY, "redacted-key");
-  assert.equal(localSettingsText.includes(secretSentinel), false);
+  const mcpConfigPath = path.join(provisionTemplateTarget, ".mcp.json");
+  const mcpConfigText = await fs.readFile(mcpConfigPath, "utf8");
+  assert.equal((await fs.stat(mcpConfigPath)).mode & 0o777, 0o600);
+  assert.equal(localSettings.env.ANTHROPIC_AUTH_TOKEN, secretSentinel);
+  assert.equal(localSettings.env.ANTHROPIC_BASE_URL, "https://example.com/v1");
+  assert.equal("CONTEXT7_API_KEY" in localSettings.env, false);
+  assert.equal("TAVILY_API_KEY" in localSettings.env, false);
+  assert.match(mcpConfigText, /redacted-key/);
+  assert.equal(mcpConfigText.includes(secretSentinel), false);
+  assert.equal(setupLockText.includes("redacted-key"), false);
   assert.equal(setupLockText.includes(secretSentinel), false);
-  assert.equal("ANTHROPIC_AUTH_TOKEN" in localSettings.env, false);
   assert.equal("OTHER_API_KEY" in localSettings.env, false);
   const repoConfig = JSON.parse(await fs.readFile(path.join(provisionTemplateTarget, ".repo-pattern", ".repo-pattern.json"), "utf8"));
   assert.equal(repoConfig.mode, "target");
@@ -495,9 +584,242 @@ try {
   }
   const repoPatternGitignore = (await fs.readFile(path.join(provisionTemplateTarget, ".repo-pattern", ".gitignore"), "utf8")).trim();
   assert.equal(repoPatternGitignore, "*");
+
+  await fs.chmod(localSettingsPath, 0o666);
+  await fs.chmod(mcpConfigPath, 0o666);
+  await provisionProject({
+    sourceRoot: repoRoot,
+    target: provisionTemplateTarget,
+    profile: "minimal",
+    mcpValues: { CONTEXT7_API_KEY: "replacement-key" },
+    localSettingsEnv: { ANTHROPIC_AUTH_TOKEN: "replacement-token" }
+  });
+  assert.equal((await fs.stat(localSettingsPath)).mode & 0o777, 0o600);
+  assert.equal((await fs.stat(mcpConfigPath)).mode & 0o777, 0o600);
+  const [backupName] = await fs.readdir(path.join(provisionTemplateTarget, ".repo-pattern", "backups"));
+  const backupRoot = path.join(provisionTemplateTarget, ".repo-pattern", "backups", backupName);
+  await assert.rejects(() => fs.readFile(path.join(backupRoot, ".mcp.json")), { code: "ENOENT" });
+  await assert.rejects(() => fs.readFile(path.join(backupRoot, ".claude", "settings.local.json")), { code: "ENOENT" });
 } finally {
   console.log = originalLog;
   await fs.rm(provisionTemplateTarget, { recursive: true, force: true });
+}
+
+const symlinkTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-symlink-target-"));
+const symlinkDestination = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-symlink-destination-"));
+console.log = () => {};
+try {
+  await fs.symlink(symlinkDestination, path.join(symlinkTarget, ".claude"), "dir");
+  await assert.rejects(
+    () => provisionProject({
+      sourceRoot: repoRoot,
+      target: symlinkTarget,
+      profile: "minimal",
+      localSettingsEnv: { ANTHROPIC_AUTH_TOKEN: secretSentinel }
+    }),
+    /\.claude.*symlink/
+  );
+  await assert.rejects(
+    () => fs.readFile(path.join(symlinkDestination, "settings.local.json")),
+    { code: "ENOENT" }
+  );
+} finally {
+  console.log = originalLog;
+  await fs.rm(symlinkTarget, { recursive: true, force: true });
+  await fs.rm(symlinkDestination, { recursive: true, force: true });
+}
+
+const settingsSymlinkTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-settings-symlink-target-"));
+const settingsSymlinkDestination = path.join(os.tmpdir(), `repo-pattern-settings-symlink-destination-${process.pid}`);
+console.log = () => {};
+try {
+  await fs.mkdir(path.join(settingsSymlinkTarget, ".claude"));
+  await fs.writeFile(settingsSymlinkDestination, "unchanged", "utf8");
+  await fs.symlink(settingsSymlinkDestination, path.join(settingsSymlinkTarget, ".claude", "settings.local.json"));
+  await assert.rejects(
+    () => provisionProject({
+      sourceRoot: repoRoot,
+      target: settingsSymlinkTarget,
+      profile: "minimal",
+      localSettingsEnv: { ANTHROPIC_AUTH_TOKEN: secretSentinel }
+    }),
+    /settings\.local\.json.*symlink/
+  );
+  assert.equal(await fs.readFile(settingsSymlinkDestination, "utf8"), "unchanged");
+} finally {
+  console.log = originalLog;
+  await fs.rm(settingsSymlinkTarget, { recursive: true, force: true });
+  await fs.rm(settingsSymlinkDestination, { force: true });
+}
+
+const eccSettingsTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-ecc-settings-"));
+console.log = () => {};
+try {
+  const eccSettingsPath = path.join(eccSettingsTarget, ".claude", "settings.local.json");
+  await fs.mkdir(path.dirname(eccSettingsPath));
+  await fs.writeFile(eccSettingsPath, JSON.stringify({ env: { ANTHROPIC_AUTH_TOKEN: secretSentinel } }), { mode: 0o666 });
+  await setupEcc({ target: eccSettingsTarget });
+  assert.equal((await fs.stat(eccSettingsPath)).mode & 0o777, 0o600);
+  assert.match(await fs.readFile(eccSettingsPath, "utf8"), /do-not-persist-anthropic-token/);
+} finally {
+  console.log = originalLog;
+  await fs.rm(eccSettingsTarget, { recursive: true, force: true });
+}
+
+const eccSymlinkTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-ecc-symlink-target-"));
+const eccSymlinkDestination = path.join(os.tmpdir(), `repo-pattern-ecc-symlink-destination-${process.pid}`);
+console.log = () => {};
+try {
+  await fs.mkdir(path.join(eccSymlinkTarget, ".claude"));
+  await fs.writeFile(eccSymlinkDestination, "not-json", "utf8");
+  await fs.symlink(eccSymlinkDestination, path.join(eccSymlinkTarget, ".claude", "settings.local.json"));
+  await assert.rejects(
+    () => setupEcc({ target: eccSymlinkTarget }),
+    /settings\.local\.json.*symlink/
+  );
+  assert.equal(await fs.readFile(eccSymlinkDestination, "utf8"), "not-json");
+} finally {
+  console.log = originalLog;
+  await fs.rm(eccSymlinkTarget, { recursive: true, force: true });
+  await fs.rm(eccSymlinkDestination, { force: true });
+}
+
+const eccClaudeSymlinkTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-ecc-claude-symlink-target-"));
+const eccClaudeSymlinkDestination = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-ecc-claude-symlink-destination-"));
+console.log = () => {};
+try {
+  await fs.symlink(eccClaudeSymlinkDestination, path.join(eccClaudeSymlinkTarget, ".claude"), "dir");
+  await assert.rejects(
+    () => setupEcc({ target: eccClaudeSymlinkTarget }),
+    /\.claude.*symlink/
+  );
+  await assert.rejects(
+    () => fs.readFile(path.join(eccClaudeSymlinkDestination, "settings.local.json")),
+    { code: "ENOENT" }
+  );
+} finally {
+  console.log = originalLog;
+  await fs.rm(eccClaudeSymlinkTarget, { recursive: true, force: true });
+  await fs.rm(eccClaudeSymlinkDestination, { recursive: true, force: true });
+}
+
+const pluginSettingsTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-plugin-settings-"));
+console.log = () => {};
+try {
+  const pluginSettingsPath = path.join(pluginSettingsTarget, ".claude", "settings.local.json");
+  await fs.mkdir(path.dirname(pluginSettingsPath));
+  await fs.writeFile(pluginSettingsPath, JSON.stringify({ env: { ANTHROPIC_AUTH_TOKEN: secretSentinel } }), { mode: 0o666 });
+  await applyOptionalSkills({ target: pluginSettingsTarget, skills: ["taste"] });
+  assert.equal((await fs.stat(pluginSettingsPath)).mode & 0o777, 0o600);
+  assert.match(await fs.readFile(pluginSettingsPath, "utf8"), /do-not-persist-anthropic-token/);
+} finally {
+  console.log = originalLog;
+  await fs.rm(pluginSettingsTarget, { recursive: true, force: true });
+}
+
+const pluginSymlinkTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-plugin-symlink-target-"));
+const pluginSymlinkDestination = path.join(os.tmpdir(), `repo-pattern-plugin-symlink-destination-${process.pid}`);
+console.log = () => {};
+try {
+  await fs.mkdir(path.join(pluginSymlinkTarget, ".claude"));
+  await fs.writeFile(pluginSymlinkDestination, "not-json", "utf8");
+  await fs.symlink(pluginSymlinkDestination, path.join(pluginSymlinkTarget, ".claude", "settings.local.json"));
+  await assert.rejects(
+    () => applyOptionalSkills({ target: pluginSymlinkTarget, skills: ["taste"] }),
+    /settings\.local\.json.*symlink/
+  );
+  assert.equal(await fs.readFile(pluginSymlinkDestination, "utf8"), "not-json");
+} finally {
+  console.log = originalLog;
+  await fs.rm(pluginSymlinkTarget, { recursive: true, force: true });
+  await fs.rm(pluginSymlinkDestination, { force: true });
+}
+
+const pluginClaudeSymlinkTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-plugin-claude-symlink-target-"));
+const pluginClaudeSymlinkDestination = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-plugin-claude-symlink-destination-"));
+console.log = () => {};
+try {
+  await fs.symlink(pluginClaudeSymlinkDestination, path.join(pluginClaudeSymlinkTarget, ".claude"), "dir");
+  await assert.rejects(
+    () => applyOptionalSkills({ target: pluginClaudeSymlinkTarget, skills: ["taste"] }),
+    /\.claude.*symlink/
+  );
+  await assert.rejects(
+    () => fs.readFile(path.join(pluginClaudeSymlinkDestination, "settings.local.json")),
+    { code: "ENOENT" }
+  );
+} finally {
+  console.log = originalLog;
+  await fs.rm(pluginClaudeSymlinkTarget, { recursive: true, force: true });
+  await fs.rm(pluginClaudeSymlinkDestination, { recursive: true, force: true });
+}
+
+const cleanupCredentialTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-cleanup-credentials-"));
+console.log = () => {};
+try {
+  await fs.mkdir(path.join(cleanupCredentialTarget, ".claude"), { recursive: true });
+  await fs.writeFile(path.join(cleanupCredentialTarget, ".claude", "settings.json"), "{}", "utf8");
+  await fs.writeFile(path.join(cleanupCredentialTarget, ".claude", "settings.local.json"), JSON.stringify({ env: { ANTHROPIC_AUTH_TOKEN: secretSentinel } }), "utf8");
+  await fs.writeFile(path.join(cleanupCredentialTarget, ".mcp.json"), JSON.stringify({ mcpServers: { context7: { env: { CONTEXT7_API_KEY: "cleanup-key" } } } }), "utf8");
+  await cleanupProject({ sourceRoot: repoRoot, target: cleanupCredentialTarget });
+  assert.match(await fs.readFile(path.join(cleanupCredentialTarget, ".claude", "settings.local.json"), "utf8"), /do-not-persist-anthropic-token/);
+  assert.match(await fs.readFile(path.join(cleanupCredentialTarget, ".mcp.json"), "utf8"), /cleanup-key/);
+  const [backupName] = await fs.readdir(path.join(cleanupCredentialTarget, ".repo-pattern", "backups"));
+  const backupRoot = path.join(cleanupCredentialTarget, ".repo-pattern", "backups", backupName);
+  await assert.rejects(() => fs.readFile(path.join(backupRoot, ".mcp.json")), { code: "ENOENT" });
+  await assert.rejects(() => fs.readFile(path.join(backupRoot, ".claude", "settings.local.json")), { code: "ENOENT" });
+} finally {
+  console.log = originalLog;
+  await fs.rm(cleanupCredentialTarget, { recursive: true, force: true });
+}
+
+const defaultProvisionTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-default-provision-"));
+console.log = () => {};
+try {
+  await provisionProject({
+    sourceRoot: repoRoot,
+    target: defaultProvisionTarget,
+    profile: "minimal",
+    mcpValues: { CONTEXT7_API_KEY: "default-run-key" }
+  });
+  const mcpConfigText = await fs.readFile(path.join(defaultProvisionTarget, ".mcp.json"), "utf8");
+  const localSettingsText = await fs.readFile(path.join(defaultProvisionTarget, ".claude", "settings.local.json"), "utf8");
+  assert.match(mcpConfigText, /default-run-key/);
+  assert.equal(localSettingsText.includes("default-run-key"), false);
+} finally {
+  console.log = originalLog;
+  await fs.rm(defaultProvisionTarget, { recursive: true, force: true });
+}
+
+const runOnlyTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-run-only-"));
+console.log = () => {};
+try {
+  await provisionProject({
+    sourceRoot: repoRoot,
+    target: runOnlyTarget,
+    profile: "minimal",
+    mcpValues: {
+      CONTEXT7_API_KEY: "run-only-key",
+      ANTHROPIC_AUTH_TOKEN: secretSentinel
+    },
+    localSettingsEnv: {
+      CONTEXT7_API_KEY: "previously-saved-key",
+      ANTHROPIC_AUTH_TOKEN: secretSentinel
+    }
+  });
+  const localSettingsText = await fs.readFile(path.join(runOnlyTarget, ".claude", "settings.local.json"), "utf8");
+  const mcpConfigText = await fs.readFile(path.join(runOnlyTarget, ".mcp.json"), "utf8");
+  const setupLockText = await fs.readFile(path.join(runOnlyTarget, ".repo-pattern", ".repo-pattern.lock.json"), "utf8");
+  assert.equal(localSettingsText.includes("run-only-key"), false);
+  assert.equal(localSettingsText.includes("previously-saved-key"), false);
+  assert.match(localSettingsText, /do-not-persist-anthropic-token/);
+  assert.match(mcpConfigText, /run-only-key/);
+  assert.equal(mcpConfigText.includes(secretSentinel), false);
+  assert.equal(setupLockText.includes("run-only-key"), false);
+  assert.equal(setupLockText.includes(secretSentinel), false);
+} finally {
+  console.log = originalLog;
+  await fs.rm(runOnlyTarget, { recursive: true, force: true });
 }
 
 const trackedLockTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-tracked-lock-"));


### PR DESCRIPTION
## Summary

- persist Anthropic provider settings and auth token in private local Claude settings
- persist Context7 and Tavily credentials only in private MCP configuration and reuse them on retry
- reject credential-file symlinks, enforce mode 0600, and exclude credentials from backups and cleanup
- add retry, leakage, permission, and symlink regression coverage
- release package version 0.1.9

## Test plan

- [x] `node scripts/self-check.mjs`
- [x] `npm test`
- [x] `npm run pack:dry`
- [x] syntax checks for changed `.mjs` files
- [x] `git diff --check`
- [x] credential ignore/tracking and synthetic leakage checks
- [x] GitNexus comparison against `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)