### PR TITLE
feat: add setup local setting defaults

### DIFF
--- a/.claude.example/settings.local.example.json
+++ b/.claude.example/settings.local.example.json
@@ -23,7 +23,9 @@
   },
   "env": {
     "ENABLE_TOOL_SEARCH": "auto:5",
-    "CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION": "5",
+    "CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION": "4",
+    "CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY": "2",
+    "workflowSizeGuideline": "small",
     "ANTHROPIC_BASE_URL": "https://example.com/v1",
     "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-4-8",
     "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-sonnet-4-6",

--- a/scripts/lib/provision.mjs
+++ b/scripts/lib/provision.mjs
@@ -146,14 +146,17 @@ async function rejectClaudeSymlink(target, { dryRun = false } = {}) {
   if (stat.isSymbolicLink()) throw new Error(".claude must not be a symlink.");
 }
 
-async function writeLocalSettings({ sourceRoot, target, localSettingsEnv, dryRun }) {
-  if (!localSettingsEnv) return;
+async function writeLocalSettings({ sourceRoot, target, localSettingsEnv = {}, dryRun }) {
   if (isTracked(target, ".claude/settings.local.json")) throw new Error(".claude/settings.local.json is tracked. Untrack it before writing local provider settings.");
   const claudeDir = path.join(target, ".claude");
   await rejectClaudeSymlink(target, { dryRun });
   const template = await readJson(path.join(sourceRoot, ".claude.example", "settings.local.example.json"), {});
   const file = path.join(claudeDir, "settings.local.json");
-  await writePrivateJson(file, applyLocalSettings(template, localSettingsEnv), {
+  await writePrivateJson(file, (current) => applyLocalSettings({
+    ...template,
+    ...current,
+    env: { ...(template.env || {}), ...(current.env || {}) }
+  }, localSettingsEnv), {
     dryRun,
     label: ".claude/settings.local.json"
   });

--- a/scripts/lib/setup.mjs
+++ b/scripts/lib/setup.mjs
@@ -36,12 +36,7 @@ function validateUrl(value) {
   }
 }
 
-function validatePositiveInteger(value) {
-  return /^[1-9]\d*$/.test(String(value)) ? true : "Use a positive whole number.";
-}
-
 const LOCAL_SETTINGS_FIELDS = [
-  ["CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION", "5", askText, validatePositiveInteger],
   ["ANTHROPIC_AUTH_TOKEN", "", askPassword, validateRequired],
   ["ANTHROPIC_BASE_URL", "https://example.com/v1", askText, validateUrl],
   ["ANTHROPIC_DEFAULT_OPUS_MODEL", "claude-opus-4-8", askText, validateRequired],
@@ -235,7 +230,7 @@ export function needsLocalSettingsPrompt(values = {}) {
 
 async function chooseLocalSettingsEnv(initialValues = {}) {
   printBox("Step 4/6 — Local Claude provider settings", ["These values are written to .claude/settings.local.json and gitignored."]);
-  const env = {};
+  const env = { ...initialValues };
   for (const [name, fallback, ask, validate] of LOCAL_SETTINGS_FIELDS) {
     env[name] = await ask(name, { initial: process.env[name] || initialValues[name] || fallback, validate });
   }
@@ -441,7 +436,13 @@ export async function setupProject({ sourceRoot, target, profile = "web", setupP
 
   const currentSettingsEnv = await currentLocalSettingsEnv(target);
   const mcpValues = await chooseMcpValues(sourceRoot, mcpConfig, await readGeneratedMcpValues(target));
-  const retryLocalSettingsEnv = { CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION: "5", ...previousOptions?.localSettingsEnv, ...currentSettingsEnv };
+  const localSettingsTemplate = await readJson(path.join(sourceRoot, ".claude.example", "settings.local.example.json"), {});
+  const defaultOverrides = Object.fromEntries([
+    "CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION",
+    "CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY",
+    "workflowSizeGuideline"
+  ].filter((name) => process.env[name]).map((name) => [name, process.env[name]]));
+  const retryLocalSettingsEnv = { ...localSettingsTemplate.env, ...previousOptions?.localSettingsEnv, ...currentSettingsEnv, ...defaultOverrides };
   const localSettingsEnv = previousOptions && !needsLocalSettingsPrompt(retryLocalSettingsEnv)
     ? retryLocalSettingsEnv
     : await chooseLocalSettingsEnv(retryLocalSettingsEnv);

--- a/scripts/self-check.mjs
+++ b/scripts/self-check.mjs
@@ -21,6 +21,17 @@ const cliDir = path.dirname(fileURLToPath(import.meta.url));
 const cliPath = path.join(cliDir, "repo-pattern.mjs");
 const repoRoot = path.dirname(cliDir);
 const secretSentinel = "do-not-persist-anthropic-token";
+const localSettingsTemplate = JSON.parse(await fs.readFile(path.join(repoRoot, ".claude.example", "settings.local.example.json"), "utf8"));
+
+assert.deepEqual({
+  CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION: localSettingsTemplate.env.CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION,
+  CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY: localSettingsTemplate.env.CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY,
+  workflowSizeGuideline: localSettingsTemplate.env.workflowSizeGuideline
+}, {
+  CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION: "4",
+  CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY: "2",
+  workflowSizeGuideline: "small"
+});
 
 const mcpServers = {
   context7: {
@@ -149,7 +160,7 @@ assert.equal(needsLocalSettingsPrompt({
   ANTHROPIC_DEFAULT_OPUS_MODEL: "claude-opus-4-8",
   ANTHROPIC_DEFAULT_SONNET_MODEL: "claude-sonnet-4-6",
   ANTHROPIC_DEFAULT_HAIKU_MODEL: "claude-haiku-4-5"
-}), true);
+}), false);
 assert.equal(needsLocalSettingsPrompt({
   ANTHROPIC_AUTH_TOKEN: " ",
   ANTHROPIC_BASE_URL: "https://example.com/v1",
@@ -717,7 +728,9 @@ try {
   assert.equal(lock.setupPipeline, "gstack");
   assert.equal(lock.gstack.status, "installed");
   assert.equal("ecc" in lock, false);
-  assert.equal((await fs.readFile(path.join(gstackProvisionTarget, ".claude", "settings.local.json"), "utf8")).includes("ecc@ecc"), false);
+  const gstackLocalSettings = JSON.parse(await fs.readFile(path.join(gstackProvisionTarget, ".claude", "settings.local.json"), "utf8"));
+  assert.equal(gstackLocalSettings.enabledPlugins["ecc@ecc"], undefined);
+  assert.equal(gstackLocalSettings.env.ANTHROPIC_AUTH_TOKEN, secretSentinel);
   await assert.rejects(() => fs.access(path.join(gstackProvisionTarget, ".claude", "rules")), { code: "ENOENT" });
   assert.equal((await auditProject(gstackProvisionTarget)).state, "GSTACK_MINIMAL");
   await doctorProject(gstackProvisionTarget);
@@ -758,6 +771,8 @@ try {
   assert.equal(localSettings.env.ANTHROPIC_AUTH_TOKEN, secretSentinel);
   assert.equal(localSettings.env.ANTHROPIC_BASE_URL, "https://example.com/v1");
   assert.equal(localSettings.env.CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION, "7");
+  assert.equal(localSettings.env.CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY, "2");
+  assert.equal(localSettings.env.workflowSizeGuideline, "small");
   assert.equal(settings.permissions.defaultMode, "bypassPermissions");
   assert.equal("disableBypassPermissionsMode" in settings.permissions, false);
   assert.equal("CONTEXT7_API_KEY" in localSettings.env, false);
@@ -983,7 +998,15 @@ try {
   assert.equal(settings.permissions.defaultMode, "default");
   assert.equal(settings.permissions.disableBypassPermissionsMode, "disable");
   const localSettings = JSON.parse(await fs.readFile(path.join(defaultProvisionTarget, ".claude", "settings.local.json"), "utf8"));
-  assert.equal("env" in localSettings, false);
+  assert.deepEqual({
+    CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION: localSettings.env.CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION,
+    CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY: localSettings.env.CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY,
+    workflowSizeGuideline: localSettings.env.workflowSizeGuideline
+  }, {
+    CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION: "4",
+    CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY: "2",
+    workflowSizeGuideline: "small"
+  });
   await updateClaudePermissions({ sourceRoot: repoRoot, target: defaultProvisionTarget, permissionConfig: { bypass: "allow" } });
   const updatedSettings = JSON.parse(await fs.readFile(settingsPath, "utf8"));
   assert.equal(updatedSettings.permissions.defaultMode, "bypassPermissions");


### PR DESCRIPTION
## Summary
- add private setup defaults for Claude Code concurrency and workflow size
- write the local settings template on every selected pipeline
- preserve existing local and explicitly supplied values

## Test plan
- [x] `npm test`
- [x] `npm run pack:dry`
- [x] `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)