### PR TITLE
feat: add gstack setup pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@
 
 **A clean Claude Code setup and migrator in one command.**
 
-`repo-pattern` initializes or migrates a project into an ECC-first (Everything Claude Code) workspace with safe defaults, MCP profiles, and zero vendored runtime clutter.
+`repo-pattern` initializes or migrates a project into an ECC or gstack Claude Code workspace with safe defaults, MCP profiles, and zero vendored runtime clutter.
 
 ## Why use it?
 
 * **Start fast** — generate `.claude/`, `.mcp.json`, and repo-pattern metadata.
 * **Stay clean** — no local skills, commands, hooks, scripts, or duplicated templates by default.
 * **Use MCP profiles** — choose `minimal`, `web`, `backend`, `research`, `full`, or `custom`.
-* **ECC-first** — `setup` runs or attempts Everything Claude Code setup automatically.
+* **Explicit pipeline** — choose ECC (default) or the upstream global gstack installer.
 * **Migrate safely** — audit, cleanup, doctor, and `setup --migrate` are built in.
 
 ## Install
@@ -44,8 +44,11 @@ npx repo-pattern setup
 Scriptable setup:
 
 ```bash
-npx repo-pattern setup --profile web --yes
+npx repo-pattern setup --profile web --setup-pipeline ecc --yes
+npx repo-pattern setup --profile web --setup-pipeline gstack --yes
 ```
+
+ECC remains the default. gstack setup uses its upstream global checkout at `~/.claude/skills/gstack` and requires Git and Bun v1.0+. On Windows, it also requires Node.js and Git Bash or WSL.
 
 Migrate an existing project:
 
@@ -73,7 +76,8 @@ Common options:
 ```bash
 --target /path/to/project  # default: current directory
 --profile web              # default MCP profile
---with-rules               # opt in to .claude/rules/ecc
+--setup-pipeline ecc        # ecc (default) or gstack
+--with-rules               # opt in to .claude/rules/ecc; ECC only
 --with-skill ui-ux-pro-max # optional UI/UX skill; requires Python 3.x
 --with-skills nextjs-pattern,fastapi-pattern # optional framework pattern skills
 --migrate                  # take over legacy/local Claude runtime surfaces
@@ -128,6 +132,7 @@ target-project/
 | Name | Integrated as | Source | License |
 |----|----|----|----|
 | `karpathy-guidelines` | Built-in `.claude/CLAUDE.md` guidance | https://github.com/multica-ai/andrej-karpathy-skills | MIT |
+| `gstack` | Global setup pipeline via `--setup-pipeline gstack` | https://github.com/garrytan/gstack | MIT |
 | `taste` | Optional Claude Code plugin via `--with-skill taste` | https://github.com/Leonxlnx/taste-skill/ | MIT |
 | `document-specialist` | Optional `.claude/skills/` install via `--with-skill document-specialist` | https://github.com/SpillwaveSolutions/document-specialist-skill/ | NOASSERTION — no upstream license declared during review on 2026-07-06 |
 | `ui-ux-pro-max` | Optional Claude Code plugin via `--with-skill ui-ux-pro-max` | https://github.com/nextlevelbuilder/ui-ux-pro-max-skill/ | MIT |

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -10,6 +10,15 @@ Copyright (c) 2026 Affaan Mustafa
 
 repo-pattern does not vendor ECC skills, commands, hooks, scripts, or runtime surfaces by default.
 
+## gstack
+
+repo-pattern can run gstack's upstream global setup when explicitly selected with `--setup-pipeline gstack`.
+
+Source: https://github.com/garrytan/gstack
+License: MIT
+
+repo-pattern does not vendor gstack. The upstream installer manages its checkout, build output, skills, and runtime state.
+
 ## Karpathy-inspired guidelines
 
 repo-pattern includes Claude Code behavioral guidelines from `multica-ai/andrej-karpathy-skills` in `.claude/CLAUDE.md`.

--- a/docs/repo-pattern/setup-guide.md
+++ b/docs/repo-pattern/setup-guide.md
@@ -11,14 +11,17 @@ Use `setup` when you want an arrow-key UI for profile choice, optional ECC rules
 Use scriptable `setup --yes` when you already know the exact options:
 
 ```bash
-node scripts/repo-pattern.mjs setup --target /path/to/project --profile web --yes
+node scripts/repo-pattern.mjs setup --target /path/to/project --profile web --setup-pipeline ecc --yes
+node scripts/repo-pattern.mjs setup --target /path/to/project --profile web --setup-pipeline gstack --yes
 ```
+
+ECC is the default. gstack uses its upstream global installer at `~/.claude/skills/gstack` and requires Git and Bun v1.0+. On Windows, it also requires Node.js and Git Bash or WSL.
 
 Use this when you want to initialize a new project with:
 
 ```text
 minimal Claude Code setup
-+ ECC setup flow
++ selected ECC or gstack setup flow
 + MCP profile
 + generated .mcp.json
 + repo-pattern metadata
@@ -119,8 +122,8 @@ For non-interactive scripts, use `setup --yes`.
 12. Create `.repo-pattern/.gitignore` with `*`.
 13. Add generated setup files and basic OS/IDE noise to `.gitignore`.
 14. Write `.repo-pattern/.repo-pattern.lock.json` without credential values.
-15. Run or attempt ECC setup flow.
-16. During `setup` with rules enabled, apply ECC rules.
+15. Run the selected setup pipeline: ECC setup after generation, or the global gstack installer after target preflight succeeds.
+16. During ECC `setup` with rules enabled, apply ECC rules.
 17. Run doctor.
 ```
 
@@ -496,6 +499,7 @@ Behavior:
 EMPTY/PARTIAL       → recommends setup
 LEGACY_VENDOR       → recommends migrate and requires confirmation
 ECC_NATIVE_MINIMAL  → offers doctor, MCP regeneration, or exit
+GSTACK_MINIMAL      → offers doctor, MCP regeneration, or exit
 ```
 
 Interactive mode uses ↑/↓ to move, Space to toggle MCP/rules choices, Enter to confirm. It writes `.claude/settings.local.json` and adds that path to the target `.gitignore`. Use `setup --yes` for CI/scripts.
@@ -517,8 +521,8 @@ It performs:
 ```text
 minimal Claude setup
 MCP generation
-ECC setup flow
-optional ECC rules sync
+selected ECC or gstack setup flow
+optional ECC rules sync for ECC
 doctor check
 ```
 
@@ -540,6 +544,7 @@ Possible states:
 EMPTY
 PARTIAL
 ECC_NATIVE_MINIMAL
+GSTACK_MINIMAL
 LEGACY_VENDOR
 ```
 
@@ -578,7 +583,7 @@ unmanaged local Claude runtime surfaces are absent
 settings hooks are empty
 .mcp.json has no hardcoded machine path
 .repo-pattern/.repo-pattern.json is valid
-ECC setup status is recorded
+the selected ECC or gstack setup status is recorded
 ```
 
 Run this after setup or after changing MCP profiles.

