### PR TITLE
feat: support combined setup pipelines

### DIFF
--- a/scripts/lib/audit.mjs
+++ b/scripts/lib/audit.mjs
@@ -77,25 +77,33 @@ export async function auditProject(target) {
 
   const allowSourceSkills = repoPattern?.mode === "template";
   const allowManagedSkills = repoPattern?.runtime?.localSkills === true && Array.isArray(repoPattern?.optionalSkills) && result.hasOnlyManagedSkills;
+  const workflow = repoPattern?.workflow;
+  const usesEcc = workflow === "ecc-native" || workflow === "ecc-gstack";
+  const usesGstack = workflow === "gstack" || workflow === "ecc-gstack";
   const legacy = (
     result.hasSettingsHooks ||
     (result.hasClaudeSkillsDir && !allowSourceSkills && !allowManagedSkills) ||
     result.hasClaudeCommandsDir ||
     result.hasClaudeHooksDir ||
     result.hasClaudeScriptsDir ||
-    (result.hasClaudeRulesDir && (repoPattern?.workflow === "gstack" || !result.hasOnlyEccRulesDir))
+    (result.hasClaudeRulesDir && (repoPattern ? (!usesEcc || !result.hasOnlyEccRulesDir) : !result.hasOnlyEccRulesDir))
   );
 
-  const setupComplete = repoPattern?.workflow !== "gstack" || lock.gstack?.status === "installed";
+  const setupComplete = !usesGstack || lock.gstack?.status === "installed";
   if (!result.hasClaudeDir && !result.hasMcpJson && !result.hasRepoPatternJson) {
     result.state = "EMPTY";
   } else if (
     result.hasRepoPatternJson &&
-    ["ecc-native", "gstack"].includes(result.repoPattern?.workflow) &&
+    ["ecc-native", "gstack", "ecc-gstack", "none"].includes(result.repoPattern?.workflow) &&
     setupComplete &&
     !legacy
   ) {
-    result.state = result.repoPattern.workflow === "gstack" ? "GSTACK_MINIMAL" : "ECC_NATIVE_MINIMAL";
+    result.state = {
+      "ecc-native": "ECC_NATIVE_MINIMAL",
+      gstack: "GSTACK_MINIMAL",
+      "ecc-gstack": "ECC_GSTACK_MINIMAL",
+      none: "NO_PIPELINE_MINIMAL"
+    }[result.repoPattern.workflow];
   } else if (legacy) {
     result.state = "LEGACY_VENDOR";
   } else {
@@ -124,8 +132,8 @@ export function printAudit(audit) {
     [audit.hasClaudeCommandsDir, ".claude/commands present"],
     [audit.hasClaudeHooksDir, ".claude/hooks present"],
     [audit.hasClaudeScriptsDir, ".claude/scripts present"],
-    [audit.hasClaudeRulesDir && audit.repoPattern?.workflow === "gstack", ".claude/rules is incompatible with gstack"],
-    [audit.hasClaudeRulesDir && audit.repoPattern?.workflow !== "gstack" && !audit.hasOnlyEccRulesDir, "non-ECC .claude/rules present"]
+    [audit.hasClaudeRulesDir && !["ecc-native", "ecc-gstack"].includes(audit.repoPattern?.workflow), ".claude/rules is incompatible with this setup pipeline"],
+    [audit.hasClaudeRulesDir && ["ecc-native", "ecc-gstack"].includes(audit.repoPattern?.workflow) && !audit.hasOnlyEccRulesDir, "non-ECC .claude/rules present"]
   ].filter(([bad]) => bad);
 
   if (issues.length > 0) {

--- a/scripts/lib/doctor.mjs
+++ b/scripts/lib/doctor.mjs
@@ -33,7 +33,8 @@ export async function doctorProject(target, { updateLock = false, dryRun = false
   check(!audit.hasClaudeCommandsDir, ".claude/commands does not exist");
   check(!audit.hasClaudeHooksDir, ".claude/hooks does not exist");
   check(!audit.hasClaudeScriptsDir, ".claude/scripts does not exist");
-  check(!audit.hasClaudeRulesDir || (audit.repoPattern?.workflow !== "gstack" && audit.hasOnlyEccRulesDir), audit.repoPattern?.workflow === "gstack" ? ".claude/rules does not exist for gstack" : "no non-ECC .claude/rules");
+  const usesEcc = audit.repoPattern?.workflow === "ecc-native" || audit.repoPattern?.workflow === "ecc-gstack";
+  check(!audit.hasClaudeRulesDir || (usesEcc && audit.hasOnlyEccRulesDir), usesEcc ? "no non-ECC .claude/rules" : ".claude/rules does not exist for this setup pipeline");
   check(audit.hasClaudeDir, ".claude exists");
   check(!audit.hasSettingsHooks, ".claude/settings.json hooks is {}");
   check(!isTracked(target, ".claude/settings.json"), ".claude/settings.json is not tracked");
@@ -44,8 +45,13 @@ export async function doctorProject(target, { updateLock = false, dryRun = false
   check(audit.hasRepoPatternJson, ".repo-pattern/.repo-pattern.json exists");
 
   const repoPattern = audit.repoPattern || {};
-  const setupPipeline = repoPattern.workflow === "gstack" ? "gstack" : "ecc";
-  check(["ecc-native", "gstack"].includes(repoPattern.workflow), ".repo-pattern/.repo-pattern.json workflow is ecc-native or gstack");
+  const setupPipeline = {
+    "ecc-native": "ecc",
+    gstack: "gstack",
+    "ecc-gstack": "both",
+    none: "none"
+  }[repoPattern.workflow] || "ecc";
+  check(["ecc-native", "gstack", "ecc-gstack", "none"].includes(repoPattern.workflow), ".repo-pattern/.repo-pattern.json workflow is ecc-native, gstack, ecc-gstack, or none");
   check(repoPattern.runtime?.localSkills === false || managedSkills, ".repo-pattern/.repo-pattern.json runtime.localSkills=false unless optional skills are managed");
   if (managedSkills) check(audit.hasClaudeSkillsDir, ".claude/skills exists for managed optional skills");
   check(repoPattern.runtime?.localCommands === false, ".repo-pattern/.repo-pattern.json runtime.localCommands=false");
@@ -71,9 +77,11 @@ export async function doctorProject(target, { updateLock = false, dryRun = false
     check(audit.hasClaudeEccRulesDir && existingRules.size > 0, ".claude/rules/ecc contains synced ECC rule pack directories");
     check(appliedRules.every((rule) => existingRules.has(rule)), "all locked ECC rule packs exist under .claude/rules/ecc");
   }
-  if (setupPipeline === "gstack") check(lock.gstack?.status === "installed", ".repo-pattern/.repo-pattern.lock.json gstack.status=installed");
-  infoRows.push(`${setupPipeline === "gstack" ? "gstack" : "ECC"} setup status: ${lock[setupPipeline]?.status || "unknown"}`);
-  if (setupPipeline === "ecc" && lock.ecc?.status === "manual-plugin-install-required") {
+  if (setupPipeline === "gstack" || setupPipeline === "both") check(lock.gstack?.status === "installed", ".repo-pattern/.repo-pattern.lock.json gstack.status=installed");
+  if (setupPipeline === "both") infoRows.push(`ECC setup status: ${lock.ecc?.status || "unknown"}, gstack setup status: ${lock.gstack?.status || "unknown"}`);
+  else if (setupPipeline !== "none") infoRows.push(`${setupPipeline === "gstack" ? "gstack" : "ECC"} setup status: ${lock[setupPipeline]?.status || "unknown"}`);
+  else infoRows.push("setup pipeline: none");
+  if ((setupPipeline === "ecc" || setupPipeline === "both") && lock.ecc?.status === "manual-plugin-install-required") {
     infoRows.push("Open Claude Code and run:");
     infoRows.push("/plugin marketplace add https://github.com/affaan-m/ECC");
     infoRows.push("/plugin install ecc@ecc");

--- a/scripts/lib/gstack.mjs
+++ b/scripts/lib/gstack.mjs
@@ -26,6 +26,14 @@ function validateGstackCheckout() {
   return true;
 }
 
+function requireBun() {
+  try {
+    execFileSync("bun", ["--version"], { stdio: "ignore" });
+  } catch {
+    throw new Error("Bun is required for gstack setup. Install Bun v1.0+ and rerun setup.");
+  }
+}
+
 export async function removeEccPluginSettings({ target, dryRun = false }) {
   if (isTracked(target, ".claude/settings.local.json")) throw new Error(".claude/settings.local.json is tracked. Untrack it before writing local plugin settings.");
   await writePrivateJson(path.join(target, ".claude", "settings.local.json"), withoutEccPlugin, {
@@ -54,14 +62,27 @@ export async function setupGstack({ target, dryRun = false }) {
       });
     }
   } else if (dryRun) {
-    if (!exists(GSTACK_DIR)) console.log(`[dry-run] git clone --single-branch --depth 1 ${GSTACK_REPOSITORY} ${GSTACK_DIR}`);
+    console.log("Checking gstack prerequisites");
+    if (!exists(GSTACK_DIR)) {
+      console.log("Cloning gstack");
+      console.log(`[dry-run] git clone --single-branch --depth 1 ${GSTACK_REPOSITORY} ${GSTACK_DIR}`);
+    } else {
+      console.log("Using existing gstack checkout");
+    }
+    console.log("Running gstack setup");
     console.log(`[dry-run] cd ${GSTACK_DIR} && ./setup`);
     status = "dry-run";
   } else {
+    console.log("Checking gstack prerequisites");
+    requireBun();
     if (!validateGstackCheckout()) {
+      console.log("Cloning gstack");
       await ensureDir(path.dirname(GSTACK_DIR));
       execFileSync("git", ["clone", "--single-branch", "--depth", "1", GSTACK_REPOSITORY, GSTACK_DIR], { stdio: "inherit" });
+    } else {
+      console.log("Using existing gstack checkout");
     }
+    console.log("Running gstack setup");
     execFileSync(process.platform === "win32" ? "bash" : "./setup", process.platform === "win32" ? ["./setup"] : [], { cwd: GSTACK_DIR, stdio: "inherit" });
     printSummary("gstack", [["Status", "installed for Claude Code"]]);
   }

--- a/scripts/lib/provision.mjs
+++ b/scripts/lib/provision.mjs
@@ -18,13 +18,32 @@ function shellQuote(value) {
   return `'${String(value).replaceAll("'", `'"'"'`)}'`;
 }
 
+const SETUP_PIPELINES = ["ecc", "gstack", "both", "none"];
+
+function usesEcc(setupPipeline) {
+  return setupPipeline === "ecc" || setupPipeline === "both";
+}
+
+function usesGstack(setupPipeline) {
+  return setupPipeline === "gstack" || setupPipeline === "both";
+}
+
+function workflowName(setupPipeline) {
+  return {
+    ecc: "ecc-native",
+    gstack: "gstack",
+    both: "ecc-gstack",
+    none: "none"
+  }[setupPipeline];
+}
+
 async function repoPatternConfig(sourceRoot, profile, setupPipeline) {
   const template = await readJson(path.join(sourceRoot, ".repo-pattern.example.json"), {});
   const { ecc, ...base } = template;
   return {
     ...base,
-    workflow: setupPipeline === "gstack" ? "gstack" : "ecc-native",
-    ...(setupPipeline === "ecc" ? { ecc } : {}),
+    workflow: workflowName(setupPipeline),
+    ...(usesEcc(setupPipeline) ? { ecc } : {}),
     mode: "target",
     mcp: {
       ...(template.mcp || {}),
@@ -34,7 +53,10 @@ async function repoPatternConfig(sourceRoot, profile, setupPipeline) {
   };
 }
 
-function lockConfig(profile, setupPipeline, pipelineStatus = "not-run") {
+function lockConfig(profile, setupPipeline, pipelineStatus = {}) {
+  const status = typeof pipelineStatus === "string" ? { ecc: pipelineStatus, gstack: pipelineStatus } : pipelineStatus;
+  const eccStatus = status.ecc || "not-run";
+  const gstackStatus = status.gstack || "not-run";
   return {
     repoPattern: {
       version: "2.0.0",
@@ -42,10 +64,10 @@ function lockConfig(profile, setupPipeline, pipelineStatus = "not-run") {
       lastDoctorRun: null
     },
     setupPipeline,
-    ...(setupPipeline === "ecc" ? {
+    ...(usesEcc(setupPipeline) ? {
       ecc: {
         installMode: "plugin",
-        status: pipelineStatus,
+        status: eccStatus,
         rulesSyncedBy: null,
         rulesScope: "project",
         recommendedRules: [],
@@ -53,16 +75,17 @@ function lockConfig(profile, setupPipeline, pipelineStatus = "not-run") {
         detectedStack: null,
         rulesAppliedAt: null,
         hooks: "plugin-managed",
-        syncedAt: pipelineStatus === "installed" ? new Date().toISOString() : null
+        syncedAt: eccStatus === "installed" ? new Date().toISOString() : null
       }
-    } : {
+    } : {}),
+    ...(usesGstack(setupPipeline) ? {
       gstack: {
         installMode: "global",
         source: "https://github.com/garrytan/gstack.git",
-        status: pipelineStatus,
-        syncedAt: pipelineStatus === "installed" ? new Date().toISOString() : null
+        status: gstackStatus,
+        syncedAt: gstackStatus === "installed" ? new Date().toISOString() : null
       }
-    }),
+    } : {}),
     mcp: {
       profile,
       generatedAt: null
@@ -162,7 +185,7 @@ async function writeLocalSettings({ sourceRoot, target, localSettingsEnv = {}, d
 }
 
 export async function provisionProject({ sourceRoot, target, profile = "web", setupPipeline = "ecc", mcpServers = null, mcpValues = {}, dryRun = false, force = false, migrate = false, localSettingsEnv = null, attributionConfig = { mode: "off" }, permissionConfig = { bypass: "deny" }, ruleMode = "auto", rules = null, applyRules = false, optionalSkills = [] }) {
-  if (!["ecc", "gstack"].includes(setupPipeline)) throw new Error(`Unknown setup pipeline: ${setupPipeline}. Available: ecc, gstack`);
+  if (!SETUP_PIPELINES.includes(setupPipeline)) throw new Error(`Unknown setup pipeline: ${setupPipeline}. Available: ${SETUP_PIPELINES.join(", ")}`);
   printSummary("Provisioning target", [["Target", target]]);
   await rejectClaudeSymlink(target, { dryRun });
   const audit = await auditProject(target);
@@ -174,7 +197,7 @@ export async function provisionProject({ sourceRoot, target, profile = "web", se
   if (isTracked(target, ".claude/settings.json")) throw new Error(".claude/settings.json is tracked. Untrack it before writing Claude Code settings.");
   if (isTracked(target, ".repo-pattern/.repo-pattern.lock.json") || isTracked(target, ".repo-pattern.lock.json")) throw new Error("repo-pattern lock is tracked. Untrack it before writing local setup state.");
 
-  const gstackStatus = setupPipeline === "gstack" ? await setupGstack({ target, dryRun }) : null;
+  const gstackStatus = usesGstack(setupPipeline) ? await setupGstack({ target, dryRun }) : null;
 
   if (audit.state === "LEGACY_VENDOR") {
     await cleanupProject({ sourceRoot, target, dryRun });
@@ -197,22 +220,21 @@ export async function provisionProject({ sourceRoot, target, profile = "web", se
   await writeClaudeSettings({ sourceRoot, target, attributionConfig, permissionConfig, dryRun });
   await appendGitignoreLine(target, ".claude/", { dryRun });
 
-  if (setupPipeline === "ecc") await writeLocalSettings({ sourceRoot, target, localSettingsEnv, dryRun });
+  await writeLocalSettings({ sourceRoot, target, localSettingsEnv, dryRun });
 
   await ensureRepoPatternGitignore(target, { dryRun });
   const lockPath = repoLockPath(target);
 
   const mcpResult = await generateMcp({ sourceRoot, target, profile, mcpServers, mcpValues, dryRun });
-  const pipelineStatus = gstackStatus || await setupEcc({ sourceRoot, target, dryRun });
-  if (setupPipeline === "gstack") {
-    await writeLocalSettings({ sourceRoot, target, localSettingsEnv, dryRun });
+  const eccStatus = usesEcc(setupPipeline) ? await setupEcc({ sourceRoot, target, dryRun }) : null;
+  if (setupPipeline === "gstack" || setupPipeline === "none") {
     await removeEccPluginSettings({ target, dryRun });
     await removePath(path.join(target, ".claude", "rules"), { dryRun });
   }
   await writeJson(repoConfigPath(target), await repoPatternConfig(sourceRoot, profile, setupPipeline), { dryRun });
-  await writeJson(lockPath, lockConfig(profile, setupPipeline, pipelineStatus), { dryRun });
+  await writeJson(lockPath, lockConfig(profile, setupPipeline, { ecc: eccStatus, gstack: gstackStatus }), { dryRun });
   await ensureRepoPatternGitignore(target, { dryRun });
-  if (setupPipeline === "ecc" && applyRules) await applyEccRules({ target, dryRun, ruleMode, rules });
+  if (usesEcc(setupPipeline) && applyRules) await applyEccRules({ target, dryRun, ruleMode, rules });
   if (optionalSkills.length > 0) await applyOptionalSkills({ target, skills: optionalSkills, dryRun });
 
   if (dryRun) {
@@ -222,7 +244,7 @@ export async function provisionProject({ sourceRoot, target, profile = "web", se
   }
 
   const pending = [
-    ...(pipelineStatus === "manual-plugin-install-required" ? ["ECC plugin"] : []),
+    ...(eccStatus === "manual-plugin-install-required" ? ["ECC plugin"] : []),
     ...(mcpResult.missingValues.length > 0 ? ["MCP values"] : [])
   ];
   const pendingText = pending.length ? `${pending.join(", ")} pending` : style("success", "ready");

--- a/scripts/lib/setup.mjs
+++ b/scripts/lib/setup.mjs
@@ -178,19 +178,48 @@ async function chooseMcpValues(sourceRoot, mcpConfig, values = {}) {
   return collectMcpValues(mcpServers, { values: persistedMcpValues(values) });
 }
 
+const SETUP_PIPELINES = ["ecc", "gstack", "both", "none"];
+
+function selectedPipeline(values = []) {
+  const selected = new Set(values);
+  if (selected.has("ecc") && selected.has("gstack")) return "both";
+  if (selected.has("gstack")) return "gstack";
+  if (selected.has("ecc")) return "ecc";
+  return "none";
+}
+
+function pipelineValues(setupPipeline = "ecc") {
+  if (setupPipeline === "both") return ["ecc", "gstack"];
+  if (setupPipeline === "none") return [];
+  return [setupPipeline];
+}
+
+function usesEcc(setupPipeline) {
+  return setupPipeline === "ecc" || setupPipeline === "both";
+}
+
+function expectedSetupState(setupPipeline) {
+  return {
+    ecc: "ECC_NATIVE_MINIMAL",
+    gstack: "GSTACK_MINIMAL",
+    both: "ECC_GSTACK_MINIMAL",
+    none: "NO_PIPELINE_MINIMAL"
+  }[setupPipeline];
+}
+
 async function chooseSetupPipeline(initialValue = "ecc") {
-  return selectOne({
+  return selectedPipeline(await selectMany({
     message: "Choose setup pipeline",
     options: [
       { value: "ecc", label: "ECC", description: "Claude Code plugin with optional project rules" },
       { value: "gstack", label: "gstack", description: "global skills install; requires Git and Bun" }
     ],
-    initialValue
-  });
+    initialValues: pipelineValues(initialValue)
+  }));
 }
 
 async function chooseRuleConfig(detection, setupPipeline) {
-  if (setupPipeline === "gstack") return { applyRules: false, ruleMode: "auto", rules: [] };
+  if (!usesEcc(setupPipeline)) return { applyRules: false, ruleMode: "auto", rules: [] };
   const autoRules = selectEccRules(detection);
   const ruleMode = await selectOne({
     message: "Step 2/6 — Choose ECC rule detection mode",
@@ -360,13 +389,13 @@ async function handleInitialized({ sourceRoot, target, profile, dryRun }) {
 }
 
 export async function setupProject({ sourceRoot, target, profile = "web", setupPipeline = "ecc", dryRun = false, force = false, migrate = false, yes = false, applyRules = false, optionalSkills = [] }) {
-  if (!["ecc", "gstack"].includes(setupPipeline)) throw new Error(`Unknown setup pipeline: ${setupPipeline}. Available: ecc, gstack`);
+  if (!SETUP_PIPELINES.includes(setupPipeline)) throw new Error(`Unknown setup pipeline: ${setupPipeline}. Available: ${SETUP_PIPELINES.join(", ")}`);
   if (!isInteractive()) {
     if (!yes) throw new Error("setup requires an interactive terminal, or pass --yes for scriptable mode.");
     if (profile === "custom") throw new Error("setup --yes cannot use the custom profile; choose a named profile.");
 
     const audit = await auditProject(target);
-    const expectedState = setupPipeline === "gstack" ? "GSTACK_MINIMAL" : "ECC_NATIVE_MINIMAL";
+    const expectedState = expectedSetupState(setupPipeline);
     if (audit.state === expectedState && !force && optionalSkills.length === 0) {
       await doctorProject(target, { dryRun });
       return;
@@ -399,11 +428,12 @@ export async function setupProject({ sourceRoot, target, profile = "web", setupP
   const previousOptions = await choosePreviousSetupOptions(target);
   const detection = await detectProject(target);
   const selectedSetupPipeline = previousOptions?.setupPipeline || await chooseSetupPipeline(setupPipeline);
+  if (!SETUP_PIPELINES.includes(selectedSetupPipeline)) throw new Error(`Unknown setup pipeline: ${selectedSetupPipeline}. Available: ${SETUP_PIPELINES.join(", ")}`);
   const chosenProfile = previousOptions?.profile || await chooseProfile(sourceRoot, profile, detection);
   const mcpConfig = previousOptions
     ? { profile: previousOptions.profile, mcpServers: previousOptions.mcpServers }
     : await chooseMcpConfig(sourceRoot, chosenProfile);
-  const ruleConfig = previousOptions && selectedSetupPipeline === "ecc"
+  const ruleConfig = previousOptions && usesEcc(selectedSetupPipeline)
     ? { applyRules: previousOptions.applyRules, ruleMode: previousOptions.ruleMode, rules: previousOptions.rules }
     : await chooseRuleConfig(detection, selectedSetupPipeline);
   const selectedOptionalSkills = previousOptions?.optionalSkills || await chooseOptionalSkills(optionalSkills);
@@ -415,7 +445,7 @@ export async function setupProject({ sourceRoot, target, profile = "web", setupP
     throw new Error("Target has legacy/local Claude runtime surfaces. Re-run setup with --migrate, not --force.");
   }
 
-  const expectedState = selectedSetupPipeline === "gstack" ? "GSTACK_MINIMAL" : "ECC_NATIVE_MINIMAL";
+  const expectedState = expectedSetupState(selectedSetupPipeline);
   if (audit.state === expectedState) {
     if (selectedOptionalSkills.length > 0) {
       await applyOptionalSkills({ target, skills: selectedOptionalSkills, dryRun });

--- a/scripts/repo-pattern.mjs
+++ b/scripts/repo-pattern.mjs
@@ -14,7 +14,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const sourceRoot = path.resolve(__dirname, "..");
 const optionalSkillNames = OPTIONAL_SKILLS.map((skill) => skill.value).join(", ");
-const setupPipelineNames = ["ecc", "gstack"];
+const setupPipelineNames = ["ecc", "gstack", "both", "none"];
 
 function requiredOptionValue(rest, index, arg) {
   const value = rest[index + 1];
@@ -79,8 +79,8 @@ function parseArgs(argv) {
     process.exit(2);
   }
 
-  if (options.setupPipeline === "gstack" && options.applyRules) {
-    console.error("--with-rules requires --setup-pipeline ecc.");
+  if (!["ecc", "both"].includes(options.setupPipeline) && options.applyRules) {
+    console.error("--with-rules requires --setup-pipeline ecc or both.");
     process.exit(2);
   }
 
@@ -96,6 +96,8 @@ Usage:
   repo-pattern setup
   repo-pattern setup --profile web --setup-pipeline ecc --yes
   repo-pattern setup --profile web --setup-pipeline gstack --yes
+  repo-pattern setup --profile web --setup-pipeline both --yes
+  repo-pattern setup --profile web --setup-pipeline none --yes
   repo-pattern setup --profile web --migrate --yes
   repo-pattern setup --with-skill taste --yes
   repo-pattern setup --with-skill ui-ux-pro-max --yes  # requires Python 3.x
@@ -113,7 +115,8 @@ Advanced:
 Options:
   --target <path>                  Target project path. Default: .
   --profile <name>                 MCP profile for scriptable commands. Default: web
-  --setup-pipeline <ecc|gstack>    Setup pipeline. Default: ecc
+  --setup-pipeline <ecc|gstack|both|none>
+                                  Setup pipeline. Default: ecc
 
 Setup UI:
   setup uses ↑/↓ to move, Space to toggle MCP/rules choices, Enter to confirm, Esc/Ctrl+C to cancel

--- a/scripts/self-check.mjs
+++ b/scripts/self-check.mjs
@@ -411,7 +411,7 @@ assert(auditLogs.includes("State   EMPTY"));
 assert(!auditLogs.some((line) => line.includes(".claude present")));
 assert(auditLogs.some((line) => line.includes("⚠ .mcp.json missing")));
 assert(auditLogs.some((line) => line.includes("⚠ .claude/settings.json hooks not empty")));
-assert(auditLogs.some((line) => line.includes("⚠ .claude/rules is incompatible with gstack")));
+assert(auditLogs.some((line) => line.includes("⚠ .claude/rules is incompatible with this setup pipeline")));
 
 const logs = [];
 const originalLog = console.log;
@@ -472,7 +472,7 @@ assert.match(result.stderr, /Unknown setup pipeline: nope\. Available: ecc, gsta
 
 result = runCli(["help"]);
 assert.equal(result.status, 0);
-assert.match(result.stdout, /--setup-pipeline <ecc\|gstack>/);
+assert.match(result.stdout, /--setup-pipeline <ecc\|gstack\|both\|none>/);
 assert.match(result.stdout, /--with-skill <name>/);
 assert.match(result.stdout, /ui-ux-pro-max/);
 assert.match(result.stdout, /impeccable/);
@@ -530,6 +530,9 @@ const gstackSetupTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-
 try {
   result = runCli(["setup", "--target", gstackSetupTarget, "--profile", "minimal", "--setup-pipeline", "gstack", "--yes", "--dry-run"]);
   assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Checking gstack prerequisites/);
+  assert.match(result.stdout, /Cloning gstack|Using existing gstack checkout/);
+  assert.match(result.stdout, /Running gstack setup/);
   assert.match(result.stdout, /\.\/setup/);
   assert.doesNotMatch(result.stdout, /Install ECC inside Claude Code/);
 } finally {
@@ -596,6 +599,18 @@ assert(gitignoreLines.includes(".repo-pattern/"));
 assert(!gitignoreLines.includes(".repo-pattern.json"));
 assert(!gitignoreLines.includes(".repo-pattern.lock.json"));
 assert(gitignoreLines.includes(".claude/"));
+
+const missingBunTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-gstack-missing-bun-"));
+const originalPath = process.env.PATH;
+console.log = () => {};
+try {
+  process.env.PATH = "";
+  await assert.rejects(() => setupGstack({ target: missingBunTarget }), /Bun is required/);
+} finally {
+  process.env.PATH = originalPath;
+  console.log = originalLog;
+  await fs.rm(missingBunTarget, { recursive: true, force: true });
+}
 
 const failedGstackTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-gstack-failed-"));
 console.log = () => {};
@@ -703,6 +718,72 @@ await assert.rejects(
   () => provisionProject({ sourceRoot: repoRoot, target: os.tmpdir(), setupPipeline: "invalid", dryRun: true }),
   /Unknown setup pipeline: invalid/
 );
+
+const bothProvisionTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-both-provision-"));
+console.log = () => {};
+try {
+  process.env.REPO_PATTERN_GSTACK_SETUP_CMD = "true";
+  await provisionProject({
+    sourceRoot: repoRoot,
+    target: bothProvisionTarget,
+    profile: "minimal",
+    setupPipeline: "both",
+    localSettingsEnv: { ANTHROPIC_AUTH_TOKEN: secretSentinel }
+  });
+  const repoConfig = JSON.parse(await fs.readFile(path.join(bothProvisionTarget, ".repo-pattern", ".repo-pattern.json"), "utf8"));
+  const lock = JSON.parse(await fs.readFile(path.join(bothProvisionTarget, ".repo-pattern", ".repo-pattern.lock.json"), "utf8"));
+  const localSettings = JSON.parse(await fs.readFile(path.join(bothProvisionTarget, ".claude", "settings.local.json"), "utf8"));
+  assert.equal(repoConfig.workflow, "ecc-gstack");
+  assert.equal(lock.setupPipeline, "both");
+  assert.equal(lock.ecc.status, "installed");
+  assert.equal(lock.gstack.status, "installed");
+  assert.equal(localSettings.enabledPlugins["ecc@ecc"], true);
+  assert.equal((await auditProject(bothProvisionTarget)).state, "ECC_GSTACK_MINIMAL");
+  await doctorProject(bothProvisionTarget);
+} finally {
+  delete process.env.REPO_PATTERN_GSTACK_SETUP_CMD;
+  console.log = originalLog;
+  await fs.rm(bothProvisionTarget, { recursive: true, force: true });
+}
+
+const noPipelineProvisionTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-none-provision-"));
+console.log = () => {};
+try {
+  await provisionProject({
+    sourceRoot: repoRoot,
+    target: noPipelineProvisionTarget,
+    profile: "minimal",
+    setupPipeline: "none",
+    localSettingsEnv: { ANTHROPIC_AUTH_TOKEN: secretSentinel },
+    applyRules: true
+  });
+  const repoConfig = JSON.parse(await fs.readFile(path.join(noPipelineProvisionTarget, ".repo-pattern", ".repo-pattern.json"), "utf8"));
+  const lock = JSON.parse(await fs.readFile(path.join(noPipelineProvisionTarget, ".repo-pattern", ".repo-pattern.lock.json"), "utf8"));
+  const localSettings = JSON.parse(await fs.readFile(path.join(noPipelineProvisionTarget, ".claude", "settings.local.json"), "utf8"));
+  assert.equal(repoConfig.workflow, "none");
+  assert.equal(lock.setupPipeline, "none");
+  assert.equal("ecc" in lock, false);
+  assert.equal("gstack" in lock, false);
+  assert.equal(localSettings.enabledPlugins["ecc@ecc"], undefined);
+  assert.equal((await auditProject(noPipelineProvisionTarget)).state, "NO_PIPELINE_MINIMAL");
+  await doctorProject(noPipelineProvisionTarget);
+} finally {
+  console.log = originalLog;
+  await fs.rm(noPipelineProvisionTarget, { recursive: true, force: true });
+}
+
+const setupBothDryRunTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-both-dry-run-"));
+try {
+  result = runCli(["setup", "--target", setupBothDryRunTarget, "--setup-pipeline", "both", "--yes", "--dry-run"]);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Setup pipeline\s+both/);
+} finally {
+  await fs.rm(setupBothDryRunTarget, { recursive: true, force: true });
+}
+
+result = runCli(["setup", "--setup-pipeline", "none", "--with-rules", "--yes", "--dry-run"]);
+assert.equal(result.status, 2);
+assert.match(result.stderr, /--with-rules requires --setup-pipeline ecc or both/);
 
 const gstackProvisionTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-gstack-provision-"));
 console.log = () => {};


### PR DESCRIPTION
## Summary
- add setup pipeline modes for ecc, gstack, both, and none across CLI, setup, provision, audit, and doctor
- keep ECC selected by default in interactive setup while allowing checkbox multi-select behavior
- improve gstack setup progress messages and fail early when Bun is missing

## Test plan
- [x] `npm test`
- [x] `npm run pack:dry`
- [x] `git diff --check`
- [x] `node .gitnexus/run.cjs detect-changes --scope unstaged --repo repo-pattern`

🤖 Generated with [Claude Code](https://claude.com/claude-code)