### PR TITLE
fix: improve gstack setup flow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@negikirin/repo-pattern",
-  "version": "0.1.10",
+  "version": "0.1.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@negikirin/repo-pattern",
-      "version": "0.1.10",
+      "version": "0.1.16",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^0.11.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@negikirin/repo-pattern",
-  "version": "0.1.14",
+  "version": "0.1.16",
   "description": "Minimal ECC-first Claude Code project setup and migrator",
   "type": "module",
   "bin": {

--- a/scripts/lib/gstack.mjs
+++ b/scripts/lib/gstack.mjs
@@ -3,13 +3,23 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { appendGitignoreLine, ensureDir, exists, isTracked, writePrivateJson } from "./fs-utils.mjs";
-import { printSummary } from "./prompt.mjs";
+import { isInteractive, printSummary, withSpinner } from "./prompt.mjs";
 
 const GSTACK_REPOSITORY = "https://github.com/garrytan/gstack.git";
 const GSTACK_DIR = path.join(os.homedir(), ".claude", "skills", "gstack");
 const BUN_INSTALLER_URL = "https://bun.sh/install";
+const BUN_INSTALLER_MIN_BYTES = 1024;
 const BUN_INSTALLER_MAX_BYTES = 1024 * 1024;
-const BUN_INSTALLER_MARKERS = ["#!/usr/bin/env bash", "BUN_INSTALL", "github.com/oven-sh/bun/releases"];
+const BUN_INSTALLER_MARKERS = ["#!/usr/bin/env bash", "set -euo pipefail", "install_env=BUN_INSTALL", "github_repo=\"$GITHUB/oven-sh/bun\"", "bun_uri=$github_repo/releases/latest/download/bun-$target.zip"];
+
+export function isValidBunInstaller(source) {
+  const text = Buffer.isBuffer(source) ? source.toString("utf8") : String(source);
+  return source.length >= BUN_INSTALLER_MIN_BYTES &&
+    source.length <= BUN_INSTALLER_MAX_BYTES &&
+    text.startsWith("#!/usr/bin/env bash\n") &&
+    !text.includes("\0") &&
+    BUN_INSTALLER_MARKERS.every((marker) => text.includes(marker));
+}
 const GSTACK_SETUP_ARGS = ["--quiet", "--no-plan-tune-hooks"];
 const GSTACK_DIAGNOSTIC_MAX_CHARS = 4000;
 const GSTACK_SETUP_MAX_BUFFER = 16 * 1024 * 1024;
@@ -59,7 +69,7 @@ export async function ensureBun({
       BUN_INSTALLER_URL
     ], { stdio: "inherit" });
     const source = await readFile(installer);
-    if (source.length === 0 || source.length > BUN_INSTALLER_MAX_BYTES || !BUN_INSTALLER_MARKERS.every((marker) => source.includes(marker))) {
+    if (!isValidBunInstaller(source)) {
       throw new Error("Downloaded Bun installer failed content validation; it was not executed.");
     }
     runCommand("bash", ["-n", installer], { stdio: "ignore" });
@@ -127,6 +137,10 @@ function redactedGstackDiagnostic(error) {
   return summary.slice(0, GSTACK_DIAGNOSTIC_MAX_CHARS);
 }
 
+export function gstackSummaryRows() {
+  return [["Scope", "user-global ~/.claude/skills/gstack"], ["Status", "ready"]];
+}
+
 export function runGstackSetup({
   platform = process.platform,
   bun,
@@ -178,18 +192,24 @@ export async function setupGstack({ target, dryRun = false }) {
     console.log(`[dry-run] cd ${GSTACK_DIR} && ./setup ${GSTACK_SETUP_ARGS.join(" ")}`);
     status = "dry-run";
   } else {
-    console.log("Checking gstack prerequisites");
-    const bun = await ensureBun();
-    if (!validateGstackCheckout()) {
-      console.log("Cloning gstack");
-      await ensureDir(path.dirname(GSTACK_DIR));
-      execFileSync("git", ["clone", "--single-branch", "--depth", "1", GSTACK_REPOSITORY, GSTACK_DIR], { stdio: "inherit" });
-    } else {
-      console.log("Using existing gstack checkout");
+    const runSetup = async () => {
+      const bun = await ensureBun();
+      if (!validateGstackCheckout()) {
+        console.log("Cloning gstack");
+        await ensureDir(path.dirname(GSTACK_DIR));
+        execFileSync("git", ["clone", "--single-branch", "--depth", "1", GSTACK_REPOSITORY, GSTACK_DIR], { stdio: "inherit" });
+      } else if (!isInteractive()) {
+        console.log("Using existing gstack checkout");
+      }
+      runGstackSetup({ bun });
+    };
+    if (isInteractive()) await withSpinner("Installing global gstack", runSetup);
+    else {
+      console.log("Checking gstack prerequisites");
+      console.log("Running gstack setup");
+      await runSetup();
     }
-    console.log("Running gstack setup");
-    runGstackSetup({ bun });
-    printSummary("gstack", [["Status", "installed globally for Claude Code"]]);
+    printSummary("gstack", gstackSummaryRows());
   }
 
   return status;

--- a/scripts/self-check.mjs
+++ b/scripts/self-check.mjs
@@ -8,7 +8,7 @@ import { auditProject, printAudit } from "./lib/audit.mjs";
 import { cleanupProject } from "./lib/cleanup.mjs";
 import { doctorProject } from "./lib/doctor.mjs";
 import { applyEccPluginSettings, setupEcc } from "./lib/ecc.mjs";
-import { ensureBun, gstackEnvironment, removeEccPluginSettings, runGstackSetup, setupGstack } from "./lib/gstack.mjs";
+import { ensureBun, gstackEnvironment, gstackSummaryRows, isValidBunInstaller, removeEccPluginSettings, runGstackSetup, setupGstack } from "./lib/gstack.mjs";
 import { applyMcpValues, generateMcp, mcpSecretPrompt, persistedMcpValues, readGeneratedMcpValues, validateRelativeMcpPath } from "./lib/mcp.mjs";
 import { applyAttributionSetting, applyLocalSettings, applyPermissionSettings, provisionProject, setupPipelineScope, updateClaudePermissions } from "./lib/provision.mjs";
 import { writePrivateJson } from "./lib/fs-utils.mjs";
@@ -618,6 +618,10 @@ assert(gitignoreLines.includes(".claude/"));
 
 assert.deepEqual(gstackEnvironment("bun", { PATH: "/usr/bin" }), { PATH: "/usr/bin" });
 assert.deepEqual(gstackEnvironment("/home/test/.bun/bin/bun", { PATH: "/usr/bin" }), { PATH: `/home/test/.bun/bin${path.delimiter}/usr/bin` });
+assert.deepEqual(gstackSummaryRows(), [
+  ["Scope", "user-global ~/.claude/skills/gstack"],
+  ["Status", "ready"]
+]);
 
 const gstackSetupCalls = [];
 const gstackSetupLogs = [];
@@ -659,6 +663,16 @@ assert.doesNotMatch(gstackFailureLog, /fatal: setup could not complete/);
 assert.doesNotMatch(gstackFailureLog, new RegExp(gstackCredentialFixture));
 assert(gstackFailureLog.length <= 4200);
 
+const validBunInstaller = Buffer.from(`#!/usr/bin/env bash
+set -euo pipefail
+install_env=BUN_INSTALL
+github_repo="\$GITHUB/oven-sh/bun"
+bun_uri=\$github_repo/releases/latest/download/bun-\$target.zip
+${"# Bun installer\n".repeat(80)}`);
+assert.equal(isValidBunInstaller(validBunInstaller), true);
+assert.equal(isValidBunInstaller(Buffer.from("<!doctype html><title>502 Bad Gateway</title>")), false);
+assert.equal(isValidBunInstaller(Buffer.from("#!/usr/bin/env bash\nset -euo pipefail\n")), false);
+
 const bunInstallCommands = [];
 let bunCheckCount = 0;
 let removedBunInstaller = false;
@@ -673,7 +687,7 @@ const installedBun = await ensureBun({
     return "";
   },
   mkdtemp: async () => "/tmp/repo-pattern-bun-installer",
-  readFile: async () => Buffer.from("#!/usr/bin/env bash\nBUN_INSTALL=\"${BUN_INSTALL:-$HOME/.bun}\"\nhttps://github.com/oven-sh/bun/releases\n"),
+  readFile: async () => validBunInstaller,
   rm: async () => { removedBunInstaller = true; }
 });
 assert.equal(installedBun, "/home/test/.bun/bin/bun");
@@ -694,7 +708,7 @@ await assert.rejects(() => ensureBun({
     return "";
   },
   mkdtemp: async () => "/tmp/repo-pattern-invalid-bun-installer",
-  readFile: async () => Buffer.from("not Bun"),
+  readFile: async () => Buffer.from("<!doctype html><title>502 Bad Gateway</title>"),
   rm: async () => {}
 }), /failed content validation/);
 


### PR DESCRIPTION
## Summary
- present interactive gstack provisioning with the existing Clack spinner and show its user-global installation scope
- accept the current official Bun installer shape while retaining bounded content, syntax, transport, cleanup, and post-install checks
- add deterministic coverage for gstack output and valid versus malformed Bun installer content
- bump the publishable package version to 0.1.16

## Verification
- npm test
- npm run pack:dry
- git diff --check
- fetched https://bun.sh/install and verified it is accepted without execution

No secrets are included.