### PR TITLE
feat: install Bun for gstack setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ npx repo-pattern setup --profile web --setup-pipeline ecc --yes
 npx repo-pattern setup --profile web --setup-pipeline gstack --yes
 ```
 
-ECC remains the default. gstack setup uses its upstream global checkout at `~/.claude/skills/gstack` and requires Git and Bun v1.0+. On Windows, it also requires Node.js and Git Bash or WSL.
+ECC remains the default. gstack setup uses its upstream global checkout at `~/.claude/skills/gstack` and requires Git and Bun v1.0+. When Bun is missing on Linux or macOS, setup downloads the official installer over TLS, validates it, and installs Bun automatically. On unsupported systems, install Bun manually before setup.
 
 Migrate an existing project:
 

--- a/docs/repo-pattern/setup-guide.md
+++ b/docs/repo-pattern/setup-guide.md
@@ -15,7 +15,7 @@ node scripts/repo-pattern.mjs setup --target /path/to/project --profile web --se
 node scripts/repo-pattern.mjs setup --target /path/to/project --profile web --setup-pipeline gstack --yes
 ```
 
-ECC is the default. gstack uses its upstream global installer at `~/.claude/skills/gstack` and requires Git and Bun v1.0+. On Windows, it also requires Node.js and Git Bash or WSL.
+ECC is the default. gstack uses its upstream global installer at `~/.claude/skills/gstack` and requires Git and Bun v1.0+. When Bun is missing on Linux or macOS, setup downloads the official installer over TLS, validates it, and installs Bun automatically. On unsupported systems, install Bun manually before setup.
 
 Use this when you want to initialize a new project with:
 

--- a/scripts/lib/gstack.mjs
+++ b/scripts/lib/gstack.mjs
@@ -1,4 +1,5 @@
 import { execFileSync, execSync } from "node:child_process";
+import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { appendGitignoreLine, ensureDir, exists, isTracked, writePrivateJson } from "./fs-utils.mjs";
@@ -6,6 +7,67 @@ import { printSummary } from "./prompt.mjs";
 
 const GSTACK_REPOSITORY = "https://github.com/garrytan/gstack.git";
 const GSTACK_DIR = path.join(os.homedir(), ".claude", "skills", "gstack");
