### PR TITLE
chore: tune local Claude defaults

### DIFF
--- a/.claude.example/settings.local.example.json
+++ b/.claude.example/settings.local.example.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
-  "model": "opus",
+  "model": "sonnet",
   "fallbackModel": ["sonnet", "haiku"],
   "effortLevel": "high",
   "alwaysThinkingEnabled": true,
@@ -26,6 +26,8 @@
     "ENABLE_TOOL_SEARCH": "auto:5",
     "CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION": "4",
     "CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY": "2",
+    "MAX_THINKING_TOKENS": "10000",
+    "CLAUDE_CODE_SUBAGENT_MODEL": "haiku",
     "ANTHROPIC_BASE_URL": "https://example.com/v1",
     "ANTHROPIC_DEFAULT_OPUS_MODEL": "claude-opus-4-8",
     "ANTHROPIC_DEFAULT_SONNET_MODEL": "claude-sonnet-4-6",

--- a/scripts/self-check.mjs
+++ b/scripts/self-check.mjs
@@ -838,7 +838,8 @@ try {
     localSettingsEnv: {
       ANTHROPIC_BASE_URL: "https://example.com/v1",
       ANTHROPIC_AUTH_TOKEN: secretSentinel,
-      CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION: "7"
+      CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION: "7",
+      MAX_THINKING_TOKENS: "9000"
     },
     permissionConfig: { bypass: "allow" }
   });
@@ -853,9 +854,12 @@ try {
   assert.equal((await fs.stat(mcpConfigPath)).mode & 0o777, 0o600);
   assert.equal(localSettings.env.ANTHROPIC_AUTH_TOKEN, secretSentinel);
   assert.equal(localSettings.env.ANTHROPIC_BASE_URL, "https://example.com/v1");
+  assert.equal(localSettings.model, "sonnet");
   assert.equal(localSettings.workflowSizeGuideline, "small");
   assert.equal(localSettings.env.CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION, "7");
   assert.equal(localSettings.env.CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY, "2");
+  assert.equal(localSettings.env.MAX_THINKING_TOKENS, "9000");
+  assert.equal(localSettings.env.CLAUDE_CODE_SUBAGENT_MODEL, "haiku");
   assert.equal("workflowSizeGuideline" in localSettings.env, false);
   assert.equal(settings.permissions.defaultMode, "bypassPermissions");
   assert.equal("disableBypassPermissionsMode" in settings.permissions, false);
@@ -1082,13 +1086,18 @@ try {
   assert.equal(settings.permissions.defaultMode, "default");
   assert.equal(settings.permissions.disableBypassPermissionsMode, "disable");
   const localSettings = JSON.parse(await fs.readFile(path.join(defaultProvisionTarget, ".claude", "settings.local.json"), "utf8"));
+  assert.equal(localSettings.model, "sonnet");
   assert.equal(localSettings.workflowSizeGuideline, "small");
   assert.deepEqual({
     CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION: localSettings.env.CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION,
-    CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY: localSettings.env.CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY
+    CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY: localSettings.env.CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY,
+    MAX_THINKING_TOKENS: localSettings.env.MAX_THINKING_TOKENS,
+    CLAUDE_CODE_SUBAGENT_MODEL: localSettings.env.CLAUDE_CODE_SUBAGENT_MODEL
   }, {
     CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION: "4",
-    CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY: "2"
+    CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY: "2",
+    MAX_THINKING_TOKENS: "10000",
+    CLAUDE_CODE_SUBAGENT_MODEL: "haiku"
   });
   assert.equal("workflowSizeGuideline" in localSettings.env, false);
   await updateClaudePermissions({ sourceRoot: repoRoot, target: defaultProvisionTarget, permissionConfig: { bypass: "allow" } });


### PR DESCRIPTION
## Summary
- set the default local Claude model to sonnet
- add MAX_THINKING_TOKENS and CLAUDE_CODE_SUBAGENT_MODEL defaults
- verify setup preserves explicit overrides while carrying the new defaults forward

## Test plan
- [x] `npm test`
- [x] `npm run pack:dry`
- [x] `git diff --check`
- [x] `node .gitnexus/run.cjs detect-changes --scope all --repo repo-pattern`

🤖 Generated with [Claude Code](https://claude.com/claude-code)