### PR TITLE
feat: add plugin-independent ECC rules

### DIFF
--- a/.claude.example/settings.example.json
+++ b/.claude.example/settings.example.json
@@ -6,7 +6,8 @@
   },
   "permissions": {
     "deny": [
-      "Agent(claude)"
+      "Agent(claude)",
+      "Agent(general-purpose)"
     ],
     "ask": [
       "Bash(git push *)",

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Scriptable setup:
 ```bash
 npx repo-pattern setup --profile web --setup-pipeline ecc --yes
 npx repo-pattern setup --profile web --setup-pipeline gstack --yes
+npx repo-pattern setup --profile web --setup-pipeline gstack --with-rules --yes
+npx repo-pattern setup --profile web --setup-pipeline none --with-rules --yes
 ```
 
 Pipeline scope is explicit:
@@ -56,6 +58,8 @@ Pipeline scope is explicit:
 - `none` — base project metadata only.
 
 gstack requires Git and Bun v1.0+. When Bun is missing on Linux or macOS, setup downloads the official installer over TLS, validates it, and installs Bun automatically. On unsupported systems, install Bun manually before setup. Its upstream setup runs with `--quiet --no-plan-tune-hooks`, so automated setup does not show settings diffs or wait for hook confirmation.
+
+ECC rules are independent of the ECC plugin. `ecc` and `both` install auto-detected packs by default; the interactive wizard can switch to manual packs or none. `gstack` and `none` prompt whether to install rules, while scriptable setup requires `--with-rules`. Managed packs live in `.claude/rules/ecc/` and can work when ECC plugin setup reports manual installation is still required.
 
 Migrate an existing project:
 
@@ -84,7 +88,8 @@ Common options:
 --target /path/to/project  # default: current directory
 --profile web              # default MCP profile
 --setup-pipeline ecc        # ecc (default), gstack, both, or none
---with-rules               # opt in to .claude/rules/ecc; ECC only
+--with-rules               # install auto-detected .claude/rules/ecc on gstack or none
+                            # ecc and both install auto-detected rules by default
 --with-skill ui-ux-pro-max # optional UI/UX skill; requires Python 3.x
 --with-skills nextjs-pattern,fastapi-pattern # optional framework pattern skills
 --migrate                  # take over legacy/local Claude runtime surfaces
@@ -130,7 +135,7 @@ target-project/
 * `.claude/` is generated from `.claude.example/` and gitignored.
 * Basic OS/IDE noise (`.DS_Store`, `Thumbs.db`, `.vscode/`, `.idea/`) is gitignored during setup.
 * `.claude/settings.json` keeps `hooks: {}` and disables commit attribution by default; interactive setup can turn it on or use a custom trailer.
-* No vendored ECC skills, commands, hooks, scripts, or rules are installed unless explicitly requested.
+* No vendored ECC skills, commands, hooks, or scripts are installed. ECC rules are auto-installed for ECC pipelines and opt-in for gstack/none.
 * Karpathy-inspired Claude Code guidelines are included in `.claude/CLAUDE.md` from `multica-ai/andrej-karpathy-skills` (MIT).
 * Optional external skills are user opt-in only: `--with-skill taste`, `--with-skill document-specialist`, `--with-skill ui-ux-pro-max`, `--with-skill impeccable`, `--with-skill huashu-design`, `--with-skill nextjs-pattern`, `--with-skill fastapi-pattern`, `--with-skill herdr`, or interactive setup.
 

--- a/docs/repo-pattern/setup-guide.md
+++ b/docs/repo-pattern/setup-guide.md
@@ -13,6 +13,8 @@ Use scriptable `setup --yes` when you already know the exact options:
 ```bash
 node scripts/repo-pattern.mjs setup --target /path/to/project --profile web --setup-pipeline ecc --yes
 node scripts/repo-pattern.mjs setup --target /path/to/project --profile web --setup-pipeline gstack --yes
+node scripts/repo-pattern.mjs setup --target /path/to/project --profile web --setup-pipeline gstack --with-rules --yes
+node scripts/repo-pattern.mjs setup --target /path/to/project --profile web --setup-pipeline none --with-rules --yes
 ```
 
 Pipeline scope is explicit:
@@ -34,7 +36,9 @@ minimal Claude Code setup
 + repo-pattern metadata
 ```
 
-`repo-pattern` is intentionally not a Claude runtime pack. It does not install local Claude skills, commands, hooks, scripts, or rules by default. Project-local ECC rules are explicit opt-in via `setup --with-rules`, `rules`, or interactive `setup`. Optional external skills are explicit opt-in via `setup --with-skill <name>` or interactive `setup`.
+`repo-pattern` is intentionally not a Claude runtime pack. It does not install local Claude skills, commands, hooks, or scripts by default. ECC and both pipelines install auto-detected project-local ECC rules by default; interactive setup can choose automatic packs, manual packs, or none. gstack and none keep rules off unless selected in the wizard or passed `setup --with-rules`. Rule sync is independent of ECC plugin installation, so managed `.claude/rules/ecc/` packs can be present while the plugin is still `manual-plugin-install-required`. Optional external skills are explicit opt-in via `setup --with-skill <name>` or interactive `setup`.
+
+Non-ECC managed rules are recorded under `repoConfig.ecc` and `lock.ecc` as rule-sync metadata only; they do not enable `ecc@ecc` or change the selected runtime pipeline.
 
 ---
 
@@ -130,7 +134,7 @@ For non-interactive scripts, use `setup --yes`.
 13. Add generated setup files and basic OS/IDE noise to `.gitignore`.
 14. Write `.repo-pattern/.repo-pattern.lock.json` without credential values.
 15. Run the selected setup pipeline: ECC setup after generation, or the global gstack installer after target preflight succeeds.
-16. During ECC `setup` with rules enabled, apply ECC rules.
+16. When rules are enabled, apply ECC rules independently of plugin installation.
 17. Run doctor.
 ```
 
@@ -529,7 +533,7 @@ It performs:
 minimal Claude setup
 MCP generation
 selected ECC or gstack setup flow
-optional ECC rules sync for ECC
+ECC rules sync (default for ecc/both; `--with-rules` for gstack/none)
 doctor check
 ```
 
@@ -703,7 +707,7 @@ full     → local testing only
 
 ## ECC rules auto-cache
 
-ECC rules are opt-in. `repo-pattern` can select ECC rule packs from the target project's stack and apply them to project scope.
+`repo-pattern` can select ECC rule packs from the target project's stack and apply them to project scope without requiring the ECC plugin. ecc and both pipelines enable auto-detected packs by default. gstack and none require an interactive opt-in or `--with-rules` in scriptable setup.
 
 Run rules explicitly with:
 
@@ -744,4 +748,4 @@ ruby
 arkts
 ```
 
-For scriptable setup, use `--with-rules --yes` to run this rules step after ECC setup and before doctor.
+For scriptable non-ECC setup, use `--with-rules --yes` to run this rules step before doctor. ECC and both run it automatically unless rules are explicitly disabled through the interactive wizard.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@negikirin/repo-pattern",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@negikirin/repo-pattern",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^0.11.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@negikirin/repo-pattern",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "Minimal ECC-first Claude Code project setup and migrator",
   "type": "module",
   "bin": {

--- a/scripts/lib/audit.mjs
+++ b/scripts/lib/audit.mjs
@@ -69,6 +69,7 @@ export async function auditProject(target) {
     hasClaudeScriptsDir: exists(path.join(target, ".claude", "scripts")),
     hasClaudeRulesDir: exists(path.join(target, ".claude", "rules")),
     hasOnlyEccRulesDir: await isOnlyEccRulesDir(target),
+    hasManagedEccRules: lock.ecc?.rulesSyncedBy === "repo-pattern-auto-cache" || (lock.ecc?.appliedRules || []).length > 0,
     hasClaudeEccRulesDir,
     eccRulePackDirs,
     hasRepoPatternJson: !!repoPattern,
@@ -86,7 +87,7 @@ export async function auditProject(target) {
     result.hasClaudeCommandsDir ||
     result.hasClaudeHooksDir ||
     result.hasClaudeScriptsDir ||
-    (result.hasClaudeRulesDir && (repoPattern ? (!usesEcc || !result.hasOnlyEccRulesDir) : !result.hasOnlyEccRulesDir))
+    (result.hasClaudeRulesDir && (repoPattern ? (!result.hasOnlyEccRulesDir || !result.hasManagedEccRules) : !result.hasOnlyEccRulesDir))
   );
 
   const setupComplete = !usesGstack || lock.gstack?.status === "installed";
@@ -132,8 +133,8 @@ export function printAudit(audit) {
     [audit.hasClaudeCommandsDir, ".claude/commands present"],
     [audit.hasClaudeHooksDir, ".claude/hooks present"],
     [audit.hasClaudeScriptsDir, ".claude/scripts present"],
-    [audit.hasClaudeRulesDir && !["ecc-native", "ecc-gstack"].includes(audit.repoPattern?.workflow), ".claude/rules is incompatible with this setup pipeline"],
-    [audit.hasClaudeRulesDir && ["ecc-native", "ecc-gstack"].includes(audit.repoPattern?.workflow) && !audit.hasOnlyEccRulesDir, "non-ECC .claude/rules present"]
+    [audit.hasClaudeRulesDir && !audit.hasOnlyEccRulesDir, "non-ECC .claude/rules present"],
+    [audit.hasClaudeRulesDir && !audit.hasManagedEccRules, ".claude/rules is not repo-pattern-managed"]
   ].filter(([bad]) => bad);
 
   if (issues.length > 0) {

--- a/scripts/lib/doctor.mjs
+++ b/scripts/lib/doctor.mjs
@@ -34,7 +34,7 @@ export async function doctorProject(target, { updateLock = false, dryRun = false
   check(!audit.hasClaudeHooksDir, ".claude/hooks does not exist");
   check(!audit.hasClaudeScriptsDir, ".claude/scripts does not exist");
   const usesEcc = audit.repoPattern?.workflow === "ecc-native" || audit.repoPattern?.workflow === "ecc-gstack";
-  check(!audit.hasClaudeRulesDir || (usesEcc && audit.hasOnlyEccRulesDir), usesEcc ? "no non-ECC .claude/rules" : ".claude/rules does not exist for this setup pipeline");
+  check(!audit.hasClaudeRulesDir || (audit.hasOnlyEccRulesDir && audit.hasManagedEccRules), "no unmanaged .claude/rules");
   check(audit.hasClaudeDir, ".claude exists");
   check(!audit.hasSettingsHooks, ".claude/settings.json hooks is {}");
   check(!isTracked(target, ".claude/settings.json"), ".claude/settings.json is not tracked");

--- a/scripts/lib/provision.mjs
+++ b/scripts/lib/provision.mjs
@@ -194,8 +194,9 @@ async function writeLocalSettings({ sourceRoot, target, localSettingsEnv = {}, d
   await appendGitignoreLine(target, ".claude/", { dryRun });
 }
 
-export async function provisionProject({ sourceRoot, target, profile = "web", setupPipeline = "ecc", planTuneHooks = false, mcpServers = null, mcpValues = {}, dryRun = false, force = false, migrate = false, localSettingsEnv = null, attributionConfig = { mode: "off" }, permissionConfig = { bypass: "deny" }, ruleMode = "auto", rules = null, applyRules = false, optionalSkills = [] }) {
+export async function provisionProject({ sourceRoot, target, profile = "web", setupPipeline = "ecc", planTuneHooks = false, mcpServers = null, mcpValues = {}, dryRun = false, force = false, migrate = false, localSettingsEnv = null, attributionConfig = { mode: "off" }, permissionConfig = { bypass: "deny" }, ruleMode = "auto", rules = null, applyRules = null, optionalSkills = [] }) {
   if (!SETUP_PIPELINES.includes(setupPipeline)) throw new Error(`Unknown setup pipeline: ${setupPipeline}. Available: ${SETUP_PIPELINES.join(", ")}`);
+  const shouldApplyRules = applyRules ?? usesEcc(setupPipeline);
   if (planTuneHooks && !usesGstack(setupPipeline)) throw new Error("--with-plan-tune-hooks requires --setup-pipeline gstack or both.");
   printSummary("Provisioning target", [["Target", target]]);
   await rejectClaudeSymlink(target, { dryRun });
@@ -245,7 +246,7 @@ export async function provisionProject({ sourceRoot, target, profile = "web", se
   await writeJson(repoConfigPath(target), await repoPatternConfig(sourceRoot, profile, setupPipeline), { dryRun });
   await writeJson(lockPath, lockConfig(profile, setupPipeline, { ecc: eccStatus, gstack: gstackStatus }, planTuneHooks), { dryRun });
   await ensureRepoPatternGitignore(target, { dryRun });
-  if (usesEcc(setupPipeline) && applyRules) await applyEccRules({ target, dryRun, ruleMode, rules });
+  if (shouldApplyRules) await applyEccRules({ target, dryRun, ruleMode, rules });
   if (optionalSkills.length > 0) await applyOptionalSkills({ target, skills: optionalSkills, dryRun });
 
   if (dryRun) {

--- a/scripts/lib/setup.mjs
+++ b/scripts/lib/setup.mjs
@@ -7,7 +7,7 @@ import { provisionProject, setupPipelineScope, updateClaudeAttribution, updateCl
 import { doctorProject } from "./doctor.mjs";
 import { collectMcpValues, generateMcp, listAvailableMcpServers, persistedMcpValues, readGeneratedMcpValues, readMcpConfig } from "./mcp.mjs";
 import { askConfirm, askPassword, askText, isInteractive, printBox, printLogo, printSummary, selectMany, selectOne, style } from "./prompt.mjs";
-import { ECC_RULE_PACKS, selectEccRules } from "./ecc-rules.mjs";
+import { ECC_RULE_PACKS, normalizeEccRules, selectEccRules } from "./ecc-rules.mjs";
 import { ensureRepoPatternGitignore, isTracked, readJson, readPrivateJson, readRepoLock, repoLockPath, writeJson } from "./fs-utils.mjs";
 import { applyOptionalSkills, OPTIONAL_SKILLS } from "./skills.mjs";
 
@@ -237,7 +237,18 @@ async function choosePlanTuneHooks(setupPipeline, initialValue = false) {
 }
 
 async function chooseRuleConfig(detection, setupPipeline) {
-  if (!usesEcc(setupPipeline)) return { applyRules: false, ruleMode: "auto", rules: [] };
+  if (!usesEcc(setupPipeline)) {
+    const installRules = await selectOne({
+      message: "Install project-local ECC rules?",
+      options: [
+        { value: false, label: "No", description: "do not install project-local ECC rules" },
+        { value: true, label: "Yes", description: "sync ECC rules without installing the ECC plugin" }
+      ],
+      initialValue: false
+    });
+    if (!installRules) return { applyRules: false, ruleMode: "auto", rules: [] };
+  }
+
   const autoRules = selectEccRules(detection);
   const ruleMode = await selectOne({
     message: "Step 2/6 — Choose ECC rule detection mode",
@@ -252,15 +263,27 @@ async function chooseRuleConfig(detection, setupPipeline) {
   if (ruleMode === "none") return { applyRules: false, ruleMode: "auto", rules: [] };
   if (ruleMode !== "manual") return { applyRules: true, ruleMode, rules: autoRules };
 
+  const rules = normalizeEccRules(await selectMany({
+    message: "Choose ECC rule packs",
+    options: ECC_RULE_PACKS,
+    initialValues: autoRules
+  }));
+  return { applyRules: rules.length > 0, ruleMode, rules };
+}
+
+function defaultRuleConfig(setupPipeline, applyRules, detection) {
+  const shouldApplyRules = usesEcc(setupPipeline) || applyRules;
   return {
-    applyRules: true,
-    ruleMode,
-    rules: await selectMany({
-      message: "Choose ECC rule packs",
-      options: ECC_RULE_PACKS,
-      initialValues: autoRules
-    })
+    applyRules: shouldApplyRules,
+    ruleMode: "auto",
+    rules: shouldApplyRules ? selectEccRules(detection) : []
   };
+}
+
+function hasRequestedRules(audit, ruleConfig) {
+  if (!ruleConfig.applyRules) return !audit.hasClaudeRulesDir;
+  const appliedRules = audit.eccRulePackDirs || [];
+  return audit.hasManagedEccRules && JSON.stringify(appliedRules) === JSON.stringify([...ruleConfig.rules].sort());
 }
 
 async function chooseOptionalSkills(initialValues = []) {
@@ -416,13 +439,16 @@ export async function setupProject({ sourceRoot, target, profile = "web", setupP
     if (profile === "custom") throw new Error("setup --yes cannot use the custom profile; choose a named profile.");
 
     const audit = await auditProject(target);
+    const detection = await detectProject(target);
+    const ruleConfig = defaultRuleConfig(setupPipeline, applyRules, detection);
+    const hasIncompleteSetup = Boolean(setupOptionsFromLock(await readRepoLock(target, {})));
     const expectedState = expectedSetupState(setupPipeline);
-    if (audit.state === expectedState && !force && optionalSkills.length === 0) {
+    if (audit.state === expectedState && hasRequestedRules(audit, ruleConfig) && !hasIncompleteSetup && !force && optionalSkills.length === 0) {
       await doctorProject(target, { dryRun });
       return;
     }
 
-    if (audit.state === expectedState && optionalSkills.length > 0) {
+    if (audit.state === expectedState && hasRequestedRules(audit, ruleConfig) && optionalSkills.length > 0) {
       await applyOptionalSkills({ target, skills: optionalSkills, dryRun });
       if (!dryRun) await doctorProject(target, { updateLock: true, dryRun });
       return;
@@ -438,7 +464,9 @@ export async function setupProject({ sourceRoot, target, profile = "web", setupP
       force,
       migrate,
       planTuneHooks,
-      applyRules,
+      ruleMode: ruleConfig.ruleMode,
+      rules: ruleConfig.rules,
+      applyRules: ruleConfig.applyRules,
       optionalSkills
     });
     return;
@@ -456,7 +484,7 @@ export async function setupProject({ sourceRoot, target, profile = "web", setupP
   const mcpConfig = previousOptions
     ? { profile: previousOptions.profile, mcpServers: previousOptions.mcpServers }
     : await chooseMcpConfig(sourceRoot, chosenProfile);
-  const ruleConfig = previousOptions && usesEcc(selectedSetupPipeline)
+  const ruleConfig = previousOptions
     ? { applyRules: previousOptions.applyRules, ruleMode: previousOptions.ruleMode, rules: previousOptions.rules }
     : await chooseRuleConfig(detection, selectedSetupPipeline);
   const selectedOptionalSkills = previousOptions?.optionalSkills || await chooseOptionalSkills(optionalSkills);
@@ -469,7 +497,7 @@ export async function setupProject({ sourceRoot, target, profile = "web", setupP
   }
 
   const expectedState = expectedSetupState(selectedSetupPipeline);
-  if (audit.state === expectedState) {
+  if (audit.state === expectedState && hasRequestedRules(audit, ruleConfig)) {
     if (selectedOptionalSkills.length > 0) {
       await applyOptionalSkills({ target, skills: selectedOptionalSkills, dryRun });
       if (!dryRun) await doctorProject(target, { updateLock: true, dryRun });

--- a/scripts/repo-pattern.mjs
+++ b/scripts/repo-pattern.mjs
@@ -81,11 +81,6 @@ function parseArgs(argv) {
     process.exit(2);
   }
 
-  if (!["ecc", "both"].includes(options.setupPipeline) && options.applyRules) {
-    console.error("--with-rules requires --setup-pipeline ecc or both.");
-    process.exit(2);
-  }
-
   if (options.planTuneHooks && !["gstack", "both"].includes(options.setupPipeline)) {
     console.error("--with-plan-tune-hooks requires --setup-pipeline gstack or both.");
     process.exit(2);
@@ -137,7 +132,8 @@ Setup UI:
   --dry-run      Print actions without writing
   --migrate      Take over legacy/local Claude runtime surfaces
   --force        Reapply setup over repo-pattern-managed state
-  --with-rules               Opt in to repo-pattern-managed .claude/rules/ecc
+  --with-rules               Install auto-detected project-local ECC rules on any pipeline
+                             ECC/both install rules by default; gstack/none opt in with this flag
   --with-skill <name>        Opt in to external skills/plugins (${optionalSkillNames})
   --with-skills <a,b>        Comma-separated optional skills
   --yes                      Run setup non-interactively

--- a/scripts/self-check.mjs
+++ b/scripts/self-check.mjs
@@ -423,7 +423,7 @@ assert(auditLogs.includes("State   EMPTY"));
 assert(!auditLogs.some((line) => line.includes(".claude present")));
 assert(auditLogs.some((line) => line.includes("⚠ .mcp.json missing")));
 assert(auditLogs.some((line) => line.includes("⚠ .claude/settings.json hooks not empty")));
-assert(auditLogs.some((line) => line.includes("⚠ .claude/rules is incompatible with this setup pipeline")));
+assert(auditLogs.some((line) => line.includes("⚠ .claude/rules is not repo-pattern-managed")));
 
 const logs = [];
 const originalLog = console.log;
@@ -902,7 +902,7 @@ try {
   const localSettings = JSON.parse(await fs.readFile(path.join(noPipelineProvisionTarget, ".claude", "settings.local.json"), "utf8"));
   assert.equal(repoConfig.workflow, "none");
   assert.equal(lock.setupPipeline, "none");
-  assert.equal("ecc" in lock, false);
+  assert.deepEqual(lock.ecc.appliedRules, ["common"]);
   assert.equal("gstack" in lock, false);
   assert.equal(localSettings.enabledPlugins["ecc@ecc"], undefined);
   assert.equal((await auditProject(noPipelineProvisionTarget)).state, "NO_PIPELINE_MINIMAL");
@@ -923,8 +923,14 @@ try {
 }
 
 result = runCli(["setup", "--setup-pipeline", "none", "--with-rules", "--yes", "--dry-run"]);
-assert.equal(result.status, 2);
-assert.match(result.stderr, /--with-rules requires --setup-pipeline ecc or both/);
+assert.equal(result.status, 0, result.stderr);
+assert.match(result.stdout, /Selected ECC rules/);
+assert.match(result.stdout, /Applied ECC rules/);
+
+result = runCli(["setup", "--setup-pipeline", "gstack", "--with-rules", "--yes", "--dry-run"]);
+assert.equal(result.status, 0, result.stderr);
+assert.match(result.stdout, /Selected ECC rules/);
+assert.match(result.stdout, /Applied ECC rules/);
 
 const gstackProvisionTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-gstack-provision-"));
 console.log = () => {};
@@ -947,16 +953,16 @@ try {
   const repoConfig = JSON.parse(await fs.readFile(path.join(gstackProvisionTarget, ".repo-pattern", ".repo-pattern.json"), "utf8"));
   const lock = JSON.parse(await fs.readFile(path.join(gstackProvisionTarget, ".repo-pattern", ".repo-pattern.lock.json"), "utf8"));
   assert.equal(repoConfig.workflow, "gstack");
-  assert.equal("ecc" in repoConfig, false);
+  assert.equal(repoConfig.ecc.rulesSync, "repo-pattern-auto-cache");
   assert.equal(lock.setupPipeline, "gstack");
   assert.equal(lock.gstack.status, "installed");
   assert.equal(lock.gstack.planTuneHooks, false);
-  assert.equal("ecc" in lock, false);
+  assert.deepEqual(lock.ecc.appliedRules, ["common"]);
   const gstackLocalSettings = JSON.parse(await fs.readFile(path.join(gstackProvisionTarget, ".claude", "settings.local.json"), "utf8"));
   assert.equal(gstackLocalSettings.enabledPlugins["ecc@ecc"], undefined);
   assert.equal(gstackLocalSettings.workflowSizeGuideline, "large");
   assert.equal(gstackLocalSettings.env.ANTHROPIC_AUTH_TOKEN, secretSentinel);
-  await assert.rejects(() => fs.access(path.join(gstackProvisionTarget, ".claude", "rules")), { code: "ENOENT" });
+  await fs.access(path.join(gstackProvisionTarget, ".claude", "rules", "ecc", "common"));
   assert.equal((await auditProject(gstackProvisionTarget)).state, "GSTACK_MINIMAL");
   await doctorProject(gstackProvisionTarget);
 } finally {
@@ -1228,6 +1234,9 @@ try {
   assert.equal(settings.permissions.defaultMode, "default");
   assert.equal(settings.permissions.disableBypassPermissionsMode, "disable");
   const localSettings = JSON.parse(await fs.readFile(path.join(defaultProvisionTarget, ".claude", "settings.local.json"), "utf8"));
+  const defaultProvisionLock = JSON.parse(await fs.readFile(path.join(defaultProvisionTarget, ".repo-pattern", ".repo-pattern.lock.json"), "utf8"));
+  assert.deepEqual(defaultProvisionLock.ecc.appliedRules, ["common"]);
+  await fs.access(path.join(defaultProvisionTarget, ".claude", "rules", "ecc", "common"));
   assert.equal(localSettings.model, "sonnet");
   assert.equal(localSettings.workflowSizeGuideline, "small");
   assert.deepEqual({


### PR DESCRIPTION
## Summary
- support repo-pattern-managed ECC rules on gstack and none pipelines without enabling the ECC plugin
- install auto-detected rules by default for ECC/both setup; keep non-ECC rules opt-in through `--with-rules` or the interactive prompt
- validate managed `.claude/rules/ecc` across all pipelines and bump the package to v0.1.18

## Test plan
- [x] `npm test`
- [x] `npm run pack:dry`
- [x] `git diff --check`
- [x] dry-run ECC and gstack-with-rules setup flows

## Notes
- Branch is intentionally retained after merge.