### PR TITLE
fix: secure global gstack setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,14 @@ npx repo-pattern setup --profile web --setup-pipeline ecc --yes
 npx repo-pattern setup --profile web --setup-pipeline gstack --yes
 ```
 
-ECC remains the default. gstack setup uses its upstream global checkout at `~/.claude/skills/gstack` and requires Git and Bun v1.0+. When Bun is missing on Linux or macOS, setup downloads the official installer over TLS, validates it, and installs Bun automatically. On unsupported systems, install Bun manually before setup.
+Pipeline scope is explicit:
+
+- `ecc` (default) — project-scoped ECC.
+- `gstack` — user-scoped/global gstack at `~/.claude/skills/gstack`.
+- `both` — project-scoped ECC plus user-scoped/global gstack.
+- `none` — base project metadata only.
+
+gstack requires Git and Bun v1.0+. When Bun is missing on Linux or macOS, setup downloads the official installer over TLS, validates it, and installs Bun automatically. On unsupported systems, install Bun manually before setup. Its upstream setup runs with `--quiet --no-plan-tune-hooks`, so automated setup does not show settings diffs or wait for hook confirmation.
 
 Migrate an existing project:
 
@@ -76,7 +83,7 @@ Common options:
 ```bash
 --target /path/to/project  # default: current directory
 --profile web              # default MCP profile
---setup-pipeline ecc        # ecc (default) or gstack
+--setup-pipeline ecc        # ecc (default), gstack, both, or none
 --with-rules               # opt in to .claude/rules/ecc; ECC only
 --with-skill ui-ux-pro-max # optional UI/UX skill; requires Python 3.x
 --with-skills nextjs-pattern,fastapi-pattern # optional framework pattern skills

