### PR TITLE
feat: configure setup permission defaults

### DIFF
--- a/.claude.example/settings.local.example.json
+++ b/.claude.example/settings.local.example.json
@@ -23,6 +23,7 @@
   },
   "env": {
     "ENABLE_TOOL_SEARCH": "auto:5",
+    "CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION": "5",
     "ANTHROPIC_BASE_URL": "https://example.com/v1",
     "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-4-8",
     "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-sonnet-4-6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@negikirin/repo-pattern",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@negikirin/repo-pattern",
-      "version": "0.1.9",
+      "version": "0.1.10",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^0.11.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@negikirin/repo-pattern",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Minimal ECC-first Claude Code project setup and migrator",
   "type": "module",
   "bin": {

--- a/scripts/lib/provision.mjs
+++ b/scripts/lib/provision.mjs
@@ -73,9 +73,22 @@ export function applyAttributionSetting(settings, attributionConfig = { mode: "o
   return next;
 }
 
-async function writeClaudeSettings({ sourceRoot, target, attributionConfig, dryRun }) {
+export function applyPermissionSettings(settings, permissionConfig = { bypass: "deny" }) {
+  const permissions = { ...(settings.permissions || {}) };
+  if (permissionConfig.bypass === "allow") {
+    permissions.defaultMode = "bypassPermissions";
+    delete permissions.disableBypassPermissionsMode;
+  } else {
+    permissions.defaultMode = "default";
+    permissions.disableBypassPermissionsMode = "disable";
+  }
+  return { ...settings, permissions };
+}
+
+async function writeClaudeSettings({ sourceRoot, target, attributionConfig, permissionConfig, dryRun }) {
   const template = await readJson(path.join(sourceRoot, ".claude.example", "settings.example.json"), {});
-  await writeJson(path.join(target, ".claude", "settings.json"), applyAttributionSetting(template, attributionConfig), { dryRun });
+  const settings = applyPermissionSettings(applyAttributionSetting(template, attributionConfig), permissionConfig);
+  await writeJson(path.join(target, ".claude", "settings.json"), settings, { dryRun });
 }
 
 export async function updateClaudeAttribution({ sourceRoot, target, attributionConfig, dryRun }) {
@@ -84,6 +97,15 @@ export async function updateClaudeAttribution({ sourceRoot, target, attributionC
   const current = await readJson(file, null);
   const template = await readJson(path.join(sourceRoot, ".claude.example", "settings.example.json"), {});
   await writeJson(file, applyAttributionSetting(current || template, attributionConfig), { dryRun });
+  await appendGitignoreLine(target, ".claude/", { dryRun });
+}
+
+export async function updateClaudePermissions({ sourceRoot, target, permissionConfig, dryRun }) {
+  if (isTracked(target, ".claude/settings.json")) throw new Error(".claude/settings.json is tracked. Untrack it before writing Claude Code settings.");
+  const file = path.join(target, ".claude", "settings.json");
+  const current = await readJson(file, null);
+  const template = await readJson(path.join(sourceRoot, ".claude.example", "settings.example.json"), {});
+  await writeJson(file, applyPermissionSettings(current || template, permissionConfig), { dryRun });
   await appendGitignoreLine(target, ".claude/", { dryRun });
 }
 
@@ -123,7 +145,7 @@ async function writeLocalSettings({ sourceRoot, target, localSettingsEnv, dryRun
   await appendGitignoreLine(target, ".claude/", { dryRun });
 }
 
-export async function provisionProject({ sourceRoot, target, profile = "web", mcpServers = null, mcpValues = {}, dryRun = false, force = false, migrate = false, localSettingsEnv = null, attributionConfig = { mode: "off" }, ruleMode = "auto", rules = null, applyRules = false, optionalSkills = [] }) {
+export async function provisionProject({ sourceRoot, target, profile = "web", mcpServers = null, mcpValues = {}, dryRun = false, force = false, migrate = false, localSettingsEnv = null, attributionConfig = { mode: "off" }, permissionConfig = { bypass: "deny" }, ruleMode = "auto", rules = null, applyRules = false, optionalSkills = [] }) {
   printSummary("Provisioning target", [["Target", target]]);
   await rejectClaudeSymlink(target, { dryRun });
   const audit = await auditProject(target);
@@ -152,7 +174,7 @@ export async function provisionProject({ sourceRoot, target, profile = "web", mc
     { dryRun }
   );
 
-  await writeClaudeSettings({ sourceRoot, target, attributionConfig, dryRun });
+  await writeClaudeSettings({ sourceRoot, target, attributionConfig, permissionConfig, dryRun });
   await appendGitignoreLine(target, ".claude/", { dryRun });
 
   await writeLocalSettings({ sourceRoot, target, localSettingsEnv, dryRun });

--- a/scripts/lib/setup.mjs
+++ b/scripts/lib/setup.mjs
@@ -3,7 +3,7 @@ import path from "node:path";
 import { promisify } from "node:util";
 import { auditProject, printAudit } from "./audit.mjs";
 import { detectProject } from "./project-detect.mjs";
-import { provisionProject, updateClaudeAttribution } from "./provision.mjs";
+import { provisionProject, updateClaudeAttribution, updateClaudePermissions } from "./provision.mjs";
 import { doctorProject } from "./doctor.mjs";
 import { collectMcpValues, generateMcp, listAvailableMcpServers, persistedMcpValues, readGeneratedMcpValues, readMcpConfig } from "./mcp.mjs";
 import { askConfirm, askPassword, askText, isInteractive, printBox, printLogo, printSummary, selectMany, selectOne, style } from "./prompt.mjs";
@@ -36,7 +36,12 @@ function validateUrl(value) {
   }
 }
 
+function validatePositiveInteger(value) {
+  return /^[1-9]\d*$/.test(String(value)) ? true : "Use a positive whole number.";
+}
+
 const LOCAL_SETTINGS_FIELDS = [
+  ["CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION", "5", askText, validatePositiveInteger],
   ["ANTHROPIC_AUTH_TOKEN", "", askPassword, validateRequired],
   ["ANTHROPIC_BASE_URL", "https://example.com/v1", askText, validateUrl],
   ["ANTHROPIC_DEFAULT_OPUS_MODEL", "claude-opus-4-8", askText, validateRequired],
@@ -53,7 +58,7 @@ function safeRetryLocalSettingsEnv(localSettingsEnv = {}) {
   return Object.fromEntries(Object.entries(localSettingsEnv).filter(([name]) => !RETRY_SECRET_LOCAL_SETTINGS.has(name)));
 }
 
-export function setupRetryOptions({ action, mcpConfig, mcpValues = {}, ruleConfig, optionalSkills, localSettingsEnv, attributionConfig, dryRun }) {
+export function setupRetryOptions({ action, mcpConfig, mcpValues = {}, ruleConfig, optionalSkills, localSettingsEnv, attributionConfig, permissionConfig = { bypass: "deny" }, dryRun }) {
   return {
     action,
     profile: mcpConfig.profile,
@@ -66,6 +71,7 @@ export function setupRetryOptions({ action, mcpConfig, mcpValues = {}, ruleConfi
     optionalSkills,
     localSettingsEnv: safeRetryLocalSettingsEnv(localSettingsEnv),
     attributionConfig,
+    permissionConfig,
     dryRun
   };
 }
@@ -73,7 +79,12 @@ export function setupRetryOptions({ action, mcpConfig, mcpValues = {}, ruleConfi
 function setupOptionsFromLock(lock) {
   const setup = lock?.setup;
   if (!["failed", "running"].includes(setup?.status)) return null;
-  return setup.options || null;
+  const options = setup.options || null;
+  if (!options) return null;
+  return {
+    ...options,
+    permissionConfig: options.permissionConfig?.bypass === "allow" ? { bypass: "allow" } : { bypass: "deny" }
+  };
 }
 
 async function writeSetupStatus(target, setup, { dryRun = false } = {}) {
@@ -103,6 +114,7 @@ function retryRows(setup) {
     ["MCP values", options.mcpValueNames?.length ? options.mcpValueNames.join(", ") : "none"],
     ["Rules", options.applyRules ? options.rules.join(", ") : "none"],
     ["Optional skills", options.optionalSkills?.length ? options.optionalSkills.join(", ") : "none"],
+    ["Bypass permissions", options.permissionConfig?.bypass === "allow" ? "allowed by default" : "disabled"],
     ["Commit attribution", attributionSummary(options.attributionConfig || { mode: "off" })],
     ["Dry-run", options.dryRun ? "yes" : "no"]
   ];
@@ -147,7 +159,7 @@ async function checkClaudeCode() {
 
 async function chooseProfile(sourceRoot, profile, detection) {
   return selectOne({
-    message: "Step 1/5 — Choose MCP profile",
+    message: "Step 1/6 — Choose MCP profile",
     options: await profileOptions(sourceRoot),
     initialValue: suggestedProfile(detection, profile)
   });
@@ -172,7 +184,7 @@ async function chooseMcpValues(sourceRoot, mcpConfig, values = {}) {
 async function chooseRuleConfig(detection) {
   const autoRules = selectEccRules(detection);
   const ruleMode = await selectOne({
-    message: "Step 2/5 — Choose ECC rule detection mode",
+    message: "Step 2/6 — Choose ECC rule detection mode",
     options: [
       { value: "auto", label: "auto", description: `detect from project (${autoRules.join(", ")})` },
       { value: "manual", label: "manual", description: "choose rule packs by type" },
@@ -197,7 +209,7 @@ async function chooseRuleConfig(detection) {
 
 async function chooseOptionalSkills(initialValues = []) {
   return selectMany({
-    message: "Step 3/5 — Optional external skills",
+    message: "Step 3/6 — Optional external skills",
     options: OPTIONAL_SKILLS,
     initialValues
   });
@@ -208,7 +220,7 @@ export function needsLocalSettingsPrompt(values = {}) {
 }
 
 async function chooseLocalSettingsEnv(initialValues = {}) {
-  printBox("Step 4/5 — Local Claude provider settings", ["These values are written to .claude/settings.local.json and gitignored."]);
+  printBox("Step 4/6 — Local Claude provider settings", ["These values are written to .claude/settings.local.json and gitignored."]);
   const env = {};
   for (const [name, fallback, ask, validate] of LOCAL_SETTINGS_FIELDS) {
     env[name] = await ask(name, { initial: process.env[name] || initialValues[name] || fallback, validate });
@@ -216,8 +228,21 @@ async function chooseLocalSettingsEnv(initialValues = {}) {
   return env;
 }
 
+async function choosePermissionConfig() {
+  return {
+    bypass: await selectOne({
+      message: "Step 5/6 — Allow bypass permissions mode?",
+      options: [
+        { value: "deny", label: "No", description: "disable bypass permissions mode" },
+        { value: "allow", label: "Yes", description: "default to bypassPermissions" }
+      ],
+      initialValue: "deny"
+    })
+  };
+}
+
 async function chooseAttributionConfig() {
-  printBox("Step 5/5 — Claude Code commit attribution", ["Controls .claude/settings.json attribution.commit."]);
+  printBox("Step 6/6 — Claude Code commit attribution", ["Controls .claude/settings.json attribution.commit."]);
   const mode = await selectOne({
     message: "Commit attribution?",
     options: [
@@ -243,7 +268,7 @@ function attributionSummary(attributionConfig) {
   return "off (commit: \"\")";
 }
 
-async function confirmSummary({ action, target, mcpConfig, mcpValues, ruleConfig, optionalSkills, localSettingsEnv, attributionConfig, dryRun }) {
+async function confirmSummary({ action, target, mcpConfig, mcpValues, ruleConfig, optionalSkills, localSettingsEnv, attributionConfig, permissionConfig, dryRun }) {
   const hasLocalSkill = optionalSkills.some((name) => !OPTIONAL_SKILLS.find((skill) => skill.value === name)?.plugin);
   printSummary("Setup summary", [
     ["Action", action],
@@ -255,10 +280,12 @@ async function confirmSummary({ action, target, mcpConfig, mcpValues, ruleConfig
     ["Optional skills", optionalSkills.length ? optionalSkills.join(", ") : "none"],
     ["Local settings", ".claude/settings.local.json"],
     ["Base URL", localSettingsEnv.ANTHROPIC_BASE_URL],
+    ["Subagent session limit", localSettingsEnv.CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION],
     ["Opus", localSettingsEnv.ANTHROPIC_DEFAULT_OPUS_MODEL],
     ["Sonnet", localSettingsEnv.ANTHROPIC_DEFAULT_SONNET_MODEL],
     ["Haiku", localSettingsEnv.ANTHROPIC_DEFAULT_HAIKU_MODEL],
     ["Auth token", style("dim", "[hidden]")],
+    ["Bypass permissions", permissionConfig.bypass === "allow" ? "allowed by default" : "disabled"],
     ["Commit attribution", attributionSummary(attributionConfig)],
     ["Dry-run", dryRun ? "yes" : "no"],
     ["Will write", `CLAUDE.md (if missing), .claude/CLAUDE.md, .claude/settings.json, .claude/settings.local.json, .mcp.json, .repo-pattern/.repo-pattern.json, .repo-pattern/.repo-pattern.lock.json${optionalSkills.length ? ", optional skill/plugin config" : ""}${hasLocalSkill ? ", .claude/skills" : ""}`],
@@ -285,6 +312,7 @@ async function handleInitialized({ sourceRoot, target, profile, dryRun }) {
       { value: "doctor", label: "Run doctor" },
       { value: "mcp", label: "Regenerate MCP profile" },
       { value: "skills", label: "Add optional skills" },
+      { value: "permissions", label: "Configure bypass permissions" },
       { value: "attribution", label: "Update commit attribution" },
       { value: "exit", label: "Exit" }
     ],
@@ -309,6 +337,10 @@ async function handleInitialized({ sourceRoot, target, profile, dryRun }) {
   if (action === "skills") {
     const optionalSkills = await chooseOptionalSkills();
     await applyOptionalSkills({ target, skills: optionalSkills, dryRun });
+    if (!dryRun) await doctorProject(target, { updateLock: true, dryRun });
+  }
+  if (action === "permissions") {
+    await updateClaudePermissions({ sourceRoot, target, permissionConfig: await choosePermissionConfig(), dryRun });
     if (!dryRun) await doctorProject(target, { updateLock: true, dryRun });
   }
   if (action === "attribution") {
@@ -389,17 +421,18 @@ export async function setupProject({ sourceRoot, target, profile = "web", dryRun
 
   const currentSettingsEnv = await currentLocalSettingsEnv(target);
   const mcpValues = await chooseMcpValues(sourceRoot, mcpConfig, await readGeneratedMcpValues(target));
-  const retryLocalSettingsEnv = { ...previousOptions?.localSettingsEnv, ...currentSettingsEnv };
+  const retryLocalSettingsEnv = { CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION: "5", ...previousOptions?.localSettingsEnv, ...currentSettingsEnv };
   const localSettingsEnv = previousOptions && !needsLocalSettingsPrompt(retryLocalSettingsEnv)
     ? retryLocalSettingsEnv
     : await chooseLocalSettingsEnv(retryLocalSettingsEnv);
+  const permissionConfig = previousOptions?.permissionConfig || await choosePermissionConfig();
   const attributionConfig = previousOptions?.attributionConfig || await chooseAttributionConfig();
 
-  if (!await confirmSummary({ action, target, mcpConfig, mcpValues, ruleConfig, optionalSkills: selectedOptionalSkills, localSettingsEnv, attributionConfig, dryRun })) {
+  if (!await confirmSummary({ action, target, mcpConfig, mcpValues, ruleConfig, optionalSkills: selectedOptionalSkills, localSettingsEnv, attributionConfig, permissionConfig, dryRun })) {
     throw new Error("Setup cancelled.");
   }
 
-  const retryOptions = setupRetryOptions({ action, mcpConfig, mcpValues, ruleConfig, optionalSkills: selectedOptionalSkills, localSettingsEnv, attributionConfig, dryRun });
+  const retryOptions = setupRetryOptions({ action, mcpConfig, mcpValues, ruleConfig, optionalSkills: selectedOptionalSkills, localSettingsEnv, attributionConfig, permissionConfig, dryRun });
   await writeSetupStatus(target, { status: "running", startedAt: new Date().toISOString(), failedStep: null, error: null, options: retryOptions }, { dryRun });
   try {
     await provisionProject({
@@ -416,7 +449,8 @@ export async function setupProject({ sourceRoot, target, profile = "web", dryRun
       applyRules: ruleConfig.applyRules,
       optionalSkills: selectedOptionalSkills,
       localSettingsEnv,
-      attributionConfig
+      attributionConfig,
+      permissionConfig
     });
     await writeSetupStatus(target, { status: "succeeded", succeededAt: new Date().toISOString(), failedStep: null, error: null, options: retryOptions }, { dryRun });
   } catch (error) {

--- a/scripts/self-check.mjs
+++ b/scripts/self-check.mjs
@@ -9,7 +9,7 @@ import { cleanupProject } from "./lib/cleanup.mjs";
 import { doctorProject } from "./lib/doctor.mjs";
 import { applyEccPluginSettings, setupEcc } from "./lib/ecc.mjs";
 import { applyMcpValues, generateMcp, mcpSecretPrompt, persistedMcpValues, readGeneratedMcpValues, validateRelativeMcpPath } from "./lib/mcp.mjs";
-import { applyAttributionSetting, applyLocalSettings, provisionProject } from "./lib/provision.mjs";
+import { applyAttributionSetting, applyLocalSettings, applyPermissionSettings, provisionProject, updateClaudePermissions } from "./lib/provision.mjs";
 import { writePrivateJson } from "./lib/fs-utils.mjs";
 import { printSummary, renderLogo, style } from "./lib/prompt.mjs";
 import { needsLocalSettingsPrompt, setupRetryOptions } from "./lib/setup.mjs";
@@ -96,6 +96,12 @@ assert.deepEqual(applyLocalSettings({ env: {
 assert.deepEqual(applyAttributionSetting({ hooks: {} }, { mode: "off" }), { hooks: {}, attribution: { commit: "" } });
 assert.deepEqual(applyAttributionSetting({ attribution: { commit: "" } }, { mode: "on" }), {});
 assert.deepEqual(applyAttributionSetting({ attribution: { pr: "PR" } }, { mode: "custom", commit: "Custom" }), { attribution: { pr: "PR", commit: "Custom" } });
+assert.deepEqual(applyPermissionSettings({ permissions: { deny: ["Read(.env)"] } }, { bypass: "allow" }), {
+  permissions: { deny: ["Read(.env)"], defaultMode: "bypassPermissions" }
+});
+assert.deepEqual(applyPermissionSettings({ permissions: { defaultMode: "bypassPermissions" } }, { bypass: "deny" }), {
+  permissions: { defaultMode: "default", disableBypassPermissionsMode: "disable" }
+});
 assert.deepEqual(setupRetryOptions({
   action: "setup",
   mcpConfig: { profile: "web", mcpServers: null },
@@ -108,6 +114,7 @@ assert.deepEqual(setupRetryOptions({
   localSettingsEnv: {
     ANTHROPIC_BASE_URL: "https://example.com/v1",
     ANTHROPIC_AUTH_TOKEN: secretSentinel,
+    CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION: "5",
     CONTEXT7_API_KEY: "context7-key",
     TAVILY_API_KEY: "tavily-key"
   },
@@ -123,11 +130,23 @@ assert.deepEqual(setupRetryOptions({
   ruleMode: "auto",
   rules: [],
   optionalSkills: ["nextjs-pattern"],
-  localSettingsEnv: { ANTHROPIC_BASE_URL: "https://example.com/v1" },
+  localSettingsEnv: {
+    ANTHROPIC_BASE_URL: "https://example.com/v1",
+    CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION: "5"
+  },
   attributionConfig: { mode: "off" },
+  permissionConfig: { bypass: "deny" },
   dryRun: false
 });
 assert.equal(needsLocalSettingsPrompt({ ANTHROPIC_BASE_URL: "https://example.com/v1" }), true);
+assert.equal(needsLocalSettingsPrompt({
+  CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION: "0",
+  ANTHROPIC_AUTH_TOKEN: secretSentinel,
+  ANTHROPIC_BASE_URL: "https://example.com/v1",
+  ANTHROPIC_DEFAULT_OPUS_MODEL: "claude-opus-4-8",
+  ANTHROPIC_DEFAULT_SONNET_MODEL: "claude-sonnet-4-6",
+  ANTHROPIC_DEFAULT_HAIKU_MODEL: "claude-haiku-4-5"
+}), true);
 assert.equal(needsLocalSettingsPrompt({
   ANTHROPIC_AUTH_TOKEN: " ",
   ANTHROPIC_BASE_URL: "https://example.com/v1",
@@ -145,6 +164,7 @@ assert.equal(needsLocalSettingsPrompt({
 assert.equal(needsLocalSettingsPrompt({
   ANTHROPIC_AUTH_TOKEN: secretSentinel,
   ANTHROPIC_BASE_URL: "https://example.com/v1",
+  CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION: "5",
   ANTHROPIC_DEFAULT_OPUS_MODEL: "claude-opus-4-8",
   ANTHROPIC_DEFAULT_SONNET_MODEL: "claude-sonnet-4-6",
   ANTHROPIC_DEFAULT_HAIKU_MODEL: "claude-haiku-4-5"
@@ -553,12 +573,15 @@ try {
     },
     localSettingsEnv: {
       ANTHROPIC_BASE_URL: "https://example.com/v1",
-      ANTHROPIC_AUTH_TOKEN: secretSentinel
-    }
+      ANTHROPIC_AUTH_TOKEN: secretSentinel,
+      CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION: "7"
+    },
+    permissionConfig: { bypass: "allow" }
   });
   const localSettingsPath = path.join(provisionTemplateTarget, ".claude", "settings.local.json");
   const localSettingsText = await fs.readFile(localSettingsPath, "utf8");
   const localSettings = JSON.parse(localSettingsText);
+  const settings = JSON.parse(await fs.readFile(path.join(provisionTemplateTarget, ".claude", "settings.json"), "utf8"));
   assert.equal((await fs.stat(localSettingsPath)).mode & 0o777, 0o600);
   const setupLockText = await fs.readFile(path.join(provisionTemplateTarget, ".repo-pattern", ".repo-pattern.lock.json"), "utf8");
   const mcpConfigPath = path.join(provisionTemplateTarget, ".mcp.json");
@@ -566,6 +589,9 @@ try {
   assert.equal((await fs.stat(mcpConfigPath)).mode & 0o777, 0o600);
   assert.equal(localSettings.env.ANTHROPIC_AUTH_TOKEN, secretSentinel);
   assert.equal(localSettings.env.ANTHROPIC_BASE_URL, "https://example.com/v1");
+  assert.equal(localSettings.env.CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION, "7");
+  assert.equal(settings.permissions.defaultMode, "bypassPermissions");
+  assert.equal("disableBypassPermissionsMode" in settings.permissions, false);
   assert.equal("CONTEXT7_API_KEY" in localSettings.env, false);
   assert.equal("TAVILY_API_KEY" in localSettings.env, false);
   assert.match(mcpConfigText, /redacted-key/);
@@ -783,9 +809,17 @@ try {
     mcpValues: { CONTEXT7_API_KEY: "default-run-key" }
   });
   const mcpConfigText = await fs.readFile(path.join(defaultProvisionTarget, ".mcp.json"), "utf8");
-  const localSettingsText = await fs.readFile(path.join(defaultProvisionTarget, ".claude", "settings.local.json"), "utf8");
+  const settingsPath = path.join(defaultProvisionTarget, ".claude", "settings.json");
+  const settings = JSON.parse(await fs.readFile(settingsPath, "utf8"));
   assert.match(mcpConfigText, /default-run-key/);
-  assert.equal(localSettingsText.includes("default-run-key"), false);
+  assert.equal(settings.permissions.defaultMode, "default");
+  assert.equal(settings.permissions.disableBypassPermissionsMode, "disable");
+  const localSettings = JSON.parse(await fs.readFile(path.join(defaultProvisionTarget, ".claude", "settings.local.json"), "utf8"));
+  assert.equal("env" in localSettings, false);
+  await updateClaudePermissions({ sourceRoot: repoRoot, target: defaultProvisionTarget, permissionConfig: { bypass: "allow" } });
+  const updatedSettings = JSON.parse(await fs.readFile(settingsPath, "utf8"));
+  assert.equal(updatedSettings.permissions.defaultMode, "bypassPermissions");
+  assert.equal("disableBypassPermissionsMode" in updatedSettings.permissions, false);
 } finally {
   console.log = originalLog;
   await fs.rm(defaultProvisionTarget, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- add a configurable per-session subagent limit to generated local Claude settings
- add an interactive setup choice for enabling or disabling bypass permissions mode
- preserve permission choices across failed setup retries and support updating initialized projects
- default new setups to disabled bypass permissions
- release package version 0.1.10

## Test plan

- [x] `node scripts/self-check.mjs`
- [x] `npm test`
- [x] `npm run pack:dry`
- [x] syntax checks for changed `.mjs` files
- [x] `git diff --check`
- [x] credential ignore/tracking and leakage checks
- [x] GitNexus comparison against `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)