### PR TITLE
fix: disable pull request attribution

### DIFF
--- a/scripts/lib/provision.mjs
+++ b/scripts/lib/provision.mjs
@@ -82,7 +82,8 @@ export function applyAttributionSetting(settings, attributionConfig = { mode: "o
 
   next.attribution = {
     ...(next.attribution || {}),
-    commit: attributionConfig.mode === "custom" ? attributionConfig.commit : ""
+    commit: attributionConfig.mode === "custom" ? attributionConfig.commit : "",
+    ...(attributionConfig.mode === "off" ? { pr: "" } : {})
   };
   return next;
 }

--- a/scripts/self-check.mjs
+++ b/scripts/self-check.mjs
@@ -94,7 +94,7 @@ assert.deepEqual(applyLocalSettings({ env: {
     ANTHROPIC_AUTH_TOKEN: secretSentinel
   }
 });
-assert.deepEqual(applyAttributionSetting({ hooks: {} }, { mode: "off" }), { hooks: {}, attribution: { commit: "" } });
+assert.deepEqual(applyAttributionSetting({ hooks: {} }, { mode: "off" }), { hooks: {}, attribution: { commit: "", pr: "" } });
 assert.deepEqual(applyAttributionSetting({ attribution: { commit: "" } }, { mode: "on" }), {});
 assert.deepEqual(applyAttributionSetting({ attribution: { pr: "PR" } }, { mode: "custom", commit: "Custom" }), { attribution: { pr: "PR", commit: "Custom" } });
 assert.deepEqual(applyPermissionSettings({ permissions: { deny: ["Read(.env)"] } }, { bypass: "allow" }), {


### PR DESCRIPTION
## Summary
- disable Claude Code attribution for created pull requests when attribution is off
- retain existing commit attribution behavior and custom attribution support

## Verification
- `npm test`
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)