### PR TITLE
feat: add gstack hook setup option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@negikirin/repo-pattern",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@negikirin/repo-pattern",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^0.11.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@negikirin/repo-pattern",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Minimal ECC-first Claude Code project setup and migrator",
   "type": "module",
   "bin": {

--- a/scripts/lib/gstack.mjs
+++ b/scripts/lib/gstack.mjs
@@ -20,8 +20,12 @@ export function isValidBunInstaller(source) {
     !text.includes("\0") &&
     BUN_INSTALLER_MARKERS.every((marker) => text.includes(marker));
 }
-const GSTACK_SETUP_ARGS = ["--quiet", "--no-plan-tune-hooks"];
+const GSTACK_SETUP_ARGS = ["--quiet"];
 const GSTACK_DIAGNOSTIC_MAX_CHARS = 4000;
+
+export function gstackSetupArgs(planTuneHooks = false) {
+  return [...GSTACK_SETUP_ARGS, planTuneHooks ? "--plan-tune-hooks" : "--no-plan-tune-hooks"];
+}
 const GSTACK_SETUP_MAX_BUFFER = 16 * 1024 * 1024;
 
 function run(command, args, options = {}) {
@@ -137,18 +141,24 @@ function redactedGstackDiagnostic(error) {
   return summary.slice(0, GSTACK_DIAGNOSTIC_MAX_CHARS);
 }
 
-export function gstackSummaryRows() {
-  return [["Scope", "user-global ~/.claude/skills/gstack"], ["Status", "ready"]];
+export function gstackSummaryRows(planTuneHooks = false) {
+  return [
+    ["Scope", "user-global ~/.claude/skills/gstack"],
+    ["Plan-tune hooks", planTuneHooks ? "installed in ~/.claude/settings.json" : "not installed"],
+    ["Status", "ready"]
+  ];
 }
 
 export function runGstackSetup({
   platform = process.platform,
   bun,
+  planTuneHooks = false,
   run: runCommand = run,
   log = console.error
 }) {
   const command = platform === "win32" ? "bash" : "./setup";
-  const args = platform === "win32" ? ["./setup", ...GSTACK_SETUP_ARGS] : GSTACK_SETUP_ARGS;
+  const setupArgs = gstackSetupArgs(planTuneHooks);
+  const args = platform === "win32" ? ["./setup", ...setupArgs] : setupArgs;
   try {
     runCommand(command, args, {
       cwd: GSTACK_DIR,
@@ -163,7 +173,7 @@ export function runGstackSetup({
   }
 }
 
-export async function setupGstack({ target, dryRun = false }) {
+export async function setupGstack({ target, dryRun = false, planTuneHooks = false }) {
   if (isTracked(target, ".claude/settings.local.json")) throw new Error(".claude/settings.local.json is tracked. Untrack it before writing local plugin settings.");
 
   let status = "installed";
@@ -189,7 +199,7 @@ export async function setupGstack({ target, dryRun = false }) {
       console.log("Using existing gstack checkout");
     }
     console.log("Running gstack setup");
-    console.log(`[dry-run] cd ${GSTACK_DIR} && ./setup ${GSTACK_SETUP_ARGS.join(" ")}`);
+    console.log(`[dry-run] cd ${GSTACK_DIR} && ./setup ${gstackSetupArgs(planTuneHooks).join(" ")}`);
     status = "dry-run";
   } else {
     const runSetup = async () => {
@@ -201,7 +211,7 @@ export async function setupGstack({ target, dryRun = false }) {
       } else if (!isInteractive()) {
         console.log("Using existing gstack checkout");
       }
-      runGstackSetup({ bun });
+      runGstackSetup({ bun, planTuneHooks });
     };
     if (isInteractive()) await withSpinner("Installing global gstack", runSetup);
     else {
@@ -209,7 +219,7 @@ export async function setupGstack({ target, dryRun = false }) {
       console.log("Running gstack setup");
       await runSetup();
     }
-    printSummary("gstack", gstackSummaryRows());
+    printSummary("gstack", gstackSummaryRows(planTuneHooks));
   }
 
   return status;

--- a/scripts/lib/provision.mjs
+++ b/scripts/lib/provision.mjs
@@ -62,7 +62,7 @@ async function repoPatternConfig(sourceRoot, profile, setupPipeline) {
   };
 }
 
-function lockConfig(profile, setupPipeline, pipelineStatus = {}) {
+function lockConfig(profile, setupPipeline, pipelineStatus = {}, planTuneHooks = false) {
   const status = typeof pipelineStatus === "string" ? { ecc: pipelineStatus, gstack: pipelineStatus } : pipelineStatus;
   const eccStatus = status.ecc || "not-run";
   const gstackStatus = status.gstack || "not-run";
@@ -91,6 +91,7 @@ function lockConfig(profile, setupPipeline, pipelineStatus = {}) {
       gstack: {
         installMode: "global",
         source: "https://github.com/garrytan/gstack.git",
+        planTuneHooks,
         status: gstackStatus,
         syncedAt: gstackStatus === "installed" ? new Date().toISOString() : null
       }
@@ -193,8 +194,9 @@ async function writeLocalSettings({ sourceRoot, target, localSettingsEnv = {}, d
   await appendGitignoreLine(target, ".claude/", { dryRun });
 }
 
-export async function provisionProject({ sourceRoot, target, profile = "web", setupPipeline = "ecc", mcpServers = null, mcpValues = {}, dryRun = false, force = false, migrate = false, localSettingsEnv = null, attributionConfig = { mode: "off" }, permissionConfig = { bypass: "deny" }, ruleMode = "auto", rules = null, applyRules = false, optionalSkills = [] }) {
+export async function provisionProject({ sourceRoot, target, profile = "web", setupPipeline = "ecc", planTuneHooks = false, mcpServers = null, mcpValues = {}, dryRun = false, force = false, migrate = false, localSettingsEnv = null, attributionConfig = { mode: "off" }, permissionConfig = { bypass: "deny" }, ruleMode = "auto", rules = null, applyRules = false, optionalSkills = [] }) {
   if (!SETUP_PIPELINES.includes(setupPipeline)) throw new Error(`Unknown setup pipeline: ${setupPipeline}. Available: ${SETUP_PIPELINES.join(", ")}`);
+  if (planTuneHooks && !usesGstack(setupPipeline)) throw new Error("--with-plan-tune-hooks requires --setup-pipeline gstack or both.");
   printSummary("Provisioning target", [["Target", target]]);
   await rejectClaudeSymlink(target, { dryRun });
   const audit = await auditProject(target);
@@ -206,7 +208,7 @@ export async function provisionProject({ sourceRoot, target, profile = "web", se
   if (isTracked(target, ".claude/settings.json")) throw new Error(".claude/settings.json is tracked. Untrack it before writing Claude Code settings.");
   if (isTracked(target, ".repo-pattern/.repo-pattern.lock.json") || isTracked(target, ".repo-pattern.lock.json")) throw new Error("repo-pattern lock is tracked. Untrack it before writing local setup state.");
 
-  const gstackStatus = usesGstack(setupPipeline) ? await setupGstack({ target, dryRun }) : null;
+  const gstackStatus = usesGstack(setupPipeline) ? await setupGstack({ target, dryRun, planTuneHooks }) : null;
 
   if (audit.state === "LEGACY_VENDOR") {
     await cleanupProject({ sourceRoot, target, dryRun });
@@ -241,7 +243,7 @@ export async function provisionProject({ sourceRoot, target, profile = "web", se
     await removePath(path.join(target, ".claude", "rules"), { dryRun });
   }
   await writeJson(repoConfigPath(target), await repoPatternConfig(sourceRoot, profile, setupPipeline), { dryRun });
-  await writeJson(lockPath, lockConfig(profile, setupPipeline, { ecc: eccStatus, gstack: gstackStatus }), { dryRun });
+  await writeJson(lockPath, lockConfig(profile, setupPipeline, { ecc: eccStatus, gstack: gstackStatus }, planTuneHooks), { dryRun });
   await ensureRepoPatternGitignore(target, { dryRun });
   if (usesEcc(setupPipeline) && applyRules) await applyEccRules({ target, dryRun, ruleMode, rules });
   if (optionalSkills.length > 0) await applyOptionalSkills({ target, skills: optionalSkills, dryRun });
@@ -267,6 +269,7 @@ export async function provisionProject({ sourceRoot, target, profile = "web", se
     ["Target", target],
     ["Setup pipeline", setupPipeline],
     ["Pipeline scope", setupPipelineScope(setupPipeline)],
+    ...(usesGstack(setupPipeline) ? [["Plan-tune hooks", planTuneHooks ? "installed in ~/.claude/settings.json" : "not installed"]] : []),
     ["Profile", profile],
     [dryRun ? "Would write" : "Written", `CLAUDE.md (if missing), .claude/, .mcp.json, .repo-pattern/.repo-pattern.json, .repo-pattern/.repo-pattern.lock.json${optionalSkills.length ? ", optional skill/plugin config" : ""}`],
     ["Doctor", dryRun ? "skipped (dry-run)" : style("success", "passed")],

--- a/scripts/lib/setup.mjs
+++ b/scripts/lib/setup.mjs
@@ -53,10 +53,11 @@ function safeRetryLocalSettingsEnv(localSettingsEnv = {}) {
   return Object.fromEntries(Object.entries(localSettingsEnv).filter(([name]) => !RETRY_SECRET_LOCAL_SETTINGS.has(name)));
 }
 
-export function setupRetryOptions({ action, setupPipeline, mcpConfig, mcpValues = {}, ruleConfig, optionalSkills, localSettingsEnv, attributionConfig, permissionConfig = { bypass: "deny" }, dryRun }) {
+export function setupRetryOptions({ action, setupPipeline, planTuneHooks = false, mcpConfig, mcpValues = {}, ruleConfig, optionalSkills, localSettingsEnv, attributionConfig, permissionConfig = { bypass: "deny" }, dryRun }) {
   return {
     action,
     setupPipeline,
+    planTuneHooks,
     profile: mcpConfig.profile,
     mcpServers: mcpConfig.mcpServers,
     mcpValueNames: Object.keys(persistedMcpValues(mcpValues)),
@@ -106,6 +107,7 @@ function retryRows(setup) {
     ["Failed step", setup.failedStep || "unknown"],
     ["Error", setup.error || "unknown"],
     ["Setup pipeline", options.setupPipeline || "ecc"],
+    ...(usesGstack(options.setupPipeline) ? [["Plan-tune hooks", options.planTuneHooks ? "installed in ~/.claude/settings.json" : "not installed"]] : []),
     ["Profile", options.profile || "web"],
     ["MCP servers", options.mcpServers?.join(", ") || "from profile"],
     ["MCP values", options.mcpValueNames?.length ? options.mcpValueNames.join(", ") : "none"],
@@ -198,6 +200,10 @@ function usesEcc(setupPipeline) {
   return setupPipeline === "ecc" || setupPipeline === "both";
 }
 
+function usesGstack(setupPipeline) {
+  return setupPipeline === "gstack" || setupPipeline === "both";
+}
+
 function expectedSetupState(setupPipeline) {
   return {
     ecc: "ECC_NATIVE_MINIMAL",
@@ -216,6 +222,18 @@ async function chooseSetupPipeline(initialValue = "ecc") {
     ],
     initialValues: pipelineValues(initialValue)
   }));
+}
+
+async function choosePlanTuneHooks(setupPipeline, initialValue = false) {
+  if (setupPipeline !== "gstack" && setupPipeline !== "both") return false;
+  return selectOne({
+    message: "Install gstack plan-tune hooks?",
+    options: [
+      { value: false, label: "No", description: "keep ~/.claude/settings.json unchanged by gstack" },
+      { value: true, label: "Yes", description: "add gstack PreToolUse and PostToolUse hooks to ~/.claude/settings.json" }
+    ],
+    initialValue
+  });
 }
 
 async function chooseRuleConfig(detection, setupPipeline) {
@@ -306,12 +324,13 @@ function attributionSummary(attributionConfig) {
   return "off (commit: \"\")";
 }
 
-async function confirmSummary({ action, setupPipeline, target, mcpConfig, mcpValues, ruleConfig, optionalSkills, localSettingsEnv, attributionConfig, permissionConfig, dryRun }) {
+async function confirmSummary({ action, setupPipeline, planTuneHooks, target, mcpConfig, mcpValues, ruleConfig, optionalSkills, localSettingsEnv, attributionConfig, permissionConfig, dryRun }) {
   const hasLocalSkill = optionalSkills.some((name) => !OPTIONAL_SKILLS.find((skill) => skill.value === name)?.plugin);
   printSummary("Setup summary", [
     ["Action", action],
     ["Setup pipeline", setupPipeline],
     ["Pipeline scope", setupPipelineScope(setupPipeline)],
+    ...(usesGstack(setupPipeline) ? [["Plan-tune hooks", planTuneHooks ? "will add PreToolUse/PostToolUse hooks to ~/.claude/settings.json" : "not installed"]] : []),
     ["Target", target],
     ["Profile", mcpConfig.profile],
     ["MCP servers", mcpConfig.mcpServers?.join(", ") || "from profile"],
@@ -389,8 +408,9 @@ async function handleInitialized({ sourceRoot, target, profile, dryRun }) {
   }
 }
 
-export async function setupProject({ sourceRoot, target, profile = "web", setupPipeline = "ecc", dryRun = false, force = false, migrate = false, yes = false, applyRules = false, optionalSkills = [] }) {
+export async function setupProject({ sourceRoot, target, profile = "web", setupPipeline = "ecc", planTuneHooks = false, dryRun = false, force = false, migrate = false, yes = false, applyRules = false, optionalSkills = [] }) {
   if (!SETUP_PIPELINES.includes(setupPipeline)) throw new Error(`Unknown setup pipeline: ${setupPipeline}. Available: ${SETUP_PIPELINES.join(", ")}`);
+  if (planTuneHooks && !["gstack", "both"].includes(setupPipeline)) throw new Error("--with-plan-tune-hooks requires --setup-pipeline gstack or both.");
   if (!isInteractive()) {
     if (!yes) throw new Error("setup requires an interactive terminal, or pass --yes for scriptable mode.");
     if (profile === "custom") throw new Error("setup --yes cannot use the custom profile; choose a named profile.");
@@ -417,6 +437,7 @@ export async function setupProject({ sourceRoot, target, profile = "web", setupP
       dryRun,
       force,
       migrate,
+      planTuneHooks,
       applyRules,
       optionalSkills
     });
@@ -430,6 +451,7 @@ export async function setupProject({ sourceRoot, target, profile = "web", setupP
   const detection = await detectProject(target);
   const selectedSetupPipeline = previousOptions?.setupPipeline || await chooseSetupPipeline(setupPipeline);
   if (!SETUP_PIPELINES.includes(selectedSetupPipeline)) throw new Error(`Unknown setup pipeline: ${selectedSetupPipeline}. Available: ${SETUP_PIPELINES.join(", ")}`);
+  const selectedPlanTuneHooks = previousOptions?.planTuneHooks ?? await choosePlanTuneHooks(selectedSetupPipeline, planTuneHooks);
   const chosenProfile = previousOptions?.profile || await chooseProfile(sourceRoot, profile, detection);
   const mcpConfig = previousOptions
     ? { profile: previousOptions.profile, mcpServers: previousOptions.mcpServers }
@@ -479,11 +501,11 @@ export async function setupProject({ sourceRoot, target, profile = "web", setupP
   const permissionConfig = previousOptions?.permissionConfig || await choosePermissionConfig();
   const attributionConfig = previousOptions?.attributionConfig || await chooseAttributionConfig();
 
-  if (!await confirmSummary({ action, setupPipeline: selectedSetupPipeline, target, mcpConfig, mcpValues, ruleConfig, optionalSkills: selectedOptionalSkills, localSettingsEnv, attributionConfig, permissionConfig, dryRun })) {
+  if (!await confirmSummary({ action, setupPipeline: selectedSetupPipeline, planTuneHooks: selectedPlanTuneHooks, target, mcpConfig, mcpValues, ruleConfig, optionalSkills: selectedOptionalSkills, localSettingsEnv, attributionConfig, permissionConfig, dryRun })) {
     throw new Error("Setup cancelled.");
   }
 
-  const retryOptions = setupRetryOptions({ action, setupPipeline: selectedSetupPipeline, mcpConfig, mcpValues, ruleConfig, optionalSkills: selectedOptionalSkills, localSettingsEnv, attributionConfig, permissionConfig, dryRun });
+  const retryOptions = setupRetryOptions({ action, setupPipeline: selectedSetupPipeline, planTuneHooks: selectedPlanTuneHooks, mcpConfig, mcpValues, ruleConfig, optionalSkills: selectedOptionalSkills, localSettingsEnv, attributionConfig, permissionConfig, dryRun });
   await writeSetupStatus(target, { status: "running", startedAt: new Date().toISOString(), failedStep: null, error: null, options: retryOptions }, { dryRun });
   try {
     await provisionProject({
@@ -491,6 +513,7 @@ export async function setupProject({ sourceRoot, target, profile = "web", setupP
       target,
       profile: mcpConfig.profile,
       setupPipeline: selectedSetupPipeline,
+      planTuneHooks: selectedPlanTuneHooks,
       mcpServers: mcpConfig.mcpServers,
       mcpValues,
       dryRun,

--- a/scripts/repo-pattern.mjs
+++ b/scripts/repo-pattern.mjs
@@ -36,6 +36,7 @@ function parseArgs(argv) {
     target: ".",
     profile: "web",
     setupPipeline: "ecc",
+    planTuneHooks: false,
     dryRun: false,
     force: false,
     migrate: false,
@@ -49,6 +50,7 @@ function parseArgs(argv) {
     if (arg === "--target") options.target = requiredOptionValue(rest, i++, arg);
     else if (arg === "--profile") options.profile = requiredOptionValue(rest, i++, arg);
     else if (arg === "--setup-pipeline") options.setupPipeline = requiredOptionValue(rest, i++, arg);
+    else if (arg === "--with-plan-tune-hooks") options.planTuneHooks = true;
     else if (arg === "--dry-run") options.dryRun = true;
     else if (arg === "--force") options.force = true;
     else if (arg === "--migrate") options.migrate = true;
@@ -84,6 +86,11 @@ function parseArgs(argv) {
     process.exit(2);
   }
 
+  if (options.planTuneHooks && !["gstack", "both"].includes(options.setupPipeline)) {
+    console.error("--with-plan-tune-hooks requires --setup-pipeline gstack or both.");
+    process.exit(2);
+  }
+
   options.target = path.resolve(process.cwd(), options.target);
   return options;
 }
@@ -96,6 +103,7 @@ Usage:
   repo-pattern setup
   repo-pattern setup --profile web --setup-pipeline ecc --yes
   repo-pattern setup --profile web --setup-pipeline gstack --yes
+  repo-pattern setup --profile web --setup-pipeline gstack --with-plan-tune-hooks --yes
   repo-pattern setup --profile web --setup-pipeline both --yes
   repo-pattern setup --profile web --setup-pipeline none --yes
   repo-pattern setup --profile web --migrate --yes
@@ -121,6 +129,8 @@ Options:
                                   gstack: user-scoped/global at ~/.claude/skills/gstack
                                   both: project-scoped ECC + user-scoped/global gstack
                                   none: base project metadata only
+  --with-plan-tune-hooks          Add gstack PreToolUse/PostToolUse hooks to ~/.claude/settings.json
+                                  Requires --setup-pipeline gstack or both. Default: not installed
 
 Setup UI:
   setup uses ↑/↓ to move, Space to toggle MCP/rules choices, Enter to confirm, Esc/Ctrl+C to cancel

--- a/scripts/self-check.mjs
+++ b/scripts/self-check.mjs
@@ -136,6 +136,7 @@ assert.deepEqual(setupRetryOptions({
 }), {
   action: "setup",
   setupPipeline: "gstack",
+  planTuneHooks: false,
   profile: "web",
   mcpServers: null,
   mcpValueNames: ["CONTEXT7_API_KEY"],
@@ -481,6 +482,10 @@ result = runCli(["setup", "--setup-pipeline", "nope", "--yes"]);
 assert.equal(result.status, 2);
 assert.match(result.stderr, /Unknown setup pipeline: nope\. Available: ecc, gstack/);
 
+result = runCli(["setup", "--setup-pipeline", "ecc", "--with-plan-tune-hooks", "--yes"]);
+assert.equal(result.status, 2);
+assert.match(result.stderr, /--with-plan-tune-hooks requires --setup-pipeline gstack or both/);
+
 result = runCli(["help"]);
 assert.equal(result.status, 0);
 assert.match(result.stdout, /--setup-pipeline <ecc\|gstack\|both\|none>/);
@@ -488,6 +493,7 @@ assert.match(result.stdout, /ecc: project-scoped ECC/);
 assert.match(result.stdout, /gstack: user-scoped\/global at ~\/\.claude\/skills\/gstack/);
 assert.match(result.stdout, /both: project-scoped ECC \+ user-scoped\/global gstack/);
 assert.match(result.stdout, /none: base project metadata only/);
+assert.match(result.stdout, /--with-plan-tune-hooks/);
 assert.match(result.stdout, /--with-skill <name>/);
 assert.match(result.stdout, /ui-ux-pro-max/);
 assert.match(result.stdout, /impeccable/);
@@ -555,6 +561,16 @@ try {
   await fs.rm(gstackSetupTarget, { recursive: true, force: true });
 }
 
+const gstackHooksSetupTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-gstack-hooks-setup-"));
+try {
+  result = runCli(["setup", "--target", gstackHooksSetupTarget, "--profile", "minimal", "--setup-pipeline", "gstack", "--with-plan-tune-hooks", "--yes", "--dry-run"]);
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /\.\/setup --quiet --plan-tune-hooks/);
+  assert.match(result.stdout, /Plan-tune hooks\s+installed in ~\/\.claude\/settings\.json/);
+} finally {
+  await fs.rm(gstackHooksSetupTarget, { recursive: true, force: true });
+}
+
 const privateWriteTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-private-write-"));
 try {
   const privateWritePath = path.join(privateWriteTarget, "settings.local.json");
@@ -620,6 +636,12 @@ assert.deepEqual(gstackEnvironment("bun", { PATH: "/usr/bin" }), { PATH: "/usr/b
 assert.deepEqual(gstackEnvironment("/home/test/.bun/bin/bun", { PATH: "/usr/bin" }), { PATH: `/home/test/.bun/bin${path.delimiter}/usr/bin` });
 assert.deepEqual(gstackSummaryRows(), [
   ["Scope", "user-global ~/.claude/skills/gstack"],
+  ["Plan-tune hooks", "not installed"],
+  ["Status", "ready"]
+]);
+assert.deepEqual(gstackSummaryRows(true), [
+  ["Scope", "user-global ~/.claude/skills/gstack"],
+  ["Plan-tune hooks", "installed in ~/.claude/settings.json"],
   ["Status", "ready"]
 ]);
 
@@ -637,6 +659,16 @@ runGstackSetup({
 assert.deepEqual(gstackSetupCalls[0].args, ["--quiet", "--no-plan-tune-hooks"]);
 assert.deepEqual(gstackSetupCalls[0].options.stdio, ["ignore", "pipe", "pipe"]);
 assert.deepEqual(gstackSetupLogs, []);
+
+runGstackSetup({
+  platform: "linux",
+  bun: "bun",
+  planTuneHooks: true,
+  run(command, args) {
+    gstackSetupCalls.push({ command, args });
+  }
+});
+assert.deepEqual(gstackSetupCalls[1].args, ["--quiet", "--plan-tune-hooks"]);
 
 const gstackCredentialFixture = ["example", "credential", "value"].join("-");
 const gstackFailure = Object.assign(new Error("setup failed"), {
@@ -818,6 +850,10 @@ await assert.rejects(
   () => provisionProject({ sourceRoot: repoRoot, target: os.tmpdir(), setupPipeline: "invalid", dryRun: true }),
   /Unknown setup pipeline: invalid/
 );
+await assert.rejects(
+  () => provisionProject({ sourceRoot: repoRoot, target: os.tmpdir(), setupPipeline: "ecc", planTuneHooks: true, dryRun: true }),
+  /--with-plan-tune-hooks requires --setup-pipeline gstack or both/
+);
 
 const bothProvisionTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-both-provision-"));
 console.log = () => {};
@@ -829,6 +865,7 @@ try {
     target: bothProvisionTarget,
     profile: "minimal",
     setupPipeline: "both",
+    planTuneHooks: true,
     localSettingsEnv: { ANTHROPIC_AUTH_TOKEN: secretSentinel }
   });
   const repoConfig = JSON.parse(await fs.readFile(path.join(bothProvisionTarget, ".repo-pattern", ".repo-pattern.json"), "utf8"));
@@ -838,6 +875,7 @@ try {
   assert.equal(lock.setupPipeline, "both");
   assert.equal(lock.ecc.status, "installed");
   assert.equal(lock.gstack.status, "installed");
+  assert.equal(lock.gstack.planTuneHooks, true);
   assert.equal(localSettings.enabledPlugins["ecc@ecc"], true);
   assert.equal((await auditProject(bothProvisionTarget)).state, "ECC_GSTACK_MINIMAL");
   await doctorProject(bothProvisionTarget);
@@ -912,6 +950,7 @@ try {
   assert.equal("ecc" in repoConfig, false);
   assert.equal(lock.setupPipeline, "gstack");
   assert.equal(lock.gstack.status, "installed");
+  assert.equal(lock.gstack.planTuneHooks, false);
   assert.equal("ecc" in lock, false);
   const gstackLocalSettings = JSON.parse(await fs.readFile(path.join(gstackProvisionTarget, ".claude", "settings.local.json"), "utf8"));
   assert.equal(gstackLocalSettings.enabledPlugins["ecc@ecc"], undefined);


### PR DESCRIPTION
## Summary
- add interactive and CLI opt-in for gstack plan-tune hooks
- retain the no-hooks default and persist the selection in setup state
- cover default, opt-in, validation, summaries, and lock metadata
- release package version 0.1.17

## Verification
- npm test
- npm run pack:dry
- git diff --check
- GitNexus detect-changes against origin/main (critical reachability reviewed)