### PR TITLE
chore: release v0.1.12

### DIFF
--- a/.claude.example/settings.example.json
+++ b/.claude.example/settings.example.json
@@ -6,21 +6,7 @@
   },
   "permissions": {
     "deny": [
-      "Read(.env)",
-      "Read(.env.*)",
-      "Read(**/.env)",
-      "Read(**/.env.*)",
-      "Read(secrets/**)",
-      "Read(private/**)",
-      "Read(**/*.pem)",
-      "Read(**/*.key)",
-      "Read(**/id_rsa)",
-      "Read(**/id_ed25519)",
-      "Read(~/.ssh/**)",
-      "Read(~/.aws/**)",
-      "Read(~/.config/gcloud/**)",
-      "Bash(rm -rf /)",
-      "Bash(rm -rf ~)"
+      "Agent(claude)"
     ],
     "ask": [
       "Bash(git push *)",

--- a/.claude.example/settings.local.example.json
+++ b/.claude.example/settings.local.example.json
@@ -10,6 +10,7 @@
   "showTurnDuration": true,
   "spinnerTipsEnabled": true,
   "fileCheckpointingEnabled": true,
+  "workflowSizeGuideline": "small",
   "enabledPlugins": {
     "ecc@ecc": true
   },
@@ -25,7 +26,6 @@
     "ENABLE_TOOL_SEARCH": "auto:5",
     "CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION": "4",
     "CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY": "2",
-    "workflowSizeGuideline": "small",
     "ANTHROPIC_BASE_URL": "https://example.com/v1",
     "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-4-8",
     "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-sonnet-4-6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@negikirin/repo-pattern",
-  "version": "0.1.10",
+  "version": "0.1.12",
   "description": "Minimal ECC-first Claude Code project setup and migrator",
   "type": "module",
   "bin": {

--- a/scripts/lib/provision.mjs
+++ b/scripts/lib/provision.mjs
@@ -125,13 +125,11 @@ export async function updateClaudePermissions({ sourceRoot, target, permissionCo
 }
 
 export function applyLocalSettings(settings, localSettingsEnv) {
-  return {
-    ...settings,
-    env: withoutPersistedMcpValues({
-      ...(settings.env || {}),
-      ...localSettingsEnv
-    })
-  };
+  const env = Object.fromEntries(Object.entries(withoutPersistedMcpValues({
+    ...(settings.env || {}),
+    ...localSettingsEnv
+  })).filter(([name]) => name !== "workflowSizeGuideline"));
+  return { ...settings, env };
 }
 
 async function rejectClaudeSymlink(target, { dryRun = false } = {}) {

--- a/scripts/lib/setup.mjs
+++ b/scripts/lib/setup.mjs
@@ -439,8 +439,7 @@ export async function setupProject({ sourceRoot, target, profile = "web", setupP
   const localSettingsTemplate = await readJson(path.join(sourceRoot, ".claude.example", "settings.local.example.json"), {});
   const defaultOverrides = Object.fromEntries([
     "CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION",
-    "CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY",
-    "workflowSizeGuideline"
+    "CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY"
   ].filter((name) => process.env[name]).map((name) => [name, process.env[name]]));
   const retryLocalSettingsEnv = { ...localSettingsTemplate.env, ...previousOptions?.localSettingsEnv, ...currentSettingsEnv, ...defaultOverrides };
   const localSettingsEnv = previousOptions && !needsLocalSettingsPrompt(retryLocalSettingsEnv)

--- a/scripts/self-check.mjs
+++ b/scripts/self-check.mjs
@@ -23,15 +23,15 @@ const repoRoot = path.dirname(cliDir);
 const secretSentinel = "do-not-persist-anthropic-token";
 const localSettingsTemplate = JSON.parse(await fs.readFile(path.join(repoRoot, ".claude.example", "settings.local.example.json"), "utf8"));
 
+assert.equal(localSettingsTemplate.workflowSizeGuideline, "small");
 assert.deepEqual({
   CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION: localSettingsTemplate.env.CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION,
-  CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY: localSettingsTemplate.env.CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY,
-  workflowSizeGuideline: localSettingsTemplate.env.workflowSizeGuideline
+  CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY: localSettingsTemplate.env.CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY
 }, {
   CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION: "4",
-  CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY: "2",
-  workflowSizeGuideline: "small"
+  CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY: "2"
 });
+assert.equal("workflowSizeGuideline" in localSettingsTemplate.env, false);
 
 const mcpServers = {
   context7: {
@@ -709,6 +709,7 @@ console.log = () => {};
 try {
   await fs.mkdir(path.join(gstackProvisionTarget, ".claude", "rules", "ecc", "typescript"), { recursive: true });
   await fs.writeFile(path.join(gstackProvisionTarget, ".claude", "settings.local.json"), JSON.stringify({
+    workflowSizeGuideline: "large",
     env: { ANTHROPIC_AUTH_TOKEN: secretSentinel },
     enabledPlugins: { "ecc@ecc": true },
     extraKnownMarketplaces: { ecc: { source: { source: "git", url: "https://github.com/affaan-m/ECC.git" } } }
@@ -730,6 +731,7 @@ try {
   assert.equal("ecc" in lock, false);
   const gstackLocalSettings = JSON.parse(await fs.readFile(path.join(gstackProvisionTarget, ".claude", "settings.local.json"), "utf8"));
   assert.equal(gstackLocalSettings.enabledPlugins["ecc@ecc"], undefined);
+  assert.equal(gstackLocalSettings.workflowSizeGuideline, "large");
   assert.equal(gstackLocalSettings.env.ANTHROPIC_AUTH_TOKEN, secretSentinel);
   await assert.rejects(() => fs.access(path.join(gstackProvisionTarget, ".claude", "rules")), { code: "ENOENT" });
   assert.equal((await auditProject(gstackProvisionTarget)).state, "GSTACK_MINIMAL");
@@ -770,9 +772,10 @@ try {
   assert.equal((await fs.stat(mcpConfigPath)).mode & 0o777, 0o600);
   assert.equal(localSettings.env.ANTHROPIC_AUTH_TOKEN, secretSentinel);
   assert.equal(localSettings.env.ANTHROPIC_BASE_URL, "https://example.com/v1");
+  assert.equal(localSettings.workflowSizeGuideline, "small");
   assert.equal(localSettings.env.CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION, "7");
   assert.equal(localSettings.env.CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY, "2");
-  assert.equal(localSettings.env.workflowSizeGuideline, "small");
+  assert.equal("workflowSizeGuideline" in localSettings.env, false);
   assert.equal(settings.permissions.defaultMode, "bypassPermissions");
   assert.equal("disableBypassPermissionsMode" in settings.permissions, false);
   assert.equal("CONTEXT7_API_KEY" in localSettings.env, false);
@@ -998,15 +1001,15 @@ try {
   assert.equal(settings.permissions.defaultMode, "default");
   assert.equal(settings.permissions.disableBypassPermissionsMode, "disable");
   const localSettings = JSON.parse(await fs.readFile(path.join(defaultProvisionTarget, ".claude", "settings.local.json"), "utf8"));
+  assert.equal(localSettings.workflowSizeGuideline, "small");
   assert.deepEqual({
     CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION: localSettings.env.CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION,
-    CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY: localSettings.env.CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY,
-    workflowSizeGuideline: localSettings.env.workflowSizeGuideline
+    CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY: localSettings.env.CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY
   }, {
     CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION: "4",
-    CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY: "2",
-    workflowSizeGuideline: "small"
+    CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY: "2"
   });
+  assert.equal("workflowSizeGuideline" in localSettings.env, false);
   await updateClaudePermissions({ sourceRoot: repoRoot, target: defaultProvisionTarget, permissionConfig: { bypass: "allow" } });
   const updatedSettings = JSON.parse(await fs.readFile(settingsPath, "utf8"));
   assert.equal(updatedSettings.permissions.defaultMode, "bypassPermissions");


### PR DESCRIPTION
## Summary
- move `workflowSizeGuideline` to the top level of local Claude settings
- add default Claude Code concurrency settings
- apply the requested `permissions.deny` update
- bump package version to 0.1.12

## Test plan
- [x] `npm test`
- [x] `npm run pack:dry`
- [x] `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)