+const BUN_INSTALLER_URL = "https://bun.sh/install";
+const BUN_INSTALLER_MAX_BYTES = 1024 * 1024;
+const BUN_INSTALLER_MARKERS = ["#!/usr/bin/env bash", "BUN_INSTALL", "github.com/oven-sh/bun/releases"];
+
+function run(command, args, options = {}) {
+  return execFileSync(command, args, { encoding: "utf8", ...options });
+}
+
+function parseBunVersion(output) {
+  const match = String(output).trim().match(/^(\d+)\.(\d+)\.(\d+)/);
+  if (!match || Number(match[1]) < 1) throw new Error(`Bun v1.0+ is required; found ${String(output).trim() || "an invalid version"}.`);
+}
+
+function checkedBun(command, runCommand) {
+  const version = runCommand(command, ["--version"], { stdio: ["ignore", "pipe", "pipe"] });
+  parseBunVersion(version);
+  return command;
+}
+
+export async function ensureBun({
+  platform = process.platform,
+  homedir = os.homedir(),
+  tmpdir = os.tmpdir(),
+  run: runCommand = run,
+  mkdtemp = fs.mkdtemp,
+  readFile = fs.readFile,
+  rm = fs.rm
+} = {}) {
+  try {
+    return checkedBun("bun", runCommand);
+  } catch (error) {
+    if (error.code !== "ENOENT") throw new Error(`Bun validation failed: ${error.message}`);
+  }
+
+  if (!["linux", "darwin"].includes(platform)) {
+    throw new Error(`Bun is missing; automatic Bun installation is supported only on Linux and macOS. Install Bun v1.0+ manually on ${platform} and rerun setup.`);
+  }
+
+  console.log("Installing Bun");
+  const installerDir = await mkdtemp(path.join(tmpdir, "repo-pattern-bun-"));
+  const installer = path.join(installerDir, "install.sh");
+  try {
+    runCommand("curl", [
+      "--fail", "--show-error", "--silent", "--location",
+      "--proto", "=https", "--proto-redir", "=https", "--tlsv1.2",
+      "--max-filesize", String(BUN_INSTALLER_MAX_BYTES), "--output", installer,
+      BUN_INSTALLER_URL
+    ], { stdio: "inherit" });
+    const source = await readFile(installer);
+    if (source.length === 0 || source.length > BUN_INSTALLER_MAX_BYTES || !BUN_INSTALLER_MARKERS.every((marker) => source.includes(marker))) {
+      throw new Error("Downloaded Bun installer failed content validation; it was not executed.");
+    }
+    runCommand("bash", ["-n", installer], { stdio: "ignore" });
+    runCommand("bash", [installer], { stdio: "inherit" });
+    return checkedBun(path.join(homedir, ".bun", "bin", "bun"), runCommand);
+  } catch (error) {
+    throw new Error(`Automatic Bun installation failed: ${error.message} Install Bun v1.0+ from https://bun.sh/docs/installation and rerun setup.`);
+  } finally {
+    await rm(installerDir, { recursive: true, force: true });
+  }
+}
 
 function withoutEccPlugin(settings = {}) {
   const enabledPlugins = { ...(settings.enabledPlugins || {}) };
@@ -26,14 +88,6 @@ function validateGstackCheckout() {
   return true;
 }
 
-function requireBun() {
-  try {
-    execFileSync("bun", ["--version"], { stdio: "ignore" });
-  } catch {
-    throw new Error("Bun is required for gstack setup. Install Bun v1.0+ and rerun setup.");
-  }
-}
-
 export async function removeEccPluginSettings({ target, dryRun = false }) {
   if (isTracked(target, ".claude/settings.local.json")) throw new Error(".claude/settings.local.json is tracked. Untrack it before writing local plugin settings.");
   await writePrivateJson(path.join(target, ".claude", "settings.local.json"), withoutEccPlugin, {
@@ -42,6 +96,11 @@ export async function removeEccPluginSettings({ target, dryRun = false }) {
     parentLabel: ".claude"
   });
   await appendGitignoreLine(target, ".claude/", { dryRun });
+}
+
+export function gstackEnvironment(bun, environment = process.env) {
+  if (!path.isAbsolute(bun)) return { ...environment };
+  return { ...environment, PATH: `${path.dirname(bun)}${path.delimiter}${environment.PATH || ""}` };
 }
 
 export async function setupGstack({ target, dryRun = false }) {
@@ -74,7 +133,7 @@ export async function setupGstack({ target, dryRun = false }) {
     status = "dry-run";
   } else {
     console.log("Checking gstack prerequisites");
-    requireBun();
+    const bun = await ensureBun();
     if (!validateGstackCheckout()) {
       console.log("Cloning gstack");
       await ensureDir(path.dirname(GSTACK_DIR));
@@ -83,7 +142,11 @@ export async function setupGstack({ target, dryRun = false }) {
       console.log("Using existing gstack checkout");
     }
     console.log("Running gstack setup");
-    execFileSync(process.platform === "win32" ? "bash" : "./setup", process.platform === "win32" ? ["./setup"] : [], { cwd: GSTACK_DIR, stdio: "inherit" });
+    execFileSync(process.platform === "win32" ? "bash" : "./setup", process.platform === "win32" ? ["./setup"] : [], {
+      cwd: GSTACK_DIR,
+      stdio: "inherit",
+      env: gstackEnvironment(bun)
+    });
     printSummary("gstack", [["Status", "installed for Claude Code"]]);
   }
 

--- a/scripts/self-check.mjs
+++ b/scripts/self-check.mjs
@@ -8,7 +8,7 @@ import { auditProject, printAudit } from "./lib/audit.mjs";
 import { cleanupProject } from "./lib/cleanup.mjs";
 import { doctorProject } from "./lib/doctor.mjs";
 import { applyEccPluginSettings, setupEcc } from "./lib/ecc.mjs";
-import { removeEccPluginSettings, setupGstack } from "./lib/gstack.mjs";
+import { ensureBun, gstackEnvironment, removeEccPluginSettings, setupGstack } from "./lib/gstack.mjs";
 import { applyMcpValues, generateMcp, mcpSecretPrompt, persistedMcpValues, readGeneratedMcpValues, validateRelativeMcpPath } from "./lib/mcp.mjs";
 import { applyAttributionSetting, applyLocalSettings, applyPermissionSettings, provisionProject, updateClaudePermissions } from "./lib/provision.mjs";
 import { writePrivateJson } from "./lib/fs-utils.mjs";
@@ -600,17 +600,47 @@ assert(!gitignoreLines.includes(".repo-pattern.json"));
 assert(!gitignoreLines.includes(".repo-pattern.lock.json"));
 assert(gitignoreLines.includes(".claude/"));
 
-const missingBunTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-gstack-missing-bun-"));
-const originalPath = process.env.PATH;
-console.log = () => {};
-try {
-  process.env.PATH = "";
-  await assert.rejects(() => setupGstack({ target: missingBunTarget }), /Bun is required/);
-} finally {
-  process.env.PATH = originalPath;
-  console.log = originalLog;
-  await fs.rm(missingBunTarget, { recursive: true, force: true });
-}
+assert.deepEqual(gstackEnvironment("bun", { PATH: "/usr/bin" }), { PATH: "/usr/bin" });
+assert.deepEqual(gstackEnvironment("/home/test/.bun/bin/bun", { PATH: "/usr/bin" }), { PATH: `/home/test/.bun/bin${path.delimiter}/usr/bin` });
+
+const bunInstallCommands = [];
+let bunCheckCount = 0;
+let removedBunInstaller = false;
+const installedBun = await ensureBun({
+  platform: "linux",
+  homedir: "/home/test",
+  tmpdir: "/tmp",
+  run(command, args, options) {
+    bunInstallCommands.push({ command, args, options });
+    if (command === "bun" && bunCheckCount++ === 0) throw Object.assign(new Error("missing"), { code: "ENOENT" });
+    if (command === "/home/test/.bun/bin/bun") return "1.2.0\n";
+    return "";
+  },
+  mkdtemp: async () => "/tmp/repo-pattern-bun-installer",
+  readFile: async () => Buffer.from("#!/usr/bin/env bash\nBUN_INSTALL=\"${BUN_INSTALL:-$HOME/.bun}\"\nhttps://github.com/oven-sh/bun/releases\n"),
+  rm: async () => { removedBunInstaller = true; }
+});
+assert.equal(installedBun, "/home/test/.bun/bin/bun");
+assert.deepEqual(bunInstallCommands[1].args, [
+  "--fail", "--show-error", "--silent", "--location",
+  "--proto", "=https", "--proto-redir", "=https", "--tlsv1.2",
+  "--max-filesize", "1048576", "--output", "/tmp/repo-pattern-bun-installer/install.sh",
+  "https://bun.sh/install"
+]);
+assert.deepEqual(bunInstallCommands[2].args, ["-n", "/tmp/repo-pattern-bun-installer/install.sh"]);
+assert.deepEqual(bunInstallCommands[3].args, ["/tmp/repo-pattern-bun-installer/install.sh"]);
+assert.equal(removedBunInstaller, true);
+await assert.rejects(() => ensureBun({ platform: "win32", run: () => { throw Object.assign(new Error("missing"), { code: "ENOENT" }); } }), /automatic Bun installation is supported only on Linux and macOS/);
+await assert.rejects(() => ensureBun({
+  platform: "linux",
+  run(command) {
+    if (command === "bun") throw Object.assign(new Error("missing"), { code: "ENOENT" });
+    return "";
+  },
+  mkdtemp: async () => "/tmp/repo-pattern-invalid-bun-installer",
+  readFile: async () => Buffer.from("not Bun"),
+  rm: async () => {}
+}), /failed content validation/);
 
 const failedGstackTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-gstack-failed-"));
 console.log = () => {};


### PR DESCRIPTION
## Summary
- install Bun automatically on Linux and macOS when gstack setup needs it
- validate the installer before execution and verify Bun v1.0+ afterward
- preserve the validated Bun path for the gstack installer and document unsupported-system behavior

## Test plan
- [x] npm test
- [x] npm run pack:dry
- [x] git diff --check

🤖 Generated with [Claude Code](https://claude.com/claude-code)