--- a/docs/repo-pattern/setup-guide.md
+++ b/docs/repo-pattern/setup-guide.md
@@ -15,7 +15,14 @@ node scripts/repo-pattern.mjs setup --target /path/to/project --profile web --se
 node scripts/repo-pattern.mjs setup --target /path/to/project --profile web --setup-pipeline gstack --yes
 ```
 
-ECC is the default. gstack uses its upstream global installer at `~/.claude/skills/gstack` and requires Git and Bun v1.0+. When Bun is missing on Linux or macOS, setup downloads the official installer over TLS, validates it, and installs Bun automatically. On unsupported systems, install Bun manually before setup.
+Pipeline scope is explicit:
+
+- `ecc` (default) — project-scoped ECC.
+- `gstack` — user-scoped/global gstack at `~/.claude/skills/gstack`.
+- `both` — project-scoped ECC plus user-scoped/global gstack.
+- `none` — base project metadata only.
+
+gstack requires Git and Bun v1.0+. When Bun is missing on Linux or macOS, setup downloads the official installer over TLS, validates it, and installs Bun automatically. On unsupported systems, install Bun manually before setup. Its upstream setup runs with `--quiet --no-plan-tune-hooks`, preventing settings diff previews and hook confirmation waits during automated setup. Routine upstream logs are suppressed; failures report a bounded, secret-redacted diagnostic summary.
 
 Use this when you want to initialize a new project with:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@negikirin/repo-pattern",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Minimal ECC-first Claude Code project setup and migrator",
   "type": "module",
   "bin": {

--- a/scripts/lib/gstack.mjs
+++ b/scripts/lib/gstack.mjs
@@ -10,6 +10,9 @@ const GSTACK_DIR = path.join(os.homedir(), ".claude", "skills", "gstack");
 const BUN_INSTALLER_URL = "https://bun.sh/install";
 const BUN_INSTALLER_MAX_BYTES = 1024 * 1024;
 const BUN_INSTALLER_MARKERS = ["#!/usr/bin/env bash", "BUN_INSTALL", "github.com/oven-sh/bun/releases"];
+const GSTACK_SETUP_ARGS = ["--quiet", "--no-plan-tune-hooks"];
+const GSTACK_DIAGNOSTIC_MAX_CHARS = 4000;
+const GSTACK_SETUP_MAX_BUFFER = 16 * 1024 * 1024;
 
 function run(command, args, options = {}) {
   return execFileSync(command, args, { encoding: "utf8", ...options });
@@ -103,6 +106,49 @@ export function gstackEnvironment(bun, environment = process.env) {
   return { ...environment, PATH: `${path.dirname(bun)}${path.delimiter}${environment.PATH || ""}` };
 }
 
+function redactedGstackDiagnostic(error) {
+  const output = [error.stderr, error.stdout]
+    .map((value) => String(value || "").slice(-65536))
+    .join("\n");
+  const diagnostics = [
+    "Upstream output: [redacted].",
+    ...(Number.isInteger(error.status) ? [`Exit code: ${error.status}.`] : []),
+    ...(/\b(?:bun)\b/i.test(output) ? ["Bun prerequisite or installation failed."] : []),
+    ...(/\b(?:git|clone|checkout)\b/i.test(output) ? ["Git checkout or repository operation failed."] : []),
+    ...(/\b(?:network|download|fetch|connection|dns|tls|certificate)\b/i.test(output) ? ["Network or download operation failed."] : []),
+    ...(/\b(?:permission|denied|access)\b/i.test(output) ? ["Permission or access check failed."] : []),
+    ...(/\b(?:missing|required|not found|prerequisite)\b/i.test(output) ? ["A required prerequisite is missing or invalid."] : []),
+    ...(/\b(?:unsupported)\b/i.test(output) ? ["The current environment is unsupported."] : []),
+    ...(/\b(?:settings?|hooks?)\b/i.test(output) ? ["Claude Code settings or hook setup failed."] : []),
+    ...(/\b(?:error|fatal|fail(?:ed|ure)?)\b/i.test(output) ? ["Upstream reported a setup failure."] : []),
+    ...(/\b(?:retry|rerun)\b/i.test(output) ? ["Correct the reported prerequisite and rerun setup."] : [])
+  ];
+  const summary = diagnostics.length > 0 ? diagnostics.join("\n") : "No safe upstream diagnostic was available.";
+  return summary.slice(0, GSTACK_DIAGNOSTIC_MAX_CHARS);
+}
+
+export function runGstackSetup({
+  platform = process.platform,
+  bun,
+  run: runCommand = run,
+  log = console.error
+}) {
+  const command = platform === "win32" ? "bash" : "./setup";
+  const args = platform === "win32" ? ["./setup", ...GSTACK_SETUP_ARGS] : GSTACK_SETUP_ARGS;
+  try {
+    runCommand(command, args, {
+      cwd: GSTACK_DIR,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: gstackEnvironment(bun),
+      maxBuffer: GSTACK_SETUP_MAX_BUFFER
+    });
+  } catch (error) {
+    log("gstack setup diagnostics (redacted):");
+    log(redactedGstackDiagnostic(error));
+    throw new Error("gstack setup failed; review the diagnostics above and rerun setup.");
+  }
+}
+
 export async function setupGstack({ target, dryRun = false }) {
   if (isTracked(target, ".claude/settings.local.json")) throw new Error(".claude/settings.local.json is tracked. Untrack it before writing local plugin settings.");
 
@@ -129,7 +175,7 @@ export async function setupGstack({ target, dryRun = false }) {
       console.log("Using existing gstack checkout");
     }
     console.log("Running gstack setup");
-    console.log(`[dry-run] cd ${GSTACK_DIR} && ./setup`);
+    console.log(`[dry-run] cd ${GSTACK_DIR} && ./setup ${GSTACK_SETUP_ARGS.join(" ")}`);
     status = "dry-run";
   } else {
     console.log("Checking gstack prerequisites");
@@ -142,12 +188,8 @@ export async function setupGstack({ target, dryRun = false }) {
       console.log("Using existing gstack checkout");
     }
     console.log("Running gstack setup");
-    execFileSync(process.platform === "win32" ? "bash" : "./setup", process.platform === "win32" ? ["./setup"] : [], {
-      cwd: GSTACK_DIR,
-      stdio: "inherit",
-      env: gstackEnvironment(bun)
-    });
-    printSummary("gstack", [["Status", "installed for Claude Code"]]);
+    runGstackSetup({ bun });
+    printSummary("gstack", [["Status", "installed globally for Claude Code"]]);
   }
 
   return status;

--- a/scripts/lib/provision.mjs
+++ b/scripts/lib/provision.mjs
@@ -28,6 +28,15 @@ function usesGstack(setupPipeline) {
   return setupPipeline === "gstack" || setupPipeline === "both";
 }
 
+export function setupPipelineScope(setupPipeline) {
+  return {
+    ecc: "project-scoped ECC",
+    gstack: "user-scoped/global gstack at ~/.claude/skills/gstack",
+    both: "project-scoped ECC + user-scoped/global gstack at ~/.claude/skills/gstack",
+    none: "writes only base project metadata"
+  }[setupPipeline];
+}
+
 function workflowName(setupPipeline) {
   return {
     ecc: "ecc-native",
@@ -257,6 +266,7 @@ export async function provisionProject({ sourceRoot, target, profile = "web", se
     ["Status", dryRun ? `preview only; ${pendingText}` : pendingText],
     ["Target", target],
     ["Setup pipeline", setupPipeline],
+    ["Pipeline scope", setupPipelineScope(setupPipeline)],
     ["Profile", profile],
     [dryRun ? "Would write" : "Written", `CLAUDE.md (if missing), .claude/, .mcp.json, .repo-pattern/.repo-pattern.json, .repo-pattern/.repo-pattern.lock.json${optionalSkills.length ? ", optional skill/plugin config" : ""}`],
     ["Doctor", dryRun ? "skipped (dry-run)" : style("success", "passed")],

--- a/scripts/lib/setup.mjs
+++ b/scripts/lib/setup.mjs
@@ -3,7 +3,7 @@ import path from "node:path";
 import { promisify } from "node:util";
 import { auditProject, printAudit } from "./audit.mjs";
 import { detectProject } from "./project-detect.mjs";
-import { provisionProject, updateClaudeAttribution, updateClaudePermissions } from "./provision.mjs";
+import { provisionProject, setupPipelineScope, updateClaudeAttribution, updateClaudePermissions } from "./provision.mjs";
 import { doctorProject } from "./doctor.mjs";
 import { collectMcpValues, generateMcp, listAvailableMcpServers, persistedMcpValues, readGeneratedMcpValues, readMcpConfig } from "./mcp.mjs";
 import { askConfirm, askPassword, askText, isInteractive, printBox, printLogo, printSummary, selectMany, selectOne, style } from "./prompt.mjs";
@@ -211,8 +211,8 @@ async function chooseSetupPipeline(initialValue = "ecc") {
   return selectedPipeline(await selectMany({
     message: "Choose setup pipeline",
     options: [
-      { value: "ecc", label: "ECC", description: "Claude Code plugin with optional project rules" },
-      { value: "gstack", label: "gstack", description: "global skills install; requires Git and Bun" }
+      { value: "ecc", label: "ECC", description: "project-scoped plugin with optional project rules" },
+      { value: "gstack", label: "gstack", description: "user-scoped/global at ~/.claude/skills/gstack; requires Git and Bun" }
     ],
     initialValues: pipelineValues(initialValue)
   }));
@@ -311,6 +311,7 @@ async function confirmSummary({ action, setupPipeline, target, mcpConfig, mcpVal
   printSummary("Setup summary", [
     ["Action", action],
     ["Setup pipeline", setupPipeline],
+    ["Pipeline scope", setupPipelineScope(setupPipeline)],
     ["Target", target],
     ["Profile", mcpConfig.profile],
     ["MCP servers", mcpConfig.mcpServers?.join(", ") || "from profile"],

--- a/scripts/repo-pattern.mjs
+++ b/scripts/repo-pattern.mjs
@@ -117,6 +117,10 @@ Options:
   --profile <name>                 MCP profile for scriptable commands. Default: web
   --setup-pipeline <ecc|gstack|both|none>
                                   Setup pipeline. Default: ecc
+                                  ecc: project-scoped ECC
+                                  gstack: user-scoped/global at ~/.claude/skills/gstack
+                                  both: project-scoped ECC + user-scoped/global gstack
+                                  none: base project metadata only
 
 Setup UI:
   setup uses ↑/↓ to move, Space to toggle MCP/rules choices, Enter to confirm, Esc/Ctrl+C to cancel

--- a/scripts/self-check.mjs
+++ b/scripts/self-check.mjs
@@ -8,9 +8,9 @@ import { auditProject, printAudit } from "./lib/audit.mjs";
 import { cleanupProject } from "./lib/cleanup.mjs";
 import { doctorProject } from "./lib/doctor.mjs";
 import { applyEccPluginSettings, setupEcc } from "./lib/ecc.mjs";
-import { ensureBun, gstackEnvironment, removeEccPluginSettings, setupGstack } from "./lib/gstack.mjs";
+import { ensureBun, gstackEnvironment, removeEccPluginSettings, runGstackSetup, setupGstack } from "./lib/gstack.mjs";
 import { applyMcpValues, generateMcp, mcpSecretPrompt, persistedMcpValues, readGeneratedMcpValues, validateRelativeMcpPath } from "./lib/mcp.mjs";
-import { applyAttributionSetting, applyLocalSettings, applyPermissionSettings, provisionProject, updateClaudePermissions } from "./lib/provision.mjs";
+import { applyAttributionSetting, applyLocalSettings, applyPermissionSettings, provisionProject, setupPipelineScope, updateClaudePermissions } from "./lib/provision.mjs";
 import { writePrivateJson } from "./lib/fs-utils.mjs";
 import { printSummary, renderLogo, style } from "./lib/prompt.mjs";
 import { needsLocalSettingsPrompt, setupProject, setupRetryOptions } from "./lib/setup.mjs";
@@ -151,6 +151,17 @@ assert.deepEqual(setupRetryOptions({
   attributionConfig: { mode: "off" },
   permissionConfig: { bypass: "deny" },
   dryRun: false
+});
+assert.deepEqual({
+  ecc: setupPipelineScope("ecc"),
+  gstack: setupPipelineScope("gstack"),
+  both: setupPipelineScope("both"),
+  none: setupPipelineScope("none")
+}, {
+  ecc: "project-scoped ECC",
+  gstack: "user-scoped/global gstack at ~/.claude/skills/gstack",
+  both: "project-scoped ECC + user-scoped/global gstack at ~/.claude/skills/gstack",
+  none: "writes only base project metadata"
 });
 assert.equal(needsLocalSettingsPrompt({ ANTHROPIC_BASE_URL: "https://example.com/v1" }), true);
 assert.equal(needsLocalSettingsPrompt({
@@ -473,6 +484,10 @@ assert.match(result.stderr, /Unknown setup pipeline: nope\. Available: ecc, gsta
 result = runCli(["help"]);
 assert.equal(result.status, 0);
 assert.match(result.stdout, /--setup-pipeline <ecc\|gstack\|both\|none>/);
+assert.match(result.stdout, /ecc: project-scoped ECC/);
+assert.match(result.stdout, /gstack: user-scoped\/global at ~\/\.claude\/skills\/gstack/);
+assert.match(result.stdout, /both: project-scoped ECC \+ user-scoped\/global gstack/);
+assert.match(result.stdout, /none: base project metadata only/);
 assert.match(result.stdout, /--with-skill <name>/);
 assert.match(result.stdout, /ui-ux-pro-max/);
 assert.match(result.stdout, /impeccable/);
@@ -533,7 +548,8 @@ try {
   assert.match(result.stdout, /Checking gstack prerequisites/);
   assert.match(result.stdout, /Cloning gstack|Using existing gstack checkout/);
   assert.match(result.stdout, /Running gstack setup/);
-  assert.match(result.stdout, /\.\/setup/);
+  assert.match(result.stdout, /\.\/setup --quiet --no-plan-tune-hooks/);
+  assert.match(result.stdout, /Pipeline scope\s+user-scoped\/global gstack at ~\/\.claude\/skills\/gstack/);
   assert.doesNotMatch(result.stdout, /Install ECC inside Claude Code/);
 } finally {
   await fs.rm(gstackSetupTarget, { recursive: true, force: true });
@@ -602,6 +618,46 @@ assert(gitignoreLines.includes(".claude/"));
 
 assert.deepEqual(gstackEnvironment("bun", { PATH: "/usr/bin" }), { PATH: "/usr/bin" });
 assert.deepEqual(gstackEnvironment("/home/test/.bun/bin/bun", { PATH: "/usr/bin" }), { PATH: `/home/test/.bun/bin${path.delimiter}/usr/bin` });
+
+const gstackSetupCalls = [];
+const gstackSetupLogs = [];
+runGstackSetup({
+  platform: "linux",
+  bun: "bun",
+  run(command, args, options) {
+    gstackSetupCalls.push({ command, args, options });
+    return "generated skill output\ninstallation detail\n";
+  },
+  log: (message) => gstackSetupLogs.push(message)
+});
+assert.deepEqual(gstackSetupCalls[0].args, ["--quiet", "--no-plan-tune-hooks"]);
+assert.deepEqual(gstackSetupCalls[0].options.stdio, ["ignore", "pipe", "pipe"]);
+assert.deepEqual(gstackSetupLogs, []);
+
+const gstackCredentialFixture = ["example", "credential", "value"].join("-");
+const gstackFailure = Object.assign(new Error("setup failed"), {
+  stdout: Buffer.from("routine output\n"),
+  stderr: Buffer.from(`${"warning: repeated diagnostic line\n".repeat(300)}fatal: setup could not complete\nAuthorization: Bearer ${gstackCredentialFixture}\nAPI_TOKEN=${gstackCredentialFixture}\ncorrect the prerequisite and retry\n`)
+});
+let gstackFailureLog = "";
+assert.throws(() => runGstackSetup({
+  platform: "win32",
+  bun: "bun",
+  run(command, args) {
+    assert.equal(command, "bash");
+    assert.deepEqual(args, ["./setup", "--quiet", "--no-plan-tune-hooks"]);
+    throw gstackFailure;
+  },
+  log: (message) => { gstackFailureLog += `${message}\n`; }
+}), /gstack setup failed; review the diagnostics above and rerun setup/);
+assert.match(gstackFailureLog, /Upstream reported a setup failure/);
+assert.match(gstackFailureLog, /A required prerequisite is missing or invalid/);
+assert.match(gstackFailureLog, /Correct the reported prerequisite and rerun setup/);
+assert.match(gstackFailureLog, /Upstream output: \[redacted\]/);
+assert.doesNotMatch(gstackFailureLog, /routine output/);
+assert.doesNotMatch(gstackFailureLog, /fatal: setup could not complete/);
+assert.doesNotMatch(gstackFailureLog, new RegExp(gstackCredentialFixture));
+assert(gstackFailureLog.length <= 4200);
 
 const bunInstallCommands = [];
 let bunCheckCount = 0;
@@ -807,6 +863,7 @@ try {
   result = runCli(["setup", "--target", setupBothDryRunTarget, "--setup-pipeline", "both", "--yes", "--dry-run"]);
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /Setup pipeline\s+both/);
+  assert.match(result.stdout, /Pipeline scope\s+project-scoped ECC \+ user-scoped\/global gstack at\s+~\/\.claude\/skills\/gstack/);
 } finally {
   await fs.rm(setupBothDryRunTarget, { recursive: true, force: true });
 }


### PR DESCRIPTION
## Summary
- label ECC and gstack setup scopes across the setup UI, summaries, help, and documentation
- run global gstack setup quietly without plan-tune hook prompts or settings diffs
- redact and bound upstream setup diagnostics while retaining actionable categories
- release @negikirin/repo-pattern v0.1.14

## Test plan
- [x] npm test
- [x] npm run pack:dry
- [x] git diff --check
- [x] GitNexus detect_changes (LOW risk, 0 affected processes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)