--- a/scripts/lib/audit.mjs
+++ b/scripts/lib/audit.mjs
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { exists, isTracked, readJson, readRepoConfig } from "./fs-utils.mjs";
+import { exists, isTracked, readJson, readRepoConfig, readRepoLock } from "./fs-utils.mjs";
 import { printBox, style } from "./prompt.mjs";
 import { expectedOptionalSkillDirs } from "./skills.mjs";
 
@@ -40,6 +40,7 @@ async function listDirNames(dir) {
 export async function auditProject(target) {
   const settings = await readJson(path.join(target, ".claude", "settings.json"), {});
   const repoPattern = await readRepoConfig(target, null);
+  const lock = await readRepoLock(target, {});
 
   const actualSkillDirs = await listDirNames(path.join(target, ".claude", "skills"));
   const expectedSkillDirs = expectedOptionalSkillDirs(repoPattern?.optionalSkills || []);
@@ -82,17 +83,19 @@ export async function auditProject(target) {
     result.hasClaudeCommandsDir ||
     result.hasClaudeHooksDir ||
     result.hasClaudeScriptsDir ||
-    (result.hasClaudeRulesDir && !result.hasOnlyEccRulesDir)
+    (result.hasClaudeRulesDir && (repoPattern?.workflow === "gstack" || !result.hasOnlyEccRulesDir))
   );
 
+  const setupComplete = repoPattern?.workflow !== "gstack" || lock.gstack?.status === "installed";
   if (!result.hasClaudeDir && !result.hasMcpJson && !result.hasRepoPatternJson) {
     result.state = "EMPTY";
   } else if (
     result.hasRepoPatternJson &&
-    result.repoPattern?.workflow === "ecc-native" &&
+    ["ecc-native", "gstack"].includes(result.repoPattern?.workflow) &&
+    setupComplete &&
     !legacy
   ) {
-    result.state = "ECC_NATIVE_MINIMAL";
+    result.state = result.repoPattern.workflow === "gstack" ? "GSTACK_MINIMAL" : "ECC_NATIVE_MINIMAL";
   } else if (legacy) {
     result.state = "LEGACY_VENDOR";
   } else {
@@ -121,7 +124,8 @@ export function printAudit(audit) {
     [audit.hasClaudeCommandsDir, ".claude/commands present"],
     [audit.hasClaudeHooksDir, ".claude/hooks present"],
     [audit.hasClaudeScriptsDir, ".claude/scripts present"],
-    [audit.hasClaudeRulesDir && !audit.hasOnlyEccRulesDir, "non-ECC .claude/rules present"]
+    [audit.hasClaudeRulesDir && audit.repoPattern?.workflow === "gstack", ".claude/rules is incompatible with gstack"],
+    [audit.hasClaudeRulesDir && audit.repoPattern?.workflow !== "gstack" && !audit.hasOnlyEccRulesDir, "non-ECC .claude/rules present"]
   ].filter(([bad]) => bad);
 
   if (issues.length > 0) {

--- a/scripts/lib/doctor.mjs
+++ b/scripts/lib/doctor.mjs
@@ -33,7 +33,7 @@ export async function doctorProject(target, { updateLock = false, dryRun = false
   check(!audit.hasClaudeCommandsDir, ".claude/commands does not exist");
   check(!audit.hasClaudeHooksDir, ".claude/hooks does not exist");
   check(!audit.hasClaudeScriptsDir, ".claude/scripts does not exist");
-  check(!audit.hasClaudeRulesDir || audit.hasOnlyEccRulesDir, "no non-ECC .claude/rules");
+  check(!audit.hasClaudeRulesDir || (audit.repoPattern?.workflow !== "gstack" && audit.hasOnlyEccRulesDir), audit.repoPattern?.workflow === "gstack" ? ".claude/rules does not exist for gstack" : "no non-ECC .claude/rules");
   check(audit.hasClaudeDir, ".claude exists");
   check(!audit.hasSettingsHooks, ".claude/settings.json hooks is {}");
   check(!isTracked(target, ".claude/settings.json"), ".claude/settings.json is not tracked");
@@ -44,7 +44,8 @@ export async function doctorProject(target, { updateLock = false, dryRun = false
   check(audit.hasRepoPatternJson, ".repo-pattern/.repo-pattern.json exists");
 
   const repoPattern = audit.repoPattern || {};
-  check(repoPattern.workflow === "ecc-native", ".repo-pattern/.repo-pattern.json workflow=ecc-native");
+  const setupPipeline = repoPattern.workflow === "gstack" ? "gstack" : "ecc";
+  check(["ecc-native", "gstack"].includes(repoPattern.workflow), ".repo-pattern/.repo-pattern.json workflow is ecc-native or gstack");
   check(repoPattern.runtime?.localSkills === false || managedSkills, ".repo-pattern/.repo-pattern.json runtime.localSkills=false unless optional skills are managed");
   if (managedSkills) check(audit.hasClaudeSkillsDir, ".claude/skills exists for managed optional skills");
   check(repoPattern.runtime?.localCommands === false, ".repo-pattern/.repo-pattern.json runtime.localCommands=false");
@@ -70,8 +71,9 @@ export async function doctorProject(target, { updateLock = false, dryRun = false
     check(audit.hasClaudeEccRulesDir && existingRules.size > 0, ".claude/rules/ecc contains synced ECC rule pack directories");
     check(appliedRules.every((rule) => existingRules.has(rule)), "all locked ECC rule packs exist under .claude/rules/ecc");
   }
-  infoRows.push(`ECC setup status: ${lock.ecc?.status || "unknown"}`);
-  if (lock.ecc?.status === "manual-plugin-install-required") {
+  if (setupPipeline === "gstack") check(lock.gstack?.status === "installed", ".repo-pattern/.repo-pattern.lock.json gstack.status=installed");
+  infoRows.push(`${setupPipeline === "gstack" ? "gstack" : "ECC"} setup status: ${lock[setupPipeline]?.status || "unknown"}`);
+  if (setupPipeline === "ecc" && lock.ecc?.status === "manual-plugin-install-required") {
     infoRows.push("Open Claude Code and run:");
     infoRows.push("/plugin marketplace add https://github.com/affaan-m/ECC");
     infoRows.push("/plugin install ecc@ecc");

--- a/scripts/lib/gstack.mjs
+++ b/scripts/lib/gstack.mjs
@@ -1,0 +1,70 @@
+import { execFileSync, execSync } from "node:child_process";
+import os from "node:os";
+import path from "node:path";
+import { appendGitignoreLine, ensureDir, exists, isTracked, writePrivateJson } from "./fs-utils.mjs";
+import { printSummary } from "./prompt.mjs";
+
+const GSTACK_REPOSITORY = "https://github.com/garrytan/gstack.git";
+const GSTACK_DIR = path.join(os.homedir(), ".claude", "skills", "gstack");
+
+function withoutEccPlugin(settings = {}) {
+  const enabledPlugins = { ...(settings.enabledPlugins || {}) };
+  const extraKnownMarketplaces = { ...(settings.extraKnownMarketplaces || {}) };
+  delete enabledPlugins["ecc@ecc"];
+  delete extraKnownMarketplaces.ecc;
+  return { ...settings, enabledPlugins, extraKnownMarketplaces };
+}
+
+function validateGstackCheckout() {
+  if (!exists(GSTACK_DIR)) return false;
+  if (!exists(path.join(GSTACK_DIR, "setup"))) throw new Error(`Existing gstack checkout is invalid: ${GSTACK_DIR}/setup is missing.`);
+  try {
+    execFileSync("git", ["-C", GSTACK_DIR, "rev-parse", "--is-inside-work-tree"], { stdio: "ignore" });
+  } catch {
+    throw new Error(`Existing gstack checkout is invalid: ${GSTACK_DIR} is not a Git worktree.`);
+  }
+  return true;
+}
+
+export async function removeEccPluginSettings({ target, dryRun = false }) {
+  if (isTracked(target, ".claude/settings.local.json")) throw new Error(".claude/settings.local.json is tracked. Untrack it before writing local plugin settings.");
+  await writePrivateJson(path.join(target, ".claude", "settings.local.json"), withoutEccPlugin, {
+    dryRun,
+    label: ".claude/settings.local.json",
+    parentLabel: ".claude"
+  });
+  await appendGitignoreLine(target, ".claude/", { dryRun });
+}
+
+export async function setupGstack({ target, dryRun = false }) {
+  if (isTracked(target, ".claude/settings.local.json")) throw new Error(".claude/settings.local.json is tracked. Untrack it before writing local plugin settings.");
+
+  let status = "installed";
+  if (process.env.REPO_PATTERN_GSTACK_SETUP_CMD) {
+    printSummary("gstack", [["Status", "using REPO_PATTERN_GSTACK_SETUP_CMD"]]);
+    if (dryRun) {
+      console.log(`[dry-run] REPO_PATTERN_TARGET=${target} ${process.env.REPO_PATTERN_GSTACK_SETUP_CMD}`);
+      status = "dry-run";
+    } else {
+      execSync(process.env.REPO_PATTERN_GSTACK_SETUP_CMD, {
+        cwd: target,
+        stdio: "inherit",
+        env: { ...process.env, REPO_PATTERN_TARGET: target },
+        shell: true
+      });
+    }
+  } else if (dryRun) {
+    if (!exists(GSTACK_DIR)) console.log(`[dry-run] git clone --single-branch --depth 1 ${GSTACK_REPOSITORY} ${GSTACK_DIR}`);
+    console.log(`[dry-run] cd ${GSTACK_DIR} && ./setup`);
+    status = "dry-run";
+  } else {
+    if (!validateGstackCheckout()) {
+      await ensureDir(path.dirname(GSTACK_DIR));
+      execFileSync("git", ["clone", "--single-branch", "--depth", "1", GSTACK_REPOSITORY, GSTACK_DIR], { stdio: "inherit" });
+    }
+    execFileSync(process.platform === "win32" ? "bash" : "./setup", process.platform === "win32" ? ["./setup"] : [], { cwd: GSTACK_DIR, stdio: "inherit" });
+    printSummary("gstack", [["Status", "installed for Claude Code"]]);
+  }
+
+  return status;
+}

--- a/scripts/lib/provision.mjs
+++ b/scripts/lib/provision.mjs
@@ -4,6 +4,7 @@ import { auditProject, printAudit } from "./audit.mjs";
 import { cleanupProject } from "./cleanup.mjs";
 import { generateMcp, withoutPersistedMcpValues } from "./mcp.mjs";
 import { setupEcc } from "./ecc.mjs";
+import { removeEccPluginSettings, setupGstack } from "./gstack.mjs";
 import { doctorProject } from "./doctor.mjs";
 import { applyEccRules } from "./rules.mjs";
 import { appendGitignoreLine, backupPaths, copyRecursive, ensureDir, ensureRepoPatternGitignore, isTracked, readJson, removePath, repoConfigPath, repoLockPath, writeJson, writeIfMissing, writePrivateJson } from "./fs-utils.mjs";
@@ -17,10 +18,13 @@ function shellQuote(value) {
   return `'${String(value).replaceAll("'", `'"'"'`)}'`;
 }
 
-async function repoPatternConfig(sourceRoot, profile) {
+async function repoPatternConfig(sourceRoot, profile, setupPipeline) {
   const template = await readJson(path.join(sourceRoot, ".repo-pattern.example.json"), {});
+  const { ecc, ...base } = template;
   return {
-    ...template,
+    ...base,
+    workflow: setupPipeline === "gstack" ? "gstack" : "ecc-native",
+    ...(setupPipeline === "ecc" ? { ecc } : {}),
     mode: "target",
     mcp: {
       ...(template.mcp || {}),
@@ -30,25 +34,35 @@ async function repoPatternConfig(sourceRoot, profile) {
   };
 }
 
-function lockConfig(profile) {
+function lockConfig(profile, setupPipeline, pipelineStatus = "not-run") {
   return {
     repoPattern: {
       version: "2.0.0",
       lastProvisionRun: new Date().toISOString(),
       lastDoctorRun: null
     },
-    ecc: {
-      installMode: "plugin",
-      status: "not-run",
-      rulesSyncedBy: null,
-      rulesScope: "project",
-      recommendedRules: [],
-      appliedRules: [],
-      detectedStack: null,
-      rulesAppliedAt: null,
-      hooks: "plugin-managed",
-      syncedAt: null
-    },
+    setupPipeline,
+    ...(setupPipeline === "ecc" ? {
+      ecc: {
+        installMode: "plugin",
+        status: pipelineStatus,
+        rulesSyncedBy: null,
+        rulesScope: "project",
+        recommendedRules: [],
+        appliedRules: [],
+        detectedStack: null,
+        rulesAppliedAt: null,
+        hooks: "plugin-managed",
+        syncedAt: pipelineStatus === "installed" ? new Date().toISOString() : null
+      }
+    } : {
+      gstack: {
+        installMode: "global",
+        source: "https://github.com/garrytan/gstack.git",
+        status: pipelineStatus,
+        syncedAt: pipelineStatus === "installed" ? new Date().toISOString() : null
+      }
+    }),
     mcp: {
       profile,
       generatedAt: null
@@ -145,7 +159,8 @@ async function writeLocalSettings({ sourceRoot, target, localSettingsEnv, dryRun
   await appendGitignoreLine(target, ".claude/", { dryRun });
 }
 
-export async function provisionProject({ sourceRoot, target, profile = "web", mcpServers = null, mcpValues = {}, dryRun = false, force = false, migrate = false, localSettingsEnv = null, attributionConfig = { mode: "off" }, permissionConfig = { bypass: "deny" }, ruleMode = "auto", rules = null, applyRules = false, optionalSkills = [] }) {
+export async function provisionProject({ sourceRoot, target, profile = "web", setupPipeline = "ecc", mcpServers = null, mcpValues = {}, dryRun = false, force = false, migrate = false, localSettingsEnv = null, attributionConfig = { mode: "off" }, permissionConfig = { bypass: "deny" }, ruleMode = "auto", rules = null, applyRules = false, optionalSkills = [] }) {
+  if (!["ecc", "gstack"].includes(setupPipeline)) throw new Error(`Unknown setup pipeline: ${setupPipeline}. Available: ecc, gstack`);
   printSummary("Provisioning target", [["Target", target]]);
   await rejectClaudeSymlink(target, { dryRun });
   const audit = await auditProject(target);
@@ -154,6 +169,10 @@ export async function provisionProject({ sourceRoot, target, profile = "web", mc
   if (audit.state === "LEGACY_VENDOR" && !migrate) {
     throw new Error("Target has legacy/local Claude runtime surfaces. Re-run setup with --migrate, not --force.");
   }
+  if (isTracked(target, ".claude/settings.json")) throw new Error(".claude/settings.json is tracked. Untrack it before writing Claude Code settings.");
+  if (isTracked(target, ".repo-pattern/.repo-pattern.lock.json") || isTracked(target, ".repo-pattern.lock.json")) throw new Error("repo-pattern lock is tracked. Untrack it before writing local setup state.");
+
+  const gstackStatus = setupPipeline === "gstack" ? await setupGstack({ target, dryRun }) : null;
 
   if (audit.state === "LEGACY_VENDOR") {
     await cleanupProject({ sourceRoot, target, dryRun });
@@ -161,7 +180,6 @@ export async function provisionProject({ sourceRoot, target, profile = "web", mc
     await backupPaths(target, ["CLAUDE.md", ".claude/CLAUDE.md", ".claude/settings.json", ".claude/rules", ".claude/skills", ".claude/commands", ".claude/hooks", ".claude/scripts", ".repo-pattern.json", ".repo-pattern.lock.json"], { dryRun });
   }
 
-  if (isTracked(target, ".claude/settings.json")) throw new Error(".claude/settings.json is tracked. Untrack it before writing Claude Code settings.");
   await ensureDir(path.join(target, ".claude"), { dryRun });
 
   // Target CLAUDE.md is created empty when missing so project-specific instructions can be added later. Existing target CLAUDE.md is preserved.
@@ -177,18 +195,22 @@ export async function provisionProject({ sourceRoot, target, profile = "web", mc
   await writeClaudeSettings({ sourceRoot, target, attributionConfig, permissionConfig, dryRun });
   await appendGitignoreLine(target, ".claude/", { dryRun });
 
-  await writeLocalSettings({ sourceRoot, target, localSettingsEnv, dryRun });
+  if (setupPipeline === "ecc") await writeLocalSettings({ sourceRoot, target, localSettingsEnv, dryRun });
 
   await ensureRepoPatternGitignore(target, { dryRun });
-  await writeJson(repoConfigPath(target), await repoPatternConfig(sourceRoot, profile), { dryRun });
   const lockPath = repoLockPath(target);
-  if (isTracked(target, ".repo-pattern/.repo-pattern.lock.json") || isTracked(target, ".repo-pattern.lock.json")) throw new Error("repo-pattern lock is tracked. Untrack it before writing local setup state.");
-  await writeJson(lockPath, lockConfig(profile), { dryRun });
-  await ensureRepoPatternGitignore(target, { dryRun });
 
   const mcpResult = await generateMcp({ sourceRoot, target, profile, mcpServers, mcpValues, dryRun });
-  const eccStatus = await setupEcc({ sourceRoot, target, dryRun });
-  if (applyRules) await applyEccRules({ target, dryRun, ruleMode, rules });
+  const pipelineStatus = gstackStatus || await setupEcc({ sourceRoot, target, dryRun });
+  if (setupPipeline === "gstack") {
+    await writeLocalSettings({ sourceRoot, target, localSettingsEnv, dryRun });
+    await removeEccPluginSettings({ target, dryRun });
+    await removePath(path.join(target, ".claude", "rules"), { dryRun });
+  }
+  await writeJson(repoConfigPath(target), await repoPatternConfig(sourceRoot, profile, setupPipeline), { dryRun });
+  await writeJson(lockPath, lockConfig(profile, setupPipeline, pipelineStatus), { dryRun });
+  await ensureRepoPatternGitignore(target, { dryRun });
+  if (setupPipeline === "ecc" && applyRules) await applyEccRules({ target, dryRun, ruleMode, rules });
   if (optionalSkills.length > 0) await applyOptionalSkills({ target, skills: optionalSkills, dryRun });
 
   if (dryRun) {
@@ -198,7 +220,7 @@ export async function provisionProject({ sourceRoot, target, profile = "web", mc
   }
 
   const pending = [
-    ...(eccStatus === "manual-plugin-install-required" ? ["ECC plugin"] : []),
+    ...(pipelineStatus === "manual-plugin-install-required" ? ["ECC plugin"] : []),
     ...(mcpResult.missingValues.length > 0 ? ["MCP values"] : [])
   ];
   const pendingText = pending.length ? `${pending.join(", ")} pending` : style("success", "ready");
@@ -210,6 +232,7 @@ export async function provisionProject({ sourceRoot, target, profile = "web", mc
   printSummary("Setup complete", [
     ["Status", dryRun ? `preview only; ${pendingText}` : pendingText],
     ["Target", target],
+    ["Setup pipeline", setupPipeline],
     ["Profile", profile],
     [dryRun ? "Would write" : "Written", `CLAUDE.md (if missing), .claude/, .mcp.json, .repo-pattern/.repo-pattern.json, .repo-pattern/.repo-pattern.lock.json${optionalSkills.length ? ", optional skill/plugin config" : ""}`],
     ["Doctor", dryRun ? "skipped (dry-run)" : style("success", "passed")],

--- a/scripts/lib/setup.mjs
+++ b/scripts/lib/setup.mjs
@@ -58,9 +58,10 @@ function safeRetryLocalSettingsEnv(localSettingsEnv = {}) {
   return Object.fromEntries(Object.entries(localSettingsEnv).filter(([name]) => !RETRY_SECRET_LOCAL_SETTINGS.has(name)));
 }
 
-export function setupRetryOptions({ action, mcpConfig, mcpValues = {}, ruleConfig, optionalSkills, localSettingsEnv, attributionConfig, permissionConfig = { bypass: "deny" }, dryRun }) {
+export function setupRetryOptions({ action, setupPipeline, mcpConfig, mcpValues = {}, ruleConfig, optionalSkills, localSettingsEnv, attributionConfig, permissionConfig = { bypass: "deny" }, dryRun }) {
   return {
     action,
+    setupPipeline,
     profile: mcpConfig.profile,
     mcpServers: mcpConfig.mcpServers,
     mcpValueNames: Object.keys(persistedMcpValues(mcpValues)),
@@ -109,6 +110,7 @@ function retryRows(setup) {
     ["Status", setup.status],
     ["Failed step", setup.failedStep || "unknown"],
     ["Error", setup.error || "unknown"],
+    ["Setup pipeline", options.setupPipeline || "ecc"],
     ["Profile", options.profile || "web"],
     ["MCP servers", options.mcpServers?.join(", ") || "from profile"],
     ["MCP values", options.mcpValueNames?.length ? options.mcpValueNames.join(", ") : "none"],
@@ -181,7 +183,19 @@ async function chooseMcpValues(sourceRoot, mcpConfig, values = {}) {
   return collectMcpValues(mcpServers, { values: persistedMcpValues(values) });
 }
 
-async function chooseRuleConfig(detection) {
+async function chooseSetupPipeline(initialValue = "ecc") {
+  return selectOne({
+    message: "Choose setup pipeline",
+    options: [
+      { value: "ecc", label: "ECC", description: "Claude Code plugin with optional project rules" },
+      { value: "gstack", label: "gstack", description: "global skills install; requires Git and Bun" }
+    ],
+    initialValue
+  });
+}
+
+async function chooseRuleConfig(detection, setupPipeline) {
+  if (setupPipeline === "gstack") return { applyRules: false, ruleMode: "auto", rules: [] };
   const autoRules = selectEccRules(detection);
   const ruleMode = await selectOne({
     message: "Step 2/6 — Choose ECC rule detection mode",
@@ -268,10 +282,11 @@ function attributionSummary(attributionConfig) {
   return "off (commit: \"\")";
 }
 
-async function confirmSummary({ action, target, mcpConfig, mcpValues, ruleConfig, optionalSkills, localSettingsEnv, attributionConfig, permissionConfig, dryRun }) {
+async function confirmSummary({ action, setupPipeline, target, mcpConfig, mcpValues, ruleConfig, optionalSkills, localSettingsEnv, attributionConfig, permissionConfig, dryRun }) {
   const hasLocalSkill = optionalSkills.some((name) => !OPTIONAL_SKILLS.find((skill) => skill.value === name)?.plugin);
   printSummary("Setup summary", [
     ["Action", action],
+    ["Setup pipeline", setupPipeline],
     ["Target", target],
     ["Profile", mcpConfig.profile],
     ["MCP servers", mcpConfig.mcpServers?.join(", ") || "from profile"],
@@ -304,7 +319,7 @@ async function confirmSummary({ action, target, mcpConfig, mcpValues, ruleConfig
 }
 
 async function handleInitialized({ sourceRoot, target, profile, dryRun }) {
-  printBox("Already initialized", ["This target already looks like repo-pattern ECC-native setup."]);
+  printBox("Already initialized", ["This target already looks like a repo-pattern setup."]);
 
   const action = await selectOne({
     message: "What do you want to do?",
@@ -349,18 +364,20 @@ async function handleInitialized({ sourceRoot, target, profile, dryRun }) {
   }
 }
 
-export async function setupProject({ sourceRoot, target, profile = "web", dryRun = false, force = false, migrate = false, yes = false, applyRules = false, optionalSkills = [] }) {
+export async function setupProject({ sourceRoot, target, profile = "web", setupPipeline = "ecc", dryRun = false, force = false, migrate = false, yes = false, applyRules = false, optionalSkills = [] }) {
+  if (!["ecc", "gstack"].includes(setupPipeline)) throw new Error(`Unknown setup pipeline: ${setupPipeline}. Available: ecc, gstack`);
   if (!isInteractive()) {
     if (!yes) throw new Error("setup requires an interactive terminal, or pass --yes for scriptable mode.");
     if (profile === "custom") throw new Error("setup --yes cannot use the custom profile; choose a named profile.");
 
     const audit = await auditProject(target);
-    if (audit.state === "ECC_NATIVE_MINIMAL" && !force && optionalSkills.length === 0) {
+    const expectedState = setupPipeline === "gstack" ? "GSTACK_MINIMAL" : "ECC_NATIVE_MINIMAL";
+    if (audit.state === expectedState && !force && optionalSkills.length === 0) {
       await doctorProject(target, { dryRun });
       return;
     }
 
-    if (audit.state === "ECC_NATIVE_MINIMAL" && optionalSkills.length > 0) {
+    if (audit.state === expectedState && optionalSkills.length > 0) {
       await applyOptionalSkills({ target, skills: optionalSkills, dryRun });
       if (!dryRun) await doctorProject(target, { updateLock: true, dryRun });
       return;
@@ -370,6 +387,7 @@ export async function setupProject({ sourceRoot, target, profile = "web", dryRun
       sourceRoot,
       target,
       profile,
+      setupPipeline,
       mcpValues: await readGeneratedMcpValues(target),
       dryRun,
       force,
@@ -385,13 +403,14 @@ export async function setupProject({ sourceRoot, target, profile = "web", dryRun
 
   const previousOptions = await choosePreviousSetupOptions(target);
   const detection = await detectProject(target);
+  const selectedSetupPipeline = previousOptions?.setupPipeline || await chooseSetupPipeline(setupPipeline);
   const chosenProfile = previousOptions?.profile || await chooseProfile(sourceRoot, profile, detection);
   const mcpConfig = previousOptions
     ? { profile: previousOptions.profile, mcpServers: previousOptions.mcpServers }
     : await chooseMcpConfig(sourceRoot, chosenProfile);
-  const ruleConfig = previousOptions
+  const ruleConfig = previousOptions && selectedSetupPipeline === "ecc"
     ? { applyRules: previousOptions.applyRules, ruleMode: previousOptions.ruleMode, rules: previousOptions.rules }
-    : await chooseRuleConfig(detection);
+    : await chooseRuleConfig(detection, selectedSetupPipeline);
   const selectedOptionalSkills = previousOptions?.optionalSkills || await chooseOptionalSkills(optionalSkills);
 
   const audit = await auditProject(target);
@@ -401,7 +420,8 @@ export async function setupProject({ sourceRoot, target, profile = "web", dryRun
     throw new Error("Target has legacy/local Claude runtime surfaces. Re-run setup with --migrate, not --force.");
   }
 
-  if (audit.state === "ECC_NATIVE_MINIMAL") {
+  const expectedState = selectedSetupPipeline === "gstack" ? "GSTACK_MINIMAL" : "ECC_NATIVE_MINIMAL";
+  if (audit.state === expectedState) {
     if (selectedOptionalSkills.length > 0) {
       await applyOptionalSkills({ target, skills: selectedOptionalSkills, dryRun });
       if (!dryRun) await doctorProject(target, { updateLock: true, dryRun });
@@ -428,17 +448,18 @@ export async function setupProject({ sourceRoot, target, profile = "web", dryRun
   const permissionConfig = previousOptions?.permissionConfig || await choosePermissionConfig();
   const attributionConfig = previousOptions?.attributionConfig || await chooseAttributionConfig();
 
-  if (!await confirmSummary({ action, target, mcpConfig, mcpValues, ruleConfig, optionalSkills: selectedOptionalSkills, localSettingsEnv, attributionConfig, permissionConfig, dryRun })) {
+  if (!await confirmSummary({ action, setupPipeline: selectedSetupPipeline, target, mcpConfig, mcpValues, ruleConfig, optionalSkills: selectedOptionalSkills, localSettingsEnv, attributionConfig, permissionConfig, dryRun })) {
     throw new Error("Setup cancelled.");
   }
 
-  const retryOptions = setupRetryOptions({ action, mcpConfig, mcpValues, ruleConfig, optionalSkills: selectedOptionalSkills, localSettingsEnv, attributionConfig, permissionConfig, dryRun });
+  const retryOptions = setupRetryOptions({ action, setupPipeline: selectedSetupPipeline, mcpConfig, mcpValues, ruleConfig, optionalSkills: selectedOptionalSkills, localSettingsEnv, attributionConfig, permissionConfig, dryRun });
   await writeSetupStatus(target, { status: "running", startedAt: new Date().toISOString(), failedStep: null, error: null, options: retryOptions }, { dryRun });
   try {
     await provisionProject({
       sourceRoot,
       target,
       profile: mcpConfig.profile,
+      setupPipeline: selectedSetupPipeline,
       mcpServers: mcpConfig.mcpServers,
       mcpValues,
       dryRun,

--- a/scripts/repo-pattern.mjs
+++ b/scripts/repo-pattern.mjs
@@ -14,6 +14,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const sourceRoot = path.resolve(__dirname, "..");
 const optionalSkillNames = OPTIONAL_SKILLS.map((skill) => skill.value).join(", ");
+const setupPipelineNames = ["ecc", "gstack"];
 
 function requiredOptionValue(rest, index, arg) {
   const value = rest[index + 1];
@@ -34,6 +35,7 @@ function parseArgs(argv) {
     command: command || "help",
     target: ".",
     profile: "web",
+    setupPipeline: "ecc",
     dryRun: false,
     force: false,
     migrate: false,
@@ -46,6 +48,7 @@ function parseArgs(argv) {
     const arg = rest[i];
     if (arg === "--target") options.target = requiredOptionValue(rest, i++, arg);
     else if (arg === "--profile") options.profile = requiredOptionValue(rest, i++, arg);
+    else if (arg === "--setup-pipeline") options.setupPipeline = requiredOptionValue(rest, i++, arg);
     else if (arg === "--dry-run") options.dryRun = true;
     else if (arg === "--force") options.force = true;
     else if (arg === "--migrate") options.migrate = true;
@@ -65,9 +68,19 @@ function parseArgs(argv) {
     process.exit(2);
   }
 
+  if (!setupPipelineNames.includes(options.setupPipeline)) {
+    console.error(`Unknown setup pipeline: ${options.setupPipeline}. Available: ${setupPipelineNames.join(", ")}`);
+    process.exit(2);
+  }
+
   const invalidSkills = invalidOptionalSkills(options.optionalSkills);
   if (invalidSkills.length > 0) {
     console.error(`Unknown optional skill(s): ${invalidSkills.join(", ")}. Available: ${optionalSkillNames}`);
+    process.exit(2);
+  }
+
+  if (options.setupPipeline === "gstack" && options.applyRules) {
+    console.error("--with-rules requires --setup-pipeline ecc.");
     process.exit(2);
   }
 
@@ -76,12 +89,13 @@ function parseArgs(argv) {
 }
 
 function help() {
-  console.log(`repo-pattern — minimal ECC-first Claude Code setup
+  console.log(`repo-pattern — minimal Claude Code setup
 
 Usage:
   repo-pattern help
   repo-pattern setup
-  repo-pattern setup --profile web --yes
+  repo-pattern setup --profile web --setup-pipeline ecc --yes
+  repo-pattern setup --profile web --setup-pipeline gstack --yes
   repo-pattern setup --profile web --migrate --yes
   repo-pattern setup --with-skill taste --yes
   repo-pattern setup --with-skill ui-ux-pro-max --yes  # requires Python 3.x
@@ -97,8 +111,9 @@ Advanced:
   repo-pattern cleanup
 
 Options:
-  --target <path>   Target project path. Default: .
-  --profile <name>  MCP profile for scriptable commands. Default: web
+  --target <path>                  Target project path. Default: .
+  --profile <name>                 MCP profile for scriptable commands. Default: web
+  --setup-pipeline <ecc|gstack>    Setup pipeline. Default: ecc
 
 Setup UI:
   setup uses ↑/↓ to move, Space to toggle MCP/rules choices, Enter to confirm, Esc/Ctrl+C to cancel

--- a/scripts/self-check.mjs
+++ b/scripts/self-check.mjs
@@ -8,11 +8,12 @@ import { auditProject, printAudit } from "./lib/audit.mjs";
 import { cleanupProject } from "./lib/cleanup.mjs";
 import { doctorProject } from "./lib/doctor.mjs";
 import { applyEccPluginSettings, setupEcc } from "./lib/ecc.mjs";
+import { removeEccPluginSettings, setupGstack } from "./lib/gstack.mjs";
 import { applyMcpValues, generateMcp, mcpSecretPrompt, persistedMcpValues, readGeneratedMcpValues, validateRelativeMcpPath } from "./lib/mcp.mjs";
 import { applyAttributionSetting, applyLocalSettings, applyPermissionSettings, provisionProject, updateClaudePermissions } from "./lib/provision.mjs";
 import { writePrivateJson } from "./lib/fs-utils.mjs";
 import { printSummary, renderLogo, style } from "./lib/prompt.mjs";
-import { needsLocalSettingsPrompt, setupRetryOptions } from "./lib/setup.mjs";
+import { needsLocalSettingsPrompt, setupProject, setupRetryOptions } from "./lib/setup.mjs";
 import { applyEccRules, formatEccCloneError } from "./lib/rules.mjs";
 import { applyOptionalSkills, applyPluginSkillSettings, expectedOptionalSkillDirs, invalidOptionalSkills, normalizeOptionalSkills, OPTIONAL_SKILLS } from "./lib/skills.mjs";
 
@@ -104,6 +105,7 @@ assert.deepEqual(applyPermissionSettings({ permissions: { defaultMode: "bypassPe
 });
 assert.deepEqual(setupRetryOptions({
   action: "setup",
+  setupPipeline: "gstack",
   mcpConfig: { profile: "web", mcpServers: null },
   mcpValues: {
     CONTEXT7_API_KEY: "secret",
@@ -122,6 +124,7 @@ assert.deepEqual(setupRetryOptions({
   dryRun: false
 }), {
   action: "setup",
+  setupPipeline: "gstack",
   profile: "web",
   mcpServers: null,
   mcpValueNames: ["CONTEXT7_API_KEY"],
@@ -380,6 +383,13 @@ process.stdout.isTTY = false;
 try {
   printAudit({ target: "/tmp/project", state: "EMPTY" });
   printAudit({ target: "/tmp/project", state: "PARTIAL", hasSettingsHooks: true });
+  printAudit({
+    target: "/tmp/project",
+    state: "LEGACY_VENDOR",
+    hasClaudeRulesDir: true,
+    hasOnlyEccRulesDir: true,
+    repoPattern: { workflow: "gstack" }
+  });
 } finally {
   console.log = originalAuditLog;
   process.stdin.isTTY = originalAuditStdinIsTty;
@@ -390,6 +400,7 @@ assert(auditLogs.includes("State   EMPTY"));
 assert(!auditLogs.some((line) => line.includes(".claude present")));
 assert(auditLogs.some((line) => line.includes("⚠ .mcp.json missing")));
 assert(auditLogs.some((line) => line.includes("⚠ .claude/settings.json hooks not empty")));
+assert(auditLogs.some((line) => line.includes("⚠ .claude/rules is incompatible with gstack")));
 
 const logs = [];
 const originalLog = console.log;
@@ -444,8 +455,13 @@ result = runCli(["setup", "--with-skill", "nope"]);
 assert.equal(result.status, 2);
 assert.match(result.stderr, /Unknown optional skill\(s\): nope/);
 
+result = runCli(["setup", "--setup-pipeline", "nope", "--yes"]);
+assert.equal(result.status, 2);
+assert.match(result.stderr, /Unknown setup pipeline: nope\. Available: ecc, gstack/);
+
 result = runCli(["help"]);
 assert.equal(result.status, 0);
+assert.match(result.stdout, /--setup-pipeline <ecc\|gstack>/);
 assert.match(result.stdout, /--with-skill <name>/);
 assert.match(result.stdout, /ui-ux-pro-max/);
 assert.match(result.stdout, /impeccable/);
@@ -491,11 +507,22 @@ try {
   await fs.writeFile(path.join(setupReuseTarget, ".mcp.json"), JSON.stringify({
     mcpServers: { context7: { env: { CONTEXT7_API_KEY: "persisted-setup-key" } } }
   }), "utf8");
-  result = runCli(["setup", "--target", setupReuseTarget, "--profile", "minimal", "--yes"]);
+  result = runCli(["setup", "--target", setupReuseTarget, "--profile", "minimal", "--setup-pipeline", "ecc", "--yes"]);
   assert.equal(result.status, 0, result.stderr);
   assert.match(await fs.readFile(path.join(setupReuseTarget, ".mcp.json"), "utf8"), /persisted-setup-key/);
+  assert.equal(JSON.parse(await fs.readFile(path.join(setupReuseTarget, ".repo-pattern", ".repo-pattern.json"), "utf8")).workflow, "ecc-native");
 } finally {
   await fs.rm(setupReuseTarget, { recursive: true, force: true });
+}
+
+const gstackSetupTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-gstack-setup-"));
+try {
+  result = runCli(["setup", "--target", gstackSetupTarget, "--profile", "minimal", "--setup-pipeline", "gstack", "--yes", "--dry-run"]);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /\.\/setup/);
+  assert.doesNotMatch(result.stdout, /Install ECC inside Claude Code/);
+} finally {
+  await fs.rm(gstackSetupTarget, { recursive: true, force: true });
 }
 
 const privateWriteTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-private-write-"));
@@ -558,6 +585,147 @@ assert(gitignoreLines.includes(".repo-pattern/"));
 assert(!gitignoreLines.includes(".repo-pattern.json"));
 assert(!gitignoreLines.includes(".repo-pattern.lock.json"));
 assert(gitignoreLines.includes(".claude/"));
+
+const failedGstackTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-gstack-failed-"));
+console.log = () => {};
+try {
+  const localSettingsPath = path.join(failedGstackTarget, ".claude", "settings.local.json");
+  await fs.mkdir(path.dirname(localSettingsPath));
+  await fs.writeFile(localSettingsPath, JSON.stringify({
+    env: { ANTHROPIC_AUTH_TOKEN: secretSentinel },
+    enabledPlugins: { "ecc@ecc": true }
+  }), { mode: 0o600 });
+  process.env.REPO_PATTERN_GSTACK_SETUP_CMD = "false";
+  await assert.rejects(() => setupGstack({ target: failedGstackTarget }), /Command failed/);
+  assert.match(await fs.readFile(localSettingsPath, "utf8"), /ecc@ecc/);
+} finally {
+  delete process.env.REPO_PATTERN_GSTACK_SETUP_CMD;
+  console.log = originalLog;
+  await fs.rm(failedGstackTarget, { recursive: true, force: true });
+}
+
+const failedGstackProvisionTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-gstack-failed-provision-"));
+console.log = () => {};
+try {
+  const localSettingsPath = path.join(failedGstackProvisionTarget, ".claude", "settings.local.json");
+  await fs.mkdir(path.dirname(localSettingsPath));
+  await fs.writeFile(localSettingsPath, JSON.stringify({
+    env: { ANTHROPIC_AUTH_TOKEN: "existing-token" },
+    enabledPlugins: { "ecc@ecc": true }
+  }), { mode: 0o600 });
+  const existingRulePath = path.join(failedGstackProvisionTarget, ".claude", "rules", "ecc", "existing.md");
+  await fs.mkdir(path.dirname(existingRulePath), { recursive: true });
+  await fs.writeFile(existingRulePath, "existing rule\n", "utf8");
+  await fs.mkdir(path.join(failedGstackProvisionTarget, ".claude", "commands"));
+  process.env.REPO_PATTERN_GSTACK_SETUP_CMD = "false";
+  await assert.rejects(() => provisionProject({
+    sourceRoot: repoRoot,
+    target: failedGstackProvisionTarget,
+    profile: "minimal",
+    setupPipeline: "gstack",
+    localSettingsEnv: { ANTHROPIC_AUTH_TOKEN: "replacement-token" },
+    migrate: true
+  }), /Command failed/);
+  const localSettings = await fs.readFile(localSettingsPath, "utf8");
+  assert.match(localSettings, /ecc@ecc/);
+  assert.match(localSettings, /existing-token/);
+  assert.equal(await fs.readFile(existingRulePath, "utf8"), "existing rule\n");
+  process.env.REPO_PATTERN_GSTACK_SETUP_CMD = "true";
+  await provisionProject({
+    sourceRoot: repoRoot,
+    target: failedGstackProvisionTarget,
+    profile: "minimal",
+    setupPipeline: "gstack",
+    localSettingsEnv: { ANTHROPIC_AUTH_TOKEN: "replacement-token" },
+    migrate: true
+  });
+  assert.equal((await auditProject(failedGstackProvisionTarget)).state, "GSTACK_MINIMAL");
+  assert.match(await fs.readFile(localSettingsPath, "utf8"), /replacement-token/);
+} finally {
+  delete process.env.REPO_PATTERN_GSTACK_SETUP_CMD;
+  console.log = originalLog;
+  await fs.rm(failedGstackProvisionTarget, { recursive: true, force: true });
+}
+
+const trackedGstackSettingsTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-gstack-tracked-settings-"));
+console.log = () => {};
+try {
+  spawnSync("git", ["init"], { cwd: trackedGstackSettingsTarget, stdio: "ignore" });
+  await fs.mkdir(path.join(trackedGstackSettingsTarget, ".claude"));
+  const localSettingsPath = path.join(trackedGstackSettingsTarget, ".claude", "settings.local.json");
+  await fs.writeFile(localSettingsPath, JSON.stringify({ enabledPlugins: { "ecc@ecc": true } }), { mode: 0o600 });
+  spawnSync("git", ["add", ".claude/settings.local.json"], { cwd: trackedGstackSettingsTarget, stdio: "ignore" });
+  process.env.REPO_PATTERN_GSTACK_SETUP_CMD = "true";
+  await assert.rejects(() => setupGstack({ target: trackedGstackSettingsTarget }), /settings\.local\.json is tracked/);
+  await assert.rejects(() => removeEccPluginSettings({ target: trackedGstackSettingsTarget }), /settings\.local\.json is tracked/);
+  assert.match(await fs.readFile(localSettingsPath, "utf8"), /ecc@ecc/);
+} finally {
+  delete process.env.REPO_PATTERN_GSTACK_SETUP_CMD;
+  console.log = originalLog;
+  await fs.rm(trackedGstackSettingsTarget, { recursive: true, force: true });
+}
+
+const incompleteGstackTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-gstack-incomplete-"));
+console.log = () => {};
+try {
+  await fs.mkdir(path.join(incompleteGstackTarget, ".claude"));
+  await fs.mkdir(path.join(incompleteGstackTarget, ".repo-pattern"));
+  await fs.writeFile(path.join(incompleteGstackTarget, ".repo-pattern", ".repo-pattern.json"), JSON.stringify({
+    workflow: "gstack",
+    runtime: { localSkills: false, localCommands: false, localHooks: false, localScripts: false, localRules: false }
+  }));
+  await fs.writeFile(path.join(incompleteGstackTarget, ".repo-pattern", ".repo-pattern.lock.json"), JSON.stringify({
+    gstack: { status: "not-run" }
+  }));
+  assert.equal((await auditProject(incompleteGstackTarget)).state, "PARTIAL");
+  await assert.rejects(() => doctorProject(incompleteGstackTarget), /Doctor failed/);
+} finally {
+  console.log = originalLog;
+  await fs.rm(incompleteGstackTarget, { recursive: true, force: true });
+}
+
+await assert.rejects(
+  () => setupProject({ sourceRoot: repoRoot, target: os.tmpdir(), setupPipeline: "invalid", yes: true }),
+  /Unknown setup pipeline: invalid/
+);
+await assert.rejects(
+  () => provisionProject({ sourceRoot: repoRoot, target: os.tmpdir(), setupPipeline: "invalid", dryRun: true }),
+  /Unknown setup pipeline: invalid/
+);
+
+const gstackProvisionTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-gstack-provision-"));
+console.log = () => {};
+try {
+  await fs.mkdir(path.join(gstackProvisionTarget, ".claude", "rules", "ecc", "typescript"), { recursive: true });
+  await fs.writeFile(path.join(gstackProvisionTarget, ".claude", "settings.local.json"), JSON.stringify({
+    env: { ANTHROPIC_AUTH_TOKEN: secretSentinel },
+    enabledPlugins: { "ecc@ecc": true },
+    extraKnownMarketplaces: { ecc: { source: { source: "git", url: "https://github.com/affaan-m/ECC.git" } } }
+  }), { mode: 0o600 });
+  process.env.REPO_PATTERN_GSTACK_SETUP_CMD = "true";
+  await provisionProject({
+    sourceRoot: repoRoot,
+    target: gstackProvisionTarget,
+    profile: "minimal",
+    setupPipeline: "gstack",
+    applyRules: true
+  });
+  const repoConfig = JSON.parse(await fs.readFile(path.join(gstackProvisionTarget, ".repo-pattern", ".repo-pattern.json"), "utf8"));
+  const lock = JSON.parse(await fs.readFile(path.join(gstackProvisionTarget, ".repo-pattern", ".repo-pattern.lock.json"), "utf8"));
+  assert.equal(repoConfig.workflow, "gstack");
+  assert.equal("ecc" in repoConfig, false);
+  assert.equal(lock.setupPipeline, "gstack");
+  assert.equal(lock.gstack.status, "installed");
+  assert.equal("ecc" in lock, false);
+  assert.equal((await fs.readFile(path.join(gstackProvisionTarget, ".claude", "settings.local.json"), "utf8")).includes("ecc@ecc"), false);
+  await assert.rejects(() => fs.access(path.join(gstackProvisionTarget, ".claude", "rules")), { code: "ENOENT" });
+  assert.equal((await auditProject(gstackProvisionTarget)).state, "GSTACK_MINIMAL");
+  await doctorProject(gstackProvisionTarget);
+} finally {
+  delete process.env.REPO_PATTERN_GSTACK_SETUP_CMD;
+  console.log = originalLog;
+  await fs.rm(gstackProvisionTarget, { recursive: true, force: true });
+}
 
 const provisionTemplateTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-template-"));
 console.log = () => {};
@@ -857,6 +1025,7 @@ try {
 }
 
 const trackedLockTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-tracked-lock-"));
+const gstackMarker = path.join(os.tmpdir(), `repo-pattern-gstack-marker-${process.pid}`);
 console.log = () => {};
 try {
   spawnSync("git", ["init"], { cwd: trackedLockTarget, stdio: "ignore" });
@@ -867,9 +1036,17 @@ try {
     () => provisionProject({ sourceRoot: repoRoot, target: trackedLockTarget, profile: "minimal" }),
     /repo-pattern lock is tracked/,
   );
+  process.env.REPO_PATTERN_GSTACK_SETUP_CMD = `touch ${JSON.stringify(gstackMarker)}`;
+  await assert.rejects(
+    () => provisionProject({ sourceRoot: repoRoot, target: trackedLockTarget, profile: "minimal", setupPipeline: "gstack" }),
+    /repo-pattern lock is tracked/,
+  );
+  await assert.rejects(() => fs.access(gstackMarker), { code: "ENOENT" });
 } finally {
+  delete process.env.REPO_PATTERN_GSTACK_SETUP_CMD;
   console.log = originalLog;
   await fs.rm(trackedLockTarget, { recursive: true, force: true });
+  await fs.rm(gstackMarker, { force: true });
 }
 
 console.log("self-check passed");


### PR DESCRIPTION
## Summary
- add `--setup-pipeline ecc|gstack`, defaulting to ECC
- install gstack through its upstream global installer and record pipeline-specific state
- update audit, doctor, self-check coverage, and setup documentation

## Verification
- `npm test`
- `npm run pack:dry`
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)