### PR TITLE
v0.1.19 fix: synchronize setup configuration

### DIFF
--- a/.claude.example/settings.example.json
+++ b/.claude.example/settings.example.json
@@ -2,7 +2,8 @@
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "hooks": {},
   "attribution": {
-    "commit": ""
+    "commit": "",
+    "pr": ""
   },
   "permissions": {
     "deny": [

--- a/.claude.example/settings.local.example.json
+++ b/.claude.example/settings.local.example.json
@@ -11,17 +11,8 @@
   "spinnerTipsEnabled": true,
   "fileCheckpointingEnabled": true,
   "workflowSizeGuideline": "small",
-  "enabledPlugins": {
-    "ecc@ecc": true
-  },
-  "extraKnownMarketplaces": {
-    "ecc": {
-      "source": {
-        "source": "git",
-        "url": "https://github.com/affaan-m/ECC.git"
-      }
-    }
-  },
+  "enabledPlugins": {},
+  "extraKnownMarketplaces": {},
   "env": {
     "ENABLE_TOOL_SEARCH": "auto:5",
     "CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION": "4",

--- a/README.md
+++ b/README.md
@@ -128,6 +128,10 @@ target-project/
 
 `repo-pattern` preserves an existing root `CLAUDE.md` and keeps machine-local values out of git.
 
+`.claude/settings.json` is generated from the tracked shared-settings template. It owns Claude Code permissions, MCP approvals, hooks, and commit/PR attribution. `.claude/settings.local.json` is generated from the local-settings template. It owns provider values plus selected plugin and marketplace entries; it never owns attribution.
+
+Each full `repo-pattern setup` run reconciles repo-pattern-managed state to its current pipeline, rule, and optional-skill selection. It removes deselected managed plugins, marketplaces, local skills, and ECC rules, while preserving provider credentials, unrelated local settings, and unknown third-party plugins or marketplaces. The initialized-project **Add optional skills** action remains additive.
+
 ## Safety defaults
 
 * `.mcp.json` is gitignored because it may contain local values.

--- a/docs/repo-pattern/setup-guide.md
+++ b/docs/repo-pattern/setup-guide.md
@@ -441,11 +441,13 @@ Meaning:
 - defer MCP tool loading unless tools fit within 5% of context
 
 
-`repo-pattern setup` writes local ignored project settings from the tracked `.claude.example/settings.example.json` template:
+`repo-pattern setup` writes ignored shared project settings from the tracked `.claude.example/settings.example.json` template:
 
 ```text
 .claude/settings.json
 ```
+
+This file owns shared Claude Code configuration: permissions, MCP approvals, hooks, and attribution. Every setup run writes both `attribution.commit` and `attribution.pr`; `off` and `on` use empty strings, and `custom` writes the selected commit trailer with `pr: ""`.
 
 The template is intentionally safe by default:
 
@@ -476,11 +478,15 @@ For example, profile `web` sets:
 ]
 ```
 
-Local preferences and Anthropic provider/model values should go in:
+Local preferences and Anthropic provider/model values go in:
 
 ```text
 .claude/settings.local.json
 ```
+
+This file also contains `enabledPlugins` and `extraKnownMarketplaces` for ECC and selected optional plugin skills. Full `setup` treats its current pipeline and optional-skill selection as the source of truth: it removes deselected repo-pattern-managed plugin entries and legacy local attribution, but preserves provider credentials, unrelated local settings, and unknown third-party plugin and marketplace entries.
+
+Selected local-copy skills are written under `.claude/skills/`; selected ECC rule packs are written under `.claude/rules/ecc/`. A full setup rerun removes deselected repo-pattern-managed skill directories and ECC packs. The separate initialized-project **Add optional skills** action is add-only.
 
 `setup` asks for these values and writes the file for you:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@negikirin/repo-pattern",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@negikirin/repo-pattern",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^0.11.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@negikirin/repo-pattern",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "Minimal ECC-first Claude Code project setup and migrator",
   "type": "module",
   "bin": {

--- a/scripts/lib/audit.mjs
+++ b/scripts/lib/audit.mjs
@@ -77,17 +77,18 @@ export async function auditProject(target) {
   };
 
   const allowSourceSkills = repoPattern?.mode === "template";
-  const allowManagedSkills = repoPattern?.runtime?.localSkills === true && Array.isArray(repoPattern?.optionalSkills) && result.hasOnlyManagedSkills;
   const workflow = repoPattern?.workflow;
   const usesEcc = workflow === "ecc-native" || workflow === "ecc-gstack";
   const usesGstack = workflow === "gstack" || workflow === "ecc-gstack";
   const legacy = (
     result.hasSettingsHooks ||
-    (result.hasClaudeSkillsDir && !allowSourceSkills && !allowManagedSkills) ||
+    (result.hasClaudeSkillsDir && !repoPattern && !allowSourceSkills) ||
     result.hasClaudeCommandsDir ||
     result.hasClaudeHooksDir ||
     result.hasClaudeScriptsDir ||
-    (result.hasClaudeRulesDir && (repoPattern ? (!result.hasOnlyEccRulesDir || !result.hasManagedEccRules) : !result.hasOnlyEccRulesDir))
+    (result.hasClaudeRulesDir && (repoPattern
+      ? (result.hasClaudeEccRulesDir && !result.hasManagedEccRules)
+      : !result.hasOnlyEccRulesDir))
   );
 
   const setupComplete = !usesGstack || lock.gstack?.status === "installed";
@@ -134,7 +135,7 @@ export function printAudit(audit) {
     [audit.hasClaudeHooksDir, ".claude/hooks present"],
     [audit.hasClaudeScriptsDir, ".claude/scripts present"],
     [audit.hasClaudeRulesDir && !audit.hasOnlyEccRulesDir, "non-ECC .claude/rules present"],
-    [audit.hasClaudeRulesDir && !audit.hasManagedEccRules, ".claude/rules is not repo-pattern-managed"]
+    [audit.hasClaudeEccRulesDir && !audit.hasManagedEccRules, ".claude/rules/ecc is not repo-pattern-managed"]
   ].filter(([bad]) => bad);
 
   if (issues.length > 0) {

--- a/scripts/lib/doctor.mjs
+++ b/scripts/lib/doctor.mjs
@@ -29,12 +29,12 @@ export async function doctorProject(target, { updateLock = false, dryRun = false
   const lock = await readRepoLock(target, {});
   const allowSourceSkills = audit.repoPattern?.mode === "template";
   const managedSkills = audit.repoPattern?.runtime?.localSkills === true && Array.isArray(audit.repoPattern?.optionalSkills) && audit.hasOnlyManagedSkills;
-  check(!audit.hasClaudeSkillsDir || allowSourceSkills || managedSkills, ".claude/skills does not exist unless repo-pattern-managed optional skills are enabled");
+  check(!audit.hasClaudeSkillsDir || allowSourceSkills || audit.hasRepoPatternJson, ".claude/skills is preserved for initialized repo-pattern projects");
   check(!audit.hasClaudeCommandsDir, ".claude/commands does not exist");
   check(!audit.hasClaudeHooksDir, ".claude/hooks does not exist");
   check(!audit.hasClaudeScriptsDir, ".claude/scripts does not exist");
   const usesEcc = audit.repoPattern?.workflow === "ecc-native" || audit.repoPattern?.workflow === "ecc-gstack";
-  check(!audit.hasClaudeRulesDir || (audit.hasOnlyEccRulesDir && audit.hasManagedEccRules), "no unmanaged .claude/rules");
+  check(!audit.hasClaudeEccRulesDir || audit.hasManagedEccRules, ".claude/rules/ecc is repo-pattern-managed when present");
   check(audit.hasClaudeDir, ".claude exists");
   check(!audit.hasSettingsHooks, ".claude/settings.json hooks is {}");
   check(!isTracked(target, ".claude/settings.json"), ".claude/settings.json is not tracked");

--- a/scripts/lib/ecc.mjs
+++ b/scripts/lib/ecc.mjs
@@ -1,13 +1,17 @@
 import { execSync } from "node:child_process";
 import path from "node:path";
-import { appendGitignoreLine, ensureRepoPatternGitignore, isTracked, readJson, readRepoLock, repoLockPath, writeJson, writePrivateJson } from "./fs-utils.mjs";
+import { appendGitignoreLine, ensureRepoPatternGitignore, isTracked, readRepoLock, repoLockPath, writeJson, writePrivateJson } from "./fs-utils.mjs";
 import { printSummary } from "./prompt.mjs";
 
 const ECC_PLUGIN_ID = "ecc@ecc";
-const ECC_MARKETPLACE = {
-  source: {
-    source: "git",
-    url: "https://github.com/affaan-m/ECC.git"
+export const ECC_PLUGIN = {
+  id: ECC_PLUGIN_ID,
+  marketplaceName: "ecc",
+  marketplace: {
+    source: {
+      source: "git",
+      url: "https://github.com/affaan-m/ECC.git"
+    }
   }
 };
 
@@ -16,11 +20,11 @@ export function applyEccPluginSettings(settings = {}) {
     ...settings,
     enabledPlugins: {
       ...(settings.enabledPlugins || {}),
-      [ECC_PLUGIN_ID]: true
+      [ECC_PLUGIN.id]: true
     },
     extraKnownMarketplaces: {
       ...(settings.extraKnownMarketplaces || {}),
-      ecc: ECC_MARKETPLACE
+      [ECC_PLUGIN.marketplaceName]: ECC_PLUGIN.marketplace
     }
   };
 }
@@ -33,10 +37,9 @@ function hasEccPlugin() {
   }
 }
 
-async function writeEccLocalSettings({ target, dryRun }) {
+async function ensureEccLocalSettings({ target, dryRun }) {
   if (isTracked(target, ".claude/settings.local.json")) throw new Error(".claude/settings.local.json is tracked. Untrack it before writing local plugin settings.");
-  const file = path.join(target, ".claude", "settings.local.json");
-  await writePrivateJson(file, applyEccPluginSettings, {
+  await writePrivateJson(path.join(target, ".claude", "settings.local.json"), applyEccPluginSettings, {
     dryRun,
     label: ".claude/settings.local.json",
     parentLabel: ".claude"
@@ -44,8 +47,8 @@ async function writeEccLocalSettings({ target, dryRun }) {
   await appendGitignoreLine(target, ".claude/", { dryRun });
 }
 
-export async function setupEcc({ target, dryRun = false }) {
-  await writeEccLocalSettings({ target, dryRun });
+export async function setupEcc({ target, dryRun = false, configurePlugin = true }) {
+  if (configurePlugin) await ensureEccLocalSettings({ target, dryRun });
   let status = hasEccPlugin() ? "installed" : "manual-plugin-install-required";
 
   if (status === "installed") {

--- a/scripts/lib/provision.mjs
+++ b/scripts/lib/provision.mjs
@@ -3,13 +3,13 @@ import path from "node:path";
 import { auditProject, printAudit } from "./audit.mjs";
 import { cleanupProject } from "./cleanup.mjs";
 import { generateMcp, withoutPersistedMcpValues } from "./mcp.mjs";
-import { setupEcc } from "./ecc.mjs";
-import { removeEccPluginSettings, setupGstack } from "./gstack.mjs";
+import { ECC_PLUGIN, applyEccPluginSettings, setupEcc } from "./ecc.mjs";
+import { setupGstack } from "./gstack.mjs";
 import { doctorProject } from "./doctor.mjs";
-import { applyEccRules } from "./rules.mjs";
-import { appendGitignoreLine, backupPaths, copyRecursive, ensureDir, ensureRepoPatternGitignore, isTracked, readJson, removePath, repoConfigPath, repoLockPath, writeJson, writeIfMissing, writePrivateJson } from "./fs-utils.mjs";
+import { applyEccRules, clearEccRules } from "./rules.mjs";
+import { appendGitignoreLine, backupPaths, copyRecursive, ensureDir, ensureRepoPatternGitignore, isTracked, readJson, readRepoConfig, removePath, repoConfigPath, repoLockPath, writeJson, writeIfMissing, writePrivateJson } from "./fs-utils.mjs";
 import { printSummary, style } from "./prompt.mjs";
-import { applyOptionalSkills } from "./skills.mjs";
+import { applyOptionalSkills, reconcilePluginSkillSettings } from "./skills.mjs";
 
 const TARGET_CLAUDE_MD = "";
 const BASIC_GITIGNORE_LINES = [".DS_Store", "Thumbs.db", ".vscode/", ".idea/"];
@@ -104,21 +104,13 @@ function lockConfig(profile, setupPipeline, pipelineStatus = {}, planTuneHooks =
 }
 
 export function applyAttributionSetting(settings, attributionConfig = { mode: "off" }) {
-  const next = { ...settings };
-  if (attributionConfig.mode === "on") {
-    if (!next.attribution) return next;
-    const { commit, ...rest } = next.attribution;
-    if (Object.keys(rest).length > 0) next.attribution = rest;
-    else delete next.attribution;
-    return next;
-  }
-
-  next.attribution = {
-    ...(next.attribution || {}),
-    commit: attributionConfig.mode === "custom" ? attributionConfig.commit : "",
-    ...(attributionConfig.mode === "off" ? { pr: "" } : {})
+  return {
+    ...settings,
+    attribution: {
+      commit: attributionConfig.mode === "custom" ? attributionConfig.commit : "",
+      pr: ""
+    }
   };
-  return next;
 }
 
 export function applyPermissionSettings(settings, permissionConfig = { bypass: "deny" }) {
@@ -165,6 +157,19 @@ export function applyLocalSettings(settings, localSettingsEnv) {
   return { ...settings, env };
 }
 
+export function reconcileLocalPluginSettings(settings = {}, { setupPipeline, optionalSkills = [] }) {
+  const { attribution, ...withoutAttribution } = settings;
+  const withoutManagedSkills = reconcilePluginSkillSettings(withoutAttribution, optionalSkills);
+  const enabledPlugins = { ...(withoutManagedSkills.enabledPlugins || {}) };
+  const extraKnownMarketplaces = { ...(withoutManagedSkills.extraKnownMarketplaces || {}) };
+  delete enabledPlugins[ECC_PLUGIN.id];
+  delete extraKnownMarketplaces[ECC_PLUGIN.marketplaceName];
+  const withoutManagedPlugins = { ...withoutManagedSkills, enabledPlugins, extraKnownMarketplaces };
+  return setupPipeline === "ecc" || setupPipeline === "both"
+    ? applyEccPluginSettings(withoutManagedPlugins)
+    : withoutManagedPlugins;
+}
+
 async function rejectClaudeSymlink(target, { dryRun = false } = {}) {
   if (dryRun) return;
   let stat;
@@ -177,17 +182,17 @@ async function rejectClaudeSymlink(target, { dryRun = false } = {}) {
   if (stat.isSymbolicLink()) throw new Error(".claude must not be a symlink.");
 }
 
-async function writeLocalSettings({ sourceRoot, target, localSettingsEnv = {}, dryRun }) {
+async function writeLocalSettings({ sourceRoot, target, localSettingsEnv = {}, setupPipeline, optionalSkills, dryRun }) {
   if (isTracked(target, ".claude/settings.local.json")) throw new Error(".claude/settings.local.json is tracked. Untrack it before writing local provider settings.");
   const claudeDir = path.join(target, ".claude");
   await rejectClaudeSymlink(target, { dryRun });
   const template = await readJson(path.join(sourceRoot, ".claude.example", "settings.local.example.json"), {});
   const file = path.join(claudeDir, "settings.local.json");
-  await writePrivateJson(file, (current) => applyLocalSettings({
+  await writePrivateJson(file, (current) => reconcileLocalPluginSettings(applyLocalSettings({
     ...template,
     ...current,
     env: { ...(template.env || {}), ...(current.env || {}) }
-  }, localSettingsEnv), {
+  }, localSettingsEnv), { setupPipeline, optionalSkills }), {
     dryRun,
     label: ".claude/settings.local.json"
   });
@@ -210,6 +215,7 @@ export async function provisionProject({ sourceRoot, target, profile = "web", se
   if (isTracked(target, ".repo-pattern/.repo-pattern.lock.json") || isTracked(target, ".repo-pattern.lock.json")) throw new Error("repo-pattern lock is tracked. Untrack it before writing local setup state.");
 
   const gstackStatus = usesGstack(setupPipeline) ? await setupGstack({ target, dryRun, planTuneHooks }) : null;
+  const previousRepoConfig = await readRepoConfig(target, {});
 
   if (audit.state === "LEGACY_VENDOR") {
     await cleanupProject({ sourceRoot, target, dryRun });
@@ -232,22 +238,25 @@ export async function provisionProject({ sourceRoot, target, profile = "web", se
   await writeClaudeSettings({ sourceRoot, target, attributionConfig, permissionConfig, dryRun });
   await appendGitignoreLine(target, ".claude/", { dryRun });
 
-  await writeLocalSettings({ sourceRoot, target, localSettingsEnv, dryRun });
+  await writeLocalSettings({ sourceRoot, target, localSettingsEnv, setupPipeline, optionalSkills, dryRun });
 
   await ensureRepoPatternGitignore(target, { dryRun });
   const lockPath = repoLockPath(target);
 
   const mcpResult = await generateMcp({ sourceRoot, target, profile, mcpServers, mcpValues, dryRun });
-  const eccStatus = usesEcc(setupPipeline) ? await setupEcc({ sourceRoot, target, dryRun }) : null;
-  if (setupPipeline === "gstack" || setupPipeline === "none") {
-    await removeEccPluginSettings({ target, dryRun });
-    await removePath(path.join(target, ".claude", "rules"), { dryRun });
-  }
+  const eccStatus = usesEcc(setupPipeline) ? await setupEcc({ sourceRoot, target, dryRun, configurePlugin: false }) : null;
   await writeJson(repoConfigPath(target), await repoPatternConfig(sourceRoot, profile, setupPipeline), { dryRun });
   await writeJson(lockPath, lockConfig(profile, setupPipeline, { ecc: eccStatus, gstack: gstackStatus }, planTuneHooks), { dryRun });
   await ensureRepoPatternGitignore(target, { dryRun });
   if (shouldApplyRules) await applyEccRules({ target, dryRun, ruleMode, rules });
-  if (optionalSkills.length > 0) await applyOptionalSkills({ target, skills: optionalSkills, dryRun });
+  else await clearEccRules({ target, dryRun });
+  await applyOptionalSkills({
+    target,
+    skills: optionalSkills,
+    dryRun,
+    reconcile: true,
+    previousOptionalSkills: previousRepoConfig.optionalSkills
+  });
 
   if (dryRun) {
     console.log("[dry-run] doctor skipped because no files were written.");

--- a/scripts/lib/rules.mjs
+++ b/scripts/lib/rules.mjs
@@ -102,6 +102,33 @@ async function ensureEccCache(target, { dryRun = false } = {}) {
   return eccCache;
 }
 
+export async function clearEccRules({ target, dryRun = false }) {
+  const destRoot = path.join(target, ".claude", "rules", "ecc");
+  await backupPaths(target, [".claude/rules/ecc"], { dryRun });
+  await removePath(destRoot, { dryRun });
+  if (!dryRun) {
+    try {
+      await fs.rmdir(path.join(target, ".claude", "rules"));
+    } catch (error) {
+      if (!["ENOENT", "ENOTEMPTY", "EEXIST"].includes(error.code)) throw error;
+    }
+  }
+
+  const repoConfig = await readRepoConfig(target, {});
+  if (repoConfig.ecc) {
+    const { rulesSync, rulesProfile, rulesScope, copyRuntimeSurfaces, ...ecc } = repoConfig.ecc;
+    repoConfig.ecc = ecc;
+    await writeJson(repoConfigPath(target), repoConfig, { dryRun });
+  }
+
+  const lock = await readRepoLock(target, {});
+  if (lock.ecc) {
+    const { rulesSyncedBy, rulesProfile, rulesScope, recommendedRules, appliedRules, detectedStack, rulesSource, rulesCache, rulesAppliedAt, ...ecc } = lock.ecc;
+    lock.ecc = { ...ecc, rulesSyncedBy: null, rulesScope: "project", recommendedRules: [], appliedRules: [] };
+    await writeJson(repoLockPath(target), lock, { dryRun });
+  }
+}
+
 export async function applyEccRules({ target, dryRun = false, ruleMode = "auto", rules = null }) {
   const detection = await detectProject(target);
   const invalidRules = ruleMode === "manual" ? invalidEccRules(rules) : [];

--- a/scripts/lib/setup.mjs
+++ b/scripts/lib/setup.mjs
@@ -438,21 +438,8 @@ export async function setupProject({ sourceRoot, target, profile = "web", setupP
     if (!yes) throw new Error("setup requires an interactive terminal, or pass --yes for scriptable mode.");
     if (profile === "custom") throw new Error("setup --yes cannot use the custom profile; choose a named profile.");
 
-    const audit = await auditProject(target);
     const detection = await detectProject(target);
     const ruleConfig = defaultRuleConfig(setupPipeline, applyRules, detection);
-    const hasIncompleteSetup = Boolean(setupOptionsFromLock(await readRepoLock(target, {})));
-    const expectedState = expectedSetupState(setupPipeline);
-    if (audit.state === expectedState && hasRequestedRules(audit, ruleConfig) && !hasIncompleteSetup && !force && optionalSkills.length === 0) {
-      await doctorProject(target, { dryRun });
-      return;
-    }
-
-    if (audit.state === expectedState && hasRequestedRules(audit, ruleConfig) && optionalSkills.length > 0) {
-      await applyOptionalSkills({ target, skills: optionalSkills, dryRun });
-      if (!dryRun) await doctorProject(target, { updateLock: true, dryRun });
-      return;
-    }
 
     await provisionProject({
       sourceRoot,
@@ -494,17 +481,6 @@ export async function setupProject({ sourceRoot, target, profile = "web", setupP
 
   if (audit.state === "LEGACY_VENDOR" && force && !migrate) {
     throw new Error("Target has legacy/local Claude runtime surfaces. Re-run setup with --migrate, not --force.");
-  }
-
-  const expectedState = expectedSetupState(selectedSetupPipeline);
-  if (audit.state === expectedState && hasRequestedRules(audit, ruleConfig)) {
-    if (selectedOptionalSkills.length > 0) {
-      await applyOptionalSkills({ target, skills: selectedOptionalSkills, dryRun });
-      if (!dryRun) await doctorProject(target, { updateLock: true, dryRun });
-    } else {
-      await handleInitialized({ sourceRoot, target, profile: chosenProfile, dryRun });
-    }
-    return;
   }
 
   const action = audit.state === "LEGACY_VENDOR" ? "migrate" : "setup";

--- a/scripts/lib/skills.mjs
+++ b/scripts/lib/skills.mjs
@@ -124,6 +124,20 @@ function pluginId(skill) {
   return `${skill.plugin.name}@${skill.plugin.marketplace}`;
 }
 
+export function selectedPluginSkills(skills = []) {
+  return normalizeOptionalSkills(skills).map(knownSkill).filter((skill) => skill?.plugin);
+}
+
+export function reconcilePluginSkillSettings(settings = {}, skills = []) {
+  const enabledPlugins = { ...(settings.enabledPlugins || {}) };
+  const extraKnownMarketplaces = { ...(settings.extraKnownMarketplaces || {}) };
+  for (const skill of OPTIONAL_SKILLS.filter((entry) => entry.plugin)) {
+    delete enabledPlugins[pluginId(skill)];
+    delete extraKnownMarketplaces[skill.plugin.marketplace];
+  }
+  return applyPluginSkillSettings({ ...settings, enabledPlugins, extraKnownMarketplaces }, selectedPluginSkills(skills));
+}
+
 export function applyPluginSkillSettings(settings = {}, skills = []) {
   const next = {
     ...settings,
@@ -270,39 +284,55 @@ async function copySkill(skill, cacheDir, destRoot, { dryRun = false } = {}) {
   return [skill.destName];
 }
 
-export async function applyOptionalSkills({ target, skills = [], dryRun = false }) {
+export async function applyOptionalSkills({
+  target,
+  skills = [],
+  dryRun = false,
+  reconcile = false,
+  previousOptionalSkills = null
+}) {
   const selected = normalizeOptionalSkills(skills);
   const invalid = invalidOptionalSkills(selected);
   if (invalid.length > 0) throw new Error(`Unknown optional skill(s): ${invalid.join(", ")}`);
-  if (selected.length === 0) return { selectedSkills: [], appliedSkills: [] };
 
   const chosen = selected.map(knownSkill);
   const repoConfig = await readRepoConfig(target, {});
-  const desired = [...new Set([...(repoConfig.optionalSkills || []), ...chosen].map((entry) => entry.name || entry.value))]
-    .map(knownSkill)
-    .filter(Boolean);
+  const previousSkills = previousOptionalSkills || repoConfig.optionalSkills || [];
+  const desired = reconcile
+    ? chosen
+    : [...new Set([...previousSkills, ...chosen].map((entry) => entry.name || entry.value))]
+      .map(knownSkill)
+      .filter(Boolean);
   const pluginSkills = desired.filter((skill) => skill.plugin);
   const localSkills = desired.filter((skill) => !skill.plugin);
-  const shouldSyncLocalSkills = chosen.some((skill) => !skill.plugin);
+  const shouldSyncLocalSkills = reconcile || chosen.some((skill) => !skill.plugin);
   const destRoot = path.join(target, ".claude", "skills");
-  await writePluginSkillSettings({ target, skills: pluginSkills, dryRun });
+  if (!reconcile) await writePluginSkillSettings({ target, skills: pluginSkills, dryRun });
 
-  const appliedSkills = shouldSyncLocalSkills
-    ? []
-    : (repoConfig.optionalSkills || []).filter((entry) => {
+  const appliedSkills = [];
+  if (shouldSyncLocalSkills) {
+    await backupPaths(target, [".claude/skills"], { dryRun });
+    const previousLocalSkills = previousSkills.filter((entry) => {
       const skill = knownSkill(entry.name);
       return skill && !skill.plugin;
     });
-  if (shouldSyncLocalSkills) {
-    await backupPaths(target, [".claude/skills"], { dryRun });
-    await removePath(destRoot, { dryRun });
-    await ensureDir(destRoot, { dryRun });
-    await ensureRepoPatternGitignore(target, { dryRun });
-
-    for (const skill of localSkills) {
-      const cacheDir = await syncSkillCache(target, skill, { dryRun });
-      const installedDirs = await copySkill(skill, cacheDir, destRoot, { dryRun });
-      appliedSkills.push({ name: skill.value, source: skill.source, revision: skill.revision, license: skill.license, installedDirs });
+    for (const skill of previousLocalSkills) {
+      for (const dir of skill.installedDirs || []) await removePath(path.join(destRoot, dir), { dryRun });
+    }
+    if (localSkills.length > 0) {
+      await ensureDir(destRoot, { dryRun });
+      await ensureRepoPatternGitignore(target, { dryRun });
+      for (const skill of localSkills) {
+        const cacheDir = await syncSkillCache(target, skill, { dryRun });
+        const installedDirs = await copySkill(skill, cacheDir, destRoot, { dryRun });
+        appliedSkills.push({ name: skill.value, source: skill.source, revision: skill.revision, license: skill.license, installedDirs });
+      }
+    } else if (!dryRun) {
+      try {
+        await fs.rmdir(destRoot);
+      } catch (error) {
+        if (!["ENOENT", "ENOTEMPTY", "EEXIST"].includes(error.code)) throw error;
+      }
     }
 
     const repoPatternDir = path.join(target, ".repo-pattern");
@@ -317,6 +347,8 @@ export async function applyOptionalSkills({ target, skills = [], dryRun = false 
         if (!["ENOENT", "ENOTEMPTY", "EEXIST"].includes(error.code)) throw error;
       }
     }
+  } else {
+    appliedSkills.push(...(repoConfig.optionalSkills || []).filter((entry) => !knownSkill(entry.name)?.plugin));
   }
 
   appliedSkills.push(...pluginSkills.map((skill) => ({ name: skill.value, source: skill.source, revision: skill.revision, license: skill.license, installedDirs: [], plugin: skill.plugin })));
@@ -334,7 +366,7 @@ export async function applyOptionalSkills({ target, skills = [], dryRun = false 
   printSummary("Applied optional skills", [
     ["Plugin settings", pluginSkills.length ? ".claude/settings.local.json" : "none"],
     ["Local skill path", localSkills.length ? path.relative(target, destRoot) : "none"],
-    ["Skills", selected.join(", ")]
+    ["Skills", selected.join(", ") || "none"]
   ]);
 
   return { selectedSkills: selected, appliedSkills };

--- a/scripts/self-check.mjs
+++ b/scripts/self-check.mjs
@@ -7,10 +7,10 @@ import { fileURLToPath } from "node:url";
 import { auditProject, printAudit } from "./lib/audit.mjs";
 import { cleanupProject } from "./lib/cleanup.mjs";
 import { doctorProject } from "./lib/doctor.mjs";
-import { applyEccPluginSettings, setupEcc } from "./lib/ecc.mjs";
+import { ECC_PLUGIN, applyEccPluginSettings, setupEcc } from "./lib/ecc.mjs";
 import { ensureBun, gstackEnvironment, gstackSummaryRows, isValidBunInstaller, removeEccPluginSettings, runGstackSetup, setupGstack } from "./lib/gstack.mjs";
 import { applyMcpValues, generateMcp, mcpSecretPrompt, persistedMcpValues, readGeneratedMcpValues, validateRelativeMcpPath } from "./lib/mcp.mjs";
-import { applyAttributionSetting, applyLocalSettings, applyPermissionSettings, provisionProject, setupPipelineScope, updateClaudePermissions } from "./lib/provision.mjs";
+import { applyAttributionSetting, applyLocalSettings, applyPermissionSettings, provisionProject, reconcileLocalPluginSettings, setupPipelineScope, updateClaudePermissions } from "./lib/provision.mjs";
 import { writePrivateJson } from "./lib/fs-utils.mjs";
 import { printSummary, renderLogo, style } from "./lib/prompt.mjs";
 import { needsLocalSettingsPrompt, setupProject, setupRetryOptions } from "./lib/setup.mjs";
@@ -21,8 +21,15 @@ const cliDir = path.dirname(fileURLToPath(import.meta.url));
 const cliPath = path.join(cliDir, "repo-pattern.mjs");
 const repoRoot = path.dirname(cliDir);
 const secretSentinel = "do-not-persist-anthropic-token";
+const sharedSettingsTemplate = JSON.parse(await fs.readFile(path.join(repoRoot, ".claude.example", "settings.example.json"), "utf8"));
 const localSettingsTemplate = JSON.parse(await fs.readFile(path.join(repoRoot, ".claude.example", "settings.local.example.json"), "utf8"));
 
+assert.deepEqual(sharedSettingsTemplate.attribution, { commit: "", pr: "" });
+assert.equal("enabledPlugins" in sharedSettingsTemplate, false);
+assert.equal("extraKnownMarketplaces" in sharedSettingsTemplate, false);
+assert.equal("attribution" in localSettingsTemplate, false);
+assert.deepEqual(localSettingsTemplate.enabledPlugins, {});
+assert.deepEqual(localSettingsTemplate.extraKnownMarketplaces, {});
 assert.equal(localSettingsTemplate.workflowSizeGuideline, "small");
 assert.deepEqual({
   CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION: localSettingsTemplate.env.CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION,
@@ -106,8 +113,25 @@ assert.deepEqual(applyLocalSettings({ env: {
   }
 });
 assert.deepEqual(applyAttributionSetting({ hooks: {} }, { mode: "off" }), { hooks: {}, attribution: { commit: "", pr: "" } });
-assert.deepEqual(applyAttributionSetting({ attribution: { commit: "" } }, { mode: "on" }), {});
-assert.deepEqual(applyAttributionSetting({ attribution: { pr: "PR" } }, { mode: "custom", commit: "Custom" }), { attribution: { pr: "PR", commit: "Custom" } });
+assert.deepEqual(applyAttributionSetting({ attribution: { commit: "old", pr: "old" } }, { mode: "on" }), { attribution: { commit: "", pr: "" } });
+assert.deepEqual(applyAttributionSetting({ attribution: { pr: "PR" } }, { mode: "custom", commit: "Custom" }), { attribution: { commit: "Custom", pr: "" } });
+assert.deepEqual(reconcileLocalPluginSettings({
+  env: { ANTHROPIC_AUTH_TOKEN: secretSentinel },
+  custom: true,
+  attribution: { commit: "legacy" },
+  enabledPlugins: { "ecc@ecc": true, "taste-skill@taste-skill": true, "unknown@plugin": true },
+  extraKnownMarketplaces: { ecc: ECC_PLUGIN.marketplace, "taste-skill": { source: { source: "git", url: "https://example.com/stale.git" } }, unknown: { source: { source: "git", url: "https://example.com/unknown.git" } } }
+}, { setupPipeline: "gstack", optionalSkills: [] }), {
+  env: { ANTHROPIC_AUTH_TOKEN: secretSentinel },
+  custom: true,
+  enabledPlugins: { "unknown@plugin": true },
+  extraKnownMarketplaces: { unknown: { source: { source: "git", url: "https://example.com/unknown.git" } } }
+});
+assert.deepEqual(reconcileLocalPluginSettings({ enabledPlugins: { "unknown@plugin": true }, extraKnownMarketplaces: {} }, { setupPipeline: "both", optionalSkills: ["impeccable"] }).enabledPlugins, {
+  "unknown@plugin": true,
+  "ecc@ecc": true,
+  "impeccable@impeccable": true
+});
 assert.deepEqual(applyPermissionSettings({ permissions: { deny: ["Read(.env)"] } }, { bypass: "allow" }), {
   permissions: { deny: ["Read(.env)"], defaultMode: "bypassPermissions" }
 });
@@ -281,11 +305,27 @@ try {
     }]
   }), "utf8");
   await applyOptionalSkills({ target: mixedSkillTarget, skills: ["taste"] });
-  console.log = originalSkillLog;
-  const repoConfig = JSON.parse(await fs.readFile(path.join(mixedSkillTarget, ".repo-pattern", ".repo-pattern.json"), "utf8"));
+  let repoConfig = JSON.parse(await fs.readFile(path.join(mixedSkillTarget, ".repo-pattern", ".repo-pattern.json"), "utf8"));
   assert.equal(await fs.readFile(path.join(mixedSkillTarget, ".claude", "skills", "document-specialist-skill", "KEEP"), "utf8"), "ok");
   assert.equal(repoConfig.runtime.localSkills, true);
   assert.deepEqual(repoConfig.optionalSkills.map((entry) => entry.name), ["document-specialist", "taste"]);
+
+  await fs.rename(
+    path.join(mixedSkillTarget, ".repo-pattern", ".repo-pattern.json"),
+    path.join(mixedSkillTarget, ".repo-pattern.json")
+  );
+  await provisionProject({
+    sourceRoot: repoRoot,
+    target: mixedSkillTarget,
+    profile: "minimal",
+    setupPipeline: "none",
+    applyRules: false
+  });
+  console.log = originalSkillLog;
+  repoConfig = JSON.parse(await fs.readFile(path.join(mixedSkillTarget, ".repo-pattern", ".repo-pattern.json"), "utf8"));
+  await assert.rejects(() => fs.access(path.join(mixedSkillTarget, ".claude", "skills", "document-specialist-skill")), { code: "ENOENT" });
+  assert.equal(repoConfig.runtime.localSkills, false);
+  assert.deepEqual(repoConfig.optionalSkills, []);
 } finally {
   console.log = originalSkillLog;
   await fs.rm(mixedSkillTarget, { recursive: true, force: true });
@@ -410,6 +450,7 @@ try {
     target: "/tmp/project",
     state: "LEGACY_VENDOR",
     hasClaudeRulesDir: true,
+    hasClaudeEccRulesDir: true,
     hasOnlyEccRulesDir: true,
     repoPattern: { workflow: "gstack" }
   });
@@ -423,7 +464,7 @@ assert(auditLogs.includes("State   EMPTY"));
 assert(!auditLogs.some((line) => line.includes(".claude present")));
 assert(auditLogs.some((line) => line.includes("⚠ .mcp.json missing")));
 assert(auditLogs.some((line) => line.includes("⚠ .claude/settings.json hooks not empty")));
-assert(auditLogs.some((line) => line.includes("⚠ .claude/rules is not repo-pattern-managed")));
+assert(auditLogs.some((line) => line.includes("⚠ .claude/rules/ecc is not repo-pattern-managed")));
 
 const logs = [];
 const originalLog = console.log;
@@ -877,6 +918,7 @@ try {
   assert.equal(lock.gstack.status, "installed");
   assert.equal(lock.gstack.planTuneHooks, true);
   assert.equal(localSettings.enabledPlugins["ecc@ecc"], true);
+  assert.equal(localSettings.extraKnownMarketplaces.ecc.source.url, "https://github.com/affaan-m/ECC.git");
   assert.equal((await auditProject(bothProvisionTarget)).state, "ECC_GSTACK_MINIMAL");
   await doctorProject(bothProvisionTarget);
 } finally {
@@ -938,9 +980,19 @@ try {
   await fs.mkdir(path.join(gstackProvisionTarget, ".claude", "rules", "ecc", "typescript"), { recursive: true });
   await fs.writeFile(path.join(gstackProvisionTarget, ".claude", "settings.local.json"), JSON.stringify({
     workflowSizeGuideline: "large",
+    custom: true,
+    attribution: { commit: "legacy", pr: "legacy" },
     env: { ANTHROPIC_AUTH_TOKEN: secretSentinel },
-    enabledPlugins: { "ecc@ecc": true },
-    extraKnownMarketplaces: { ecc: { source: { source: "git", url: "https://github.com/affaan-m/ECC.git" } } }
+    enabledPlugins: {
+      "ecc@ecc": true,
+      "taste-skill@taste-skill": true,
+      "unknown@plugin": true
+    },
+    extraKnownMarketplaces: {
+      ecc: { source: { source: "git", url: "https://github.com/affaan-m/ECC.git" } },
+      "taste-skill": { source: { source: "git", url: "https://example.com/taste.git" } },
+      unknown: { source: { source: "git", url: "https://example.com/unknown.git" } }
+    }
   }), { mode: 0o600 });
   process.env.REPO_PATTERN_GSTACK_SETUP_CMD = "true";
   await provisionProject({
@@ -960,15 +1012,130 @@ try {
   assert.deepEqual(lock.ecc.appliedRules, ["common"]);
   const gstackLocalSettings = JSON.parse(await fs.readFile(path.join(gstackProvisionTarget, ".claude", "settings.local.json"), "utf8"));
   assert.equal(gstackLocalSettings.enabledPlugins["ecc@ecc"], undefined);
+  assert.equal(gstackLocalSettings.enabledPlugins["taste-skill@taste-skill"], undefined);
+  assert.equal(gstackLocalSettings.enabledPlugins["unknown@plugin"], true);
+  assert.equal(gstackLocalSettings.extraKnownMarketplaces.ecc, undefined);
+  assert.equal(gstackLocalSettings.extraKnownMarketplaces["taste-skill"], undefined);
+  assert.equal(gstackLocalSettings.extraKnownMarketplaces.unknown.source.url, "https://example.com/unknown.git");
+  assert.equal("attribution" in gstackLocalSettings, false);
+  assert.equal(gstackLocalSettings.custom, true);
   assert.equal(gstackLocalSettings.workflowSizeGuideline, "large");
   assert.equal(gstackLocalSettings.env.ANTHROPIC_AUTH_TOKEN, secretSentinel);
   await fs.access(path.join(gstackProvisionTarget, ".claude", "rules", "ecc", "common"));
   assert.equal((await auditProject(gstackProvisionTarget)).state, "GSTACK_MINIMAL");
   await doctorProject(gstackProvisionTarget);
+
+  await provisionProject({
+    sourceRoot: repoRoot,
+    target: gstackProvisionTarget,
+    profile: "minimal",
+    setupPipeline: "both",
+    optionalSkills: ["nextjs-pattern"],
+    applyRules: false
+  });
+  await fs.access(path.join(gstackProvisionTarget, ".claude", "skills", "nextjs-pattern"));
+
+  await provisionProject({
+    sourceRoot: repoRoot,
+    target: gstackProvisionTarget,
+    profile: "minimal",
+    setupPipeline: "both",
+    optionalSkills: ["impeccable"],
+    applyRules: false
+  });
+  await assert.rejects(() => fs.access(path.join(gstackProvisionTarget, ".claude", "skills", "nextjs-pattern")), { code: "ENOENT" });
+  const reconciledLocalSettings = JSON.parse(await fs.readFile(path.join(gstackProvisionTarget, ".claude", "settings.local.json"), "utf8"));
+  const reconciledLock = JSON.parse(await fs.readFile(path.join(gstackProvisionTarget, ".repo-pattern", ".repo-pattern.lock.json"), "utf8"));
+  assert.equal(reconciledLocalSettings.enabledPlugins["ecc@ecc"], true);
+  assert.equal(reconciledLocalSettings.enabledPlugins["taste-skill@taste-skill"], undefined);
+  assert.equal(reconciledLocalSettings.enabledPlugins["impeccable@impeccable"], true);
+  assert.equal(reconciledLocalSettings.enabledPlugins["unknown@plugin"], true);
+  assert.equal(reconciledLocalSettings.extraKnownMarketplaces["taste-skill"], undefined);
+  assert.equal(reconciledLocalSettings.extraKnownMarketplaces.impeccable.source.url, "https://github.com/pbakaus/impeccable.git");
+  assert.equal(reconciledLocalSettings.extraKnownMarketplaces.unknown.source.url, "https://example.com/unknown.git");
+  assert.equal(reconciledLocalSettings.env.ANTHROPIC_AUTH_TOKEN, secretSentinel);
+  assert.equal(reconciledLock.ecc.appliedRules.length, 0);
+  await assert.rejects(() => fs.access(path.join(gstackProvisionTarget, ".claude", "rules", "ecc", "common")), { code: "ENOENT" });
+  await assert.rejects(() => fs.access(path.join(gstackProvisionTarget, ".claude", "rules")), { code: "ENOENT" });
+
+  await provisionProject({
+    sourceRoot: repoRoot,
+    target: gstackProvisionTarget,
+    profile: "minimal",
+    setupPipeline: "gstack",
+    optionalSkills: [],
+    applyRules: false
+  });
+  const deselectedLocalSettings = JSON.parse(await fs.readFile(path.join(gstackProvisionTarget, ".claude", "settings.local.json"), "utf8"));
+  const deselectedConfig = JSON.parse(await fs.readFile(path.join(gstackProvisionTarget, ".repo-pattern", ".repo-pattern.json"), "utf8"));
+  const deselectedLock = JSON.parse(await fs.readFile(path.join(gstackProvisionTarget, ".repo-pattern", ".repo-pattern.lock.json"), "utf8"));
+  assert.deepEqual(deselectedConfig.optionalSkills, []);
+  assert.equal(deselectedConfig.runtime.localSkills, false);
+  assert.deepEqual(deselectedLock.optionalSkills.appliedSkills, []);
+  assert.equal(deselectedLocalSettings.enabledPlugins["ecc@ecc"], undefined);
+  assert.equal(deselectedLocalSettings.enabledPlugins["impeccable@impeccable"], undefined);
+  assert.equal(deselectedLocalSettings.enabledPlugins["unknown@plugin"], true);
+
+  const idempotentSnapshot = JSON.stringify({
+    settings: deselectedLocalSettings,
+    config: deselectedConfig,
+    appliedSkills: deselectedLock.optionalSkills.appliedSkills,
+    appliedRules: deselectedLock.ecc?.appliedRules || []
+  });
+  await provisionProject({
+    sourceRoot: repoRoot,
+    target: gstackProvisionTarget,
+    profile: "minimal",
+    setupPipeline: "gstack",
+    optionalSkills: [],
+    applyRules: false
+  });
+  const idempotentSettings = JSON.parse(await fs.readFile(path.join(gstackProvisionTarget, ".claude", "settings.local.json"), "utf8"));
+  const idempotentConfig = JSON.parse(await fs.readFile(path.join(gstackProvisionTarget, ".repo-pattern", ".repo-pattern.json"), "utf8"));
+  const idempotentLock = JSON.parse(await fs.readFile(path.join(gstackProvisionTarget, ".repo-pattern", ".repo-pattern.lock.json"), "utf8"));
+  assert.equal(JSON.stringify({
+    settings: idempotentSettings,
+    config: idempotentConfig,
+    appliedSkills: idempotentLock.optionalSkills.appliedSkills,
+    appliedRules: idempotentLock.ecc?.appliedRules || []
+  }), idempotentSnapshot);
 } finally {
   delete process.env.REPO_PATTERN_GSTACK_SETUP_CMD;
   console.log = originalLog;
   await fs.rm(gstackProvisionTarget, { recursive: true, force: true });
+}
+
+const unrelatedRulesTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-unrelated-rules-"));
+console.log = () => {};
+try {
+  await provisionProject({
+    sourceRoot: repoRoot,
+    target: unrelatedRulesTarget,
+    profile: "minimal",
+    setupPipeline: "none",
+    applyRules: false
+  });
+  const unrelatedRulePath = path.join(unrelatedRulesTarget, ".claude", "rules", "third-party", "rule.md");
+  const unrelatedSkillPath = path.join(unrelatedRulesTarget, ".claude", "skills", "third-party", "SKILL.md");
+  await fs.mkdir(path.dirname(unrelatedRulePath), { recursive: true });
+  await fs.mkdir(path.dirname(unrelatedSkillPath), { recursive: true });
+  await fs.writeFile(unrelatedRulePath, "preserve", "utf8");
+  await fs.writeFile(unrelatedSkillPath, "preserve", "utf8");
+
+  await provisionProject({
+    sourceRoot: repoRoot,
+    target: unrelatedRulesTarget,
+    profile: "minimal",
+    setupPipeline: "none",
+    applyRules: false
+  });
+  assert.equal(await fs.readFile(unrelatedRulePath, "utf8"), "preserve");
+  assert.equal(await fs.readFile(unrelatedSkillPath, "utf8"), "preserve");
+  assert.equal((await auditProject(unrelatedRulesTarget)).state, "NO_PIPELINE_MINIMAL");
+  await doctorProject(unrelatedRulesTarget);
+} finally {
+  console.log = originalLog;
+  await fs.rm(unrelatedRulesTarget, { recursive: true, force: true });
 }
 
 const provisionTemplateTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-template-"));


### PR DESCRIPTION
## Summary
- reconcile setup-managed shared/local settings from the selected pipeline and optional skills
- remove deselected repo-pattern-managed ECC plugins, marketplaces, local skills, and ECC rules while preserving third-party configuration and credentials
- document the desired-state ownership model and add regression coverage
- release package version 0.1.19

Closes #28

## Verification
- `npm test`
- `npm run pack:dry`
- `git diff --check`