### PR TITLE
v0.1.20 fix: synchronize ECC agents transactionally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ node_modules/
 
 AGENTS.md
 Thumbs.db
+
+.gstack

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Pipeline scope is explicit:
 
 gstack requires Git and Bun v1.0+. When Bun is missing on Linux or macOS, setup downloads the official installer over TLS, validates it, and installs Bun automatically. On unsupported systems, install Bun manually before setup. Its upstream setup runs with `--quiet --no-plan-tune-hooks`, so automated setup does not show settings diffs or wait for hook confirmation.
 
-ECC rules are independent of the ECC plugin. `ecc` and `both` install auto-detected packs by default; the interactive wizard can switch to manual packs or none. `gstack` and `none` prompt whether to install rules, while scriptable setup requires `--with-rules`. Managed packs live in `.claude/rules/ecc/` and can work when ECC plugin setup reports manual installation is still required.
+ECC rules are independent of the ECC plugin. Whenever rules are applied, repo-pattern atomically replaces `.claude/agents/` with ECC's upstream `agents/**` tree and records the source revision plus a SHA-256 file manifest only in `.repo-pattern/.repo-pattern.lock.json`. `ecc` and `both` install auto-detected packs by default; the interactive wizard can switch to manual packs or none. `gstack` and `none` prompt whether to install rules, while scriptable setup requires `--with-rules`. Managed packs live in `.claude/rules/ecc/`; ECC skills are never copied. `doctor` verifies agent provenance and manifest integrity.
 
 Migrate an existing project:
 
@@ -118,7 +118,8 @@ target-project/
 ├── .claude/
 │   ├── CLAUDE.md
 │   ├── settings.json             # copied from example, gitignored
-│   └── settings.local.json       # when local settings are provided, gitignored
+│   ├── settings.local.json       # when local settings are provided, gitignored
+│   └── agents/                   # ECC agents when ECC rules are applied, gitignored
 ├── .mcp.json                     # generated, gitignored
 ├── .repo-pattern/
 │   ├── .gitignore               # *
@@ -139,7 +140,7 @@ Each full `repo-pattern setup` run reconciles repo-pattern-managed state to its 
 * `.claude/` is generated from `.claude.example/` and gitignored.
 * Basic OS/IDE noise (`.DS_Store`, `Thumbs.db`, `.vscode/`, `.idea/`) is gitignored during setup.
 * `.claude/settings.json` keeps `hooks: {}` and disables commit attribution by default; interactive setup can turn it on or use a custom trailer.
-* No vendored ECC skills, commands, hooks, or scripts are installed. ECC rules are auto-installed for ECC pipelines and opt-in for gstack/none.
+* ECC rule application atomically stages and replaces upstream ECC agents, with rollback through nested repo-pattern metadata writes. The lock records their source revision and SHA-256 inventory; ECC skills, commands, hooks, scripts, and `.agents` are never copied. Clearing ECC rules clears only agent metadata and retains `.claude/agents/`.
 * Karpathy-inspired Claude Code guidelines are included in `.claude/CLAUDE.md` from `multica-ai/andrej-karpathy-skills` (MIT).
 * Optional external skills are user opt-in only: `--with-skill taste`, `--with-skill document-specialist`, `--with-skill ui-ux-pro-max`, `--with-skill impeccable`, `--with-skill huashu-design`, `--with-skill nextjs-pattern`, `--with-skill fastapi-pattern`, `--with-skill herdr`, or interactive setup.
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -2,13 +2,13 @@
 
 ## ECC
 
-repo-pattern integrates with ECC (Everything Claude Code) by referencing the official ECC plugin and, when explicitly requested by the user, syncing ECC rule packs from the upstream repository.
+repo-pattern integrates with ECC (Everything Claude Code) by referencing the official ECC plugin and, when explicitly requested by the user, syncing ECC rule packs and agent definitions from the upstream repository.
 
 Source: https://github.com/affaan-m/ECC  
 License: MIT  
 Copyright (c) 2026 Affaan Mustafa
 
-repo-pattern does not vendor ECC skills, commands, hooks, scripts, or runtime surfaces by default.
+repo-pattern synchronizes only ECC rule packs and `agents/**` when rules are enabled. It does not vendor ECC skills, `.agents`, commands, hooks, or scripts.
 
 ## gstack
 

--- a/docs/repo-pattern/setup-guide.md
+++ b/docs/repo-pattern/setup-guide.md
@@ -36,7 +36,7 @@ minimal Claude Code setup
 + repo-pattern metadata
 ```
 
-`repo-pattern` is intentionally not a Claude runtime pack. It does not install local Claude skills, commands, hooks, or scripts by default. ECC and both pipelines install auto-detected project-local ECC rules by default; interactive setup can choose automatic packs, manual packs, or none. gstack and none keep rules off unless selected in the wizard or passed `setup --with-rules`. Rule sync is independent of ECC plugin installation, so managed `.claude/rules/ecc/` packs can be present while the plugin is still `manual-plugin-install-required`. Optional external skills are explicit opt-in via `setup --with-skill <name>` or interactive `setup`.
+`repo-pattern` is intentionally not a Claude runtime pack. It does not install local Claude skills, commands, hooks, or scripts by default. Whenever ECC rules are applied, it stages and atomically replaces `.claude/agents/` with ECC's upstream `agents/**` tree; ECC skills, `.agents`, commands, hooks, and scripts are never copied. ECC and both pipelines install auto-detected project-local ECC rules by default; interactive setup can choose automatic packs, manual packs, or none. gstack and none keep rules off unless selected in the wizard or passed `setup --with-rules`. Rule sync is independent of ECC plugin installation, so managed `.claude/rules/ecc/` packs and agents can be present while the plugin is still `manual-plugin-install-required`. Optional external skills are explicit opt-in via `setup --with-skill <name>` or interactive `setup`.
 
 Non-ECC managed rules are recorded under `repoConfig.ecc` and `lock.ecc` as rule-sync metadata only; they do not enable `ecc@ecc` or change the selected runtime pipeline.
 
@@ -134,8 +134,9 @@ For non-interactive scripts, use `setup --yes`.
 13. Add generated setup files and basic OS/IDE noise to `.gitignore`.
 14. Write `.repo-pattern/.repo-pattern.lock.json` without credential values.
 15. Run the selected setup pipeline: ECC setup after generation, or the global gstack installer after target preflight succeeds.
-16. When rules are enabled, apply ECC rules independently of plugin installation.
-17. Run doctor.
+16. When rules are enabled, apply ECC rules independently of plugin installation, validate the cached ECC Git `HEAD`, and atomically promote upstream `agents/**` into `.claude/agents/`.
+17. Write ECC agent provenance and the sorted SHA-256 file inventory only to `.repo-pattern/.repo-pattern.lock.json`; rollback agents and nested metadata if promotion or metadata writes fail.
+18. Run doctor, which validates ECC agent source, revision, manifest paths, missing/extra files, and hashes.
 ```
 
 After setup, the target project should contain:
@@ -146,12 +147,13 @@ target-project/
 ├── .claude/
 │   ├── CLAUDE.md
 │   ├── settings.json
-│   └── settings.local.json  # setup only, gitignored
+│   ├── settings.local.json  # setup only, gitignored
+│   └── agents/              # synchronized only when ECC rules are applied, gitignored
 ├── .mcp.json
 ├── .repo-pattern/
 │   ├── .gitignore
 │   ├── .repo-pattern.json
-│   └── .repo-pattern.lock.json
+│   └── .repo-pattern.lock.json  # ECC agent source, revision, and SHA-256 inventory when rules are enabled
 ```
 
 ## Root `CLAUDE.md` policy

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@negikirin/repo-pattern",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@negikirin/repo-pattern",
-      "version": "0.1.19",
+      "version": "0.1.20",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^0.11.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@negikirin/repo-pattern",
-  "version": "0.1.19",
+  "version": "0.1.20",
   "description": "Minimal ECC-first Claude Code project setup and migrator",
   "type": "module",
   "bin": {

--- a/scripts/lib/audit.mjs
+++ b/scripts/lib/audit.mjs
@@ -48,6 +48,9 @@ export async function auditProject(target) {
   const eccRulesDir = path.join(target, ".claude", "rules", "ecc");
   const hasClaudeEccRulesDir = exists(eccRulesDir);
   const eccRulePackDirs = await listDirNames(eccRulesDir);
+  const agentsDir = path.join(target, ".claude", "agents");
+  const hasClaudeAgentsDir = exists(agentsDir);
+  const agentEntries = await listDirNames(agentsDir);
   const hasMcpJson = exists(path.join(target, ".mcp.json"));
   const hasHardcodedMcpPath = hasMcpJson
     ? await fileContains(path.join(target, ".mcp.json"), HARDCODED_PATH_RE)
@@ -68,6 +71,9 @@ export async function auditProject(target) {
     hasClaudeHooksDir: exists(path.join(target, ".claude", "hooks")),
     hasClaudeScriptsDir: exists(path.join(target, ".claude", "scripts")),
     hasClaudeRulesDir: exists(path.join(target, ".claude", "rules")),
+    hasClaudeAgentsDir,
+    agentEntries,
+    hasManagedEccAgents: lock.ecc?.agentsSyncedBy === "repo-pattern-auto-cache" || (lock.ecc?.appliedAgents || []).length > 0,
     hasOnlyEccRulesDir: await isOnlyEccRulesDir(target),
     hasManagedEccRules: lock.ecc?.rulesSyncedBy === "repo-pattern-auto-cache" || (lock.ecc?.appliedRules || []).length > 0,
     hasClaudeEccRulesDir,
@@ -135,7 +141,9 @@ export function printAudit(audit) {
     [audit.hasClaudeHooksDir, ".claude/hooks present"],
     [audit.hasClaudeScriptsDir, ".claude/scripts present"],
     [audit.hasClaudeRulesDir && !audit.hasOnlyEccRulesDir, "non-ECC .claude/rules present"],
-    [audit.hasClaudeEccRulesDir && !audit.hasManagedEccRules, ".claude/rules/ecc is not repo-pattern-managed"]
+    [audit.hasClaudeEccRulesDir && !audit.hasManagedEccRules, ".claude/rules/ecc is not repo-pattern-managed"],
+    [audit.hasManagedEccAgents && !audit.hasClaudeAgentsDir, ".claude/agents is missing for repo-pattern-managed ECC agents"],
+    [audit.hasClaudeAgentsDir && !audit.hasManagedEccAgents, ".claude/agents is not repo-pattern-managed"]
   ].filter(([bad]) => bad);
 
   if (issues.length > 0) {

--- a/scripts/lib/doctor.mjs
+++ b/scripts/lib/doctor.mjs
@@ -2,6 +2,7 @@ import path from "node:path";
 import { auditProject } from "./audit.mjs";
 import { ensureRepoPatternGitignore, isTracked, readJson, readRepoLock, repoLockPath, writeJson } from "./fs-utils.mjs";
 import { printBox, style } from "./prompt.mjs";
+import { isValidEccAgentProvenance, verifyAgentInventory } from "./rules.mjs";
 
 function renderDoctor(target, checks, infoRows) {
   const failed = checks.filter((row) => !row.ok);
@@ -76,6 +77,12 @@ export async function doctorProject(target, { updateLock = false, dryRun = false
     check(audit.hasOnlyEccRulesDir, ".claude/rules/ecc contains only ECC-managed project rules");
     check(audit.hasClaudeEccRulesDir && existingRules.size > 0, ".claude/rules/ecc contains synced ECC rule pack directories");
     check(appliedRules.every((rule) => existingRules.has(rule)), "all locked ECC rule packs exist under .claude/rules/ecc");
+  }
+  const managedAgentsClaimed = lock.ecc?.agentsSyncedBy === "repo-pattern-auto-cache" || (lock.ecc?.appliedAgents || []).length > 0;
+  if (managedAgentsClaimed) {
+    check(audit.hasClaudeAgentsDir, ".claude/agents exists for managed ECC agents");
+    check(isValidEccAgentProvenance(lock.ecc), ".repo-pattern/.repo-pattern.lock.json ECC agent provenance and manifest are valid");
+    check(await verifyAgentInventory(path.join(target, ".claude", "agents"), lock.ecc?.appliedAgents), ".claude/agents exactly matches the locked ECC SHA-256 manifest");
   }
   if (setupPipeline === "gstack" || setupPipeline === "both") check(lock.gstack?.status === "installed", ".repo-pattern/.repo-pattern.lock.json gstack.status=installed");
   if (setupPipeline === "both") infoRows.push(`ECC setup status: ${lock.ecc?.status || "unknown"}, gstack setup status: ${lock.gstack?.status || "unknown"}`);

--- a/scripts/lib/ecc.mjs
+++ b/scripts/lib/ecc.mjs
@@ -77,8 +77,8 @@ Install ECC inside Claude Code:
 /plugin marketplace add https://github.com/affaan-m/ECC
 /plugin install ecc@ecc
 
-repo-pattern does not vendor ECC skills, commands, hooks, scripts, or rules.
-ECC runtime surfaces are plugin-managed.
+repo-pattern does not vendor ECC skills, commands, hooks, or scripts.
+When ECC rules are applied, repo-pattern synchronizes upstream agent definitions and rule packs; other runtime surfaces are plugin-managed.
 `);
   }
 

--- a/scripts/lib/provision.mjs
+++ b/scripts/lib/provision.mjs
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { auditProject, printAudit } from "./audit.mjs";
 import { cleanupProject } from "./cleanup.mjs";
@@ -7,7 +8,7 @@ import { ECC_PLUGIN, applyEccPluginSettings, setupEcc } from "./ecc.mjs";
 import { setupGstack } from "./gstack.mjs";
 import { doctorProject } from "./doctor.mjs";
 import { applyEccRules, clearEccRules } from "./rules.mjs";
-import { appendGitignoreLine, backupPaths, copyRecursive, ensureDir, ensureRepoPatternGitignore, isTracked, readJson, readRepoConfig, removePath, repoConfigPath, repoLockPath, writeJson, writeIfMissing, writePrivateJson } from "./fs-utils.mjs";
+import { appendGitignoreLine, backupPaths, copyRecursive, ensureDir, ensureRepoPatternGitignore, exists, isTracked, readJson, readRepoConfig, removePath, repoConfigPath, repoLockPath, writeJson, writeIfMissing, writePrivateJson } from "./fs-utils.mjs";
 import { printSummary, style } from "./prompt.mjs";
 import { applyOptionalSkills, reconcilePluginSkillSettings } from "./skills.mjs";
 
@@ -182,6 +183,52 @@ async function rejectClaudeSymlink(target, { dryRun = false } = {}) {
   if (stat.isSymbolicLink()) throw new Error(".claude must not be a symlink.");
 }
 
+async function snapshotProvisionState(target, { dryRun = false } = {}) {
+  if (dryRun) return null;
+  const files = [
+    path.join(target, ".mcp.json"),
+    repoConfigPath(target),
+    repoLockPath(target),
+    path.join(target, ".repo-pattern", ".gitignore"),
+    path.join(target, ".claude", "CLAUDE.md")
+  ];
+  const snapshots = await Promise.all(files.map(async (file) => {
+    try {
+      return { file, exists: true, content: await fs.readFile(file) };
+    } catch (error) {
+      if (error.code === "ENOENT") return { file, exists: false, content: null };
+      throw error;
+    }
+  }));
+  const snapshotRoot = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-provision-transaction-"));
+  const directories = [
+    { path: path.join(target, ".claude", "agents"), snapshot: path.join(snapshotRoot, "agents") },
+    { path: path.join(target, ".claude", "rules", "ecc"), snapshot: path.join(snapshotRoot, "ecc-rules") }
+  ].map((entry) => ({ ...entry, exists: exists(entry.path) }));
+  for (const directory of directories) {
+    if (directory.exists) await fs.cp(directory.path, directory.snapshot, { recursive: true, force: true });
+  }
+  return { snapshots, directories, snapshotRoot };
+}
+
+async function restoreProvisionState(snapshot) {
+  if (!snapshot) return;
+  for (const directory of snapshot.directories) {
+    await fs.rm(directory.path, { recursive: true, force: true });
+    if (directory.exists) await fs.cp(directory.snapshot, directory.path, { recursive: true, force: true });
+  }
+  for (const entry of snapshot.snapshots) {
+    if (entry.exists) {
+      await ensureDir(path.dirname(entry.file));
+      await fs.writeFile(entry.file, entry.content);
+    } else await fs.rm(entry.file, { force: true });
+  }
+}
+
+async function removeProvisionSnapshot(snapshot) {
+  if (snapshot) await fs.rm(snapshot.snapshotRoot, { recursive: true, force: true });
+}
+
 async function writeLocalSettings({ sourceRoot, target, localSettingsEnv = {}, setupPipeline, optionalSkills, dryRun }) {
   if (isTracked(target, ".claude/settings.local.json")) throw new Error(".claude/settings.local.json is tracked. Untrack it before writing local provider settings.");
   const claudeDir = path.join(target, ".claude");
@@ -214,54 +261,71 @@ export async function provisionProject({ sourceRoot, target, profile = "web", se
   if (isTracked(target, ".claude/settings.json")) throw new Error(".claude/settings.json is tracked. Untrack it before writing Claude Code settings.");
   if (isTracked(target, ".repo-pattern/.repo-pattern.lock.json") || isTracked(target, ".repo-pattern.lock.json")) throw new Error("repo-pattern lock is tracked. Untrack it before writing local setup state.");
 
-  const gstackStatus = usesGstack(setupPipeline) ? await setupGstack({ target, dryRun, planTuneHooks }) : null;
-  const previousRepoConfig = await readRepoConfig(target, {});
+  const provisionSnapshot = await snapshotProvisionState(target, { dryRun });
+  let eccStatus = null;
+  let mcpResult = null;
+  try {
+    const gstackStatus = usesGstack(setupPipeline) ? await setupGstack({ target, dryRun, planTuneHooks }) : null;
+    const previousRepoConfig = await readRepoConfig(target, {});
 
-  if (audit.state === "LEGACY_VENDOR") {
-    await cleanupProject({ sourceRoot, target, dryRun });
-  } else {
-    await backupPaths(target, ["CLAUDE.md", ".claude/CLAUDE.md", ".claude/settings.json", ".claude/rules", ".claude/skills", ".claude/commands", ".claude/hooks", ".claude/scripts", ".repo-pattern.json", ".repo-pattern.lock.json"], { dryRun });
-  }
+    if (audit.state === "LEGACY_VENDOR") {
+      await cleanupProject({ sourceRoot, target, dryRun });
+    } else {
+      await backupPaths(target, ["CLAUDE.md", ".claude/CLAUDE.md", ".claude/settings.json", ".claude/rules", ".claude/agents", ".claude/skills", ".claude/commands", ".claude/hooks", ".claude/scripts", ".repo-pattern/.repo-pattern.json", ".repo-pattern/.repo-pattern.lock.json"], { dryRun });
+    }
 
-  await ensureDir(path.join(target, ".claude"), { dryRun });
+    await ensureDir(path.join(target, ".claude"), { dryRun });
 
-  // Target CLAUDE.md is created empty when missing so project-specific instructions can be added later. Existing target CLAUDE.md is preserved.
-  await writeIfMissing(path.join(target, "CLAUDE.md"), TARGET_CLAUDE_MD, { dryRun });
-  for (const line of BASIC_GITIGNORE_LINES) await appendGitignoreLine(target, line, { dryRun });
+    // Target CLAUDE.md is created empty when missing so project-specific instructions can be added later. Existing target CLAUDE.md is preserved.
+    await writeIfMissing(path.join(target, "CLAUDE.md"), TARGET_CLAUDE_MD, { dryRun });
+    for (const line of BASIC_GITIGNORE_LINES) await appendGitignoreLine(target, line, { dryRun });
 
-  await copyRecursive(
-    path.join(sourceRoot, ".claude.example", "CLAUDE.md"),
-    path.join(target, ".claude", "CLAUDE.md"),
-    { dryRun }
-  );
+    await copyRecursive(
+      path.join(sourceRoot, ".claude.example", "CLAUDE.md"),
+      path.join(target, ".claude", "CLAUDE.md"),
+      { dryRun }
+    );
 
-  await writeClaudeSettings({ sourceRoot, target, attributionConfig, permissionConfig, dryRun });
-  await appendGitignoreLine(target, ".claude/", { dryRun });
+    await writeClaudeSettings({ sourceRoot, target, attributionConfig, permissionConfig, dryRun });
+    await appendGitignoreLine(target, ".claude/", { dryRun });
 
-  await writeLocalSettings({ sourceRoot, target, localSettingsEnv, setupPipeline, optionalSkills, dryRun });
+    await writeLocalSettings({ sourceRoot, target, localSettingsEnv, setupPipeline, optionalSkills, dryRun });
 
-  await ensureRepoPatternGitignore(target, { dryRun });
-  const lockPath = repoLockPath(target);
+    await ensureRepoPatternGitignore(target, { dryRun });
+    const lockPath = repoLockPath(target);
+    mcpResult = await generateMcp({ sourceRoot, target, profile, mcpServers, mcpValues, dryRun });
+    eccStatus = usesEcc(setupPipeline) ? await setupEcc({ sourceRoot, target, dryRun, configurePlugin: false }) : null;
+    await writeJson(repoConfigPath(target), await repoPatternConfig(sourceRoot, profile, setupPipeline), { dryRun });
+    await writeJson(lockPath, lockConfig(profile, setupPipeline, { ecc: eccStatus, gstack: gstackStatus }, planTuneHooks), { dryRun });
+    await ensureRepoPatternGitignore(target, { dryRun });
+    if (shouldApplyRules) await applyEccRules({ target, dryRun, ruleMode, rules });
+    else await clearEccRules({ target, dryRun });
+    await applyOptionalSkills({
+      target,
+      skills: optionalSkills,
+      dryRun,
+      reconcile: true,
+      previousOptionalSkills: previousRepoConfig.optionalSkills
+    });
 
-  const mcpResult = await generateMcp({ sourceRoot, target, profile, mcpServers, mcpValues, dryRun });
-  const eccStatus = usesEcc(setupPipeline) ? await setupEcc({ sourceRoot, target, dryRun, configurePlugin: false }) : null;
-  await writeJson(repoConfigPath(target), await repoPatternConfig(sourceRoot, profile, setupPipeline), { dryRun });
-  await writeJson(lockPath, lockConfig(profile, setupPipeline, { ecc: eccStatus, gstack: gstackStatus }, planTuneHooks), { dryRun });
-  await ensureRepoPatternGitignore(target, { dryRun });
-  if (shouldApplyRules) await applyEccRules({ target, dryRun, ruleMode, rules });
-  else await clearEccRules({ target, dryRun });
-  await applyOptionalSkills({
-    target,
-    skills: optionalSkills,
-    dryRun,
-    reconcile: true,
-    previousOptionalSkills: previousRepoConfig.optionalSkills
-  });
-
-  if (dryRun) {
-    console.log("[dry-run] doctor skipped because no files were written.");
-  } else {
-    await doctorProject(target, { updateLock: true, dryRun });
+    if (dryRun) {
+      console.log("[dry-run] doctor skipped because no files were written.");
+    } else {
+      await doctorProject(target, { updateLock: true, dryRun });
+    }
+  } catch (error) {
+    try {
+      await restoreProvisionState(provisionSnapshot);
+    } catch (rollbackError) {
+      console.warn(`WARN: Provision rollback failed: ${rollbackError.message}`);
+    }
+    throw error;
+  } finally {
+    try {
+      await removeProvisionSnapshot(provisionSnapshot);
+    } catch (cleanupError) {
+      console.warn(`WARN: Provision rollback snapshot cleanup failed: ${cleanupError.message}`);
+    }
   }
 
   const pending = [

--- a/scripts/lib/rules.mjs
+++ b/scripts/lib/rules.mjs
@@ -1,13 +1,14 @@
-import path from "node:path";
 import { execFile, execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
+import path from "node:path";
 import { promisify } from "node:util";
 import { backupPaths, copyRecursive, ensureDir, ensureRepoPatternGitignore, exists, readRepoConfig, readRepoLock, removePath, repoConfigPath, repoLockPath, writeJson } from "./fs-utils.mjs";
 import { detectProject } from "./project-detect.mjs";
 import { selectEccRules, normalizeEccRules, invalidEccRules } from "./ecc-rules.mjs";
 import { isInteractive, printSummary, withSpinner } from "./prompt.mjs";
 
-const ECC_REPO_URL = "https://github.com/affaan-m/ECC.git";
+export const ECC_REPO_URL = "https://github.com/affaan-m/ECC.git";
 const USE_UV_RULES = `<!-- USE UV:Start -->
 Python project uses \`uv\`. Do not run \`python\`, \`python3\`, \`pip\`, \`pytest\`, or manually activate \`.venv\` unless explicitly required. Use \`uv run\` so commands execute inside the project environment.
 
@@ -30,8 +31,8 @@ Dependency commands:
 - Install/sync deps: \`uv sync\`
 - Reproducible install: \`uv sync --locked\`
 - Add runtime dep: \`uv add <package>\`
-- Add dev dep: \`uv add --dev <package>\`
-- Remove dep: \`uv remove <package>\`
+- Add dev dep: \`uv add --dev\`
+- Remove dep: \`uv remove\`
 - Update lockfile: \`uv lock\`
 - Check lockfile: \`uv lock --check\`
 - Inspect deps: \`uv tree\`
@@ -40,16 +41,28 @@ Dependency commands:
 Rule: \`uv run\` owns \`.venv\`. Put uv options before the child command: \`uv run --python -- pytest -q\`.
 <!-- USE UV:End -->`;
 const execFileAsync = promisify(execFile);
+const SHA256_RE = /^[a-f0-9]{64}$/;
+const REVISION_RE = /^[a-f0-9]{40}$/;
 
 function runGit(args, cwd, { quiet = false } = {}) {
-  execFileSync("git", args, {
-    cwd,
-    stdio: quiet ? "ignore" : "inherit"
-  });
+  execFileSync("git", args, { cwd, stdio: quiet ? "ignore" : "inherit" });
 }
 
 async function runGitAsync(args, cwd) {
   await execFileAsync("git", args, { cwd });
+}
+
+function gitOutput(args, cwd) {
+  return execFileSync("git", args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+}
+
+export function hasGitUpstream(cwd) {
+  try {
+    gitOutput(["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"], cwd);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function list(values, fallback = "none detected") {
@@ -68,10 +81,8 @@ export function formatEccCloneError(error) {
 async function ensureEccCache(target, { dryRun = false } = {}) {
   const cacheRoot = path.join(target, ".repo-pattern", "cache");
   const eccCache = path.join(cacheRoot, "ECC");
-  const rulesDir = path.join(eccCache, "rules");
-
-  if (exists(rulesDir)) {
-    if (!dryRun && exists(path.join(eccCache, ".git"))) {
+  if (exists(path.join(eccCache, "rules")) || exists(path.join(eccCache, "agents"))) {
+    if (!dryRun && exists(path.join(eccCache, ".git")) && hasGitUpstream(eccCache)) {
       try {
         runGit(["pull", "--ff-only", "--quiet"], eccCache);
       } catch {
@@ -80,26 +91,297 @@ async function ensureEccCache(target, { dryRun = false } = {}) {
     }
     return eccCache;
   }
-
   if (dryRun) {
     console.log(`[dry-run] git clone --depth 1 ${ECC_REPO_URL} ${eccCache}`);
     return eccCache;
   }
-
   await ensureDir(cacheRoot);
   try {
     if (isInteractive()) {
-      await withSpinner("Syncing ECC rules", async () => {
+      await withSpinner("Syncing ECC rules and agents", async () => {
         await runGitAsync(["clone", "--depth", "1", "--quiet", ECC_REPO_URL, eccCache], target);
       });
     } else {
-      console.log(`Syncing ECC rules from ${ECC_REPO_URL}`);
+      console.log(`Syncing ECC rules and agents from ${ECC_REPO_URL}`);
       runGit(["clone", "--depth", "1", ECC_REPO_URL, eccCache], target);
     }
   } catch (error) {
     throw new Error(formatEccCloneError(error));
   }
   return eccCache;
+}
+
+function posixRelative(root, file) {
+  return path.relative(root, file).split(path.sep).join("/");
+}
+
+async function inspectRegularTree(root, { requireNonEmpty = false, label = "ECC agents source" } = {}) {
+  let rootStat;
+  try {
+    rootStat = await fs.lstat(root);
+  } catch (error) {
+    if (error.code === "ENOENT") throw new Error(`${label} not found: ${root}`);
+    throw error;
+  }
+  if (!rootStat.isDirectory() || rootStat.isSymbolicLink()) throw new Error(`${label} must be a directory: ${root}`);
+  const files = [];
+  async function visit(directory) {
+    const entries = await fs.readdir(directory, { withFileTypes: true });
+    for (const entry of entries) {
+      const current = path.join(directory, entry.name);
+      const stat = await fs.lstat(current);
+      if (stat.isSymbolicLink()) throw new Error(`${label} must not contain symlinks: ${posixRelative(root, current)}`);
+      if (stat.isDirectory()) await visit(current);
+      else if (stat.isFile()) files.push(current);
+      else throw new Error(`${label} contains unsupported entry: ${posixRelative(root, current)}`);
+    }
+  }
+  await visit(root);
+  if (requireNonEmpty && files.length === 0) throw new Error(`${label} is empty.`);
+  return files.sort((left, right) => compareAgentPaths(posixRelative(root, left), posixRelative(root, right)));
+}
+
+function compareAgentPaths(left, right) {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+async function sha256(file) {
+  const content = await fs.readFile(file);
+  return createHash("sha256").update(content).digest("hex");
+}
+
+export function validateAgentManifest(manifest) {
+  if (!Array.isArray(manifest) || manifest.length === 0) return false;
+  let previous = null;
+  for (const entry of manifest) {
+    if (!entry || typeof entry !== "object" || typeof entry.path !== "string" || typeof entry.sha256 !== "string") return false;
+    if (!entry.path || entry.path.startsWith("/") || entry.path.includes("\\") || entry.path.split("/").some((part) => !part || part === "." || part === "..") || !SHA256_RE.test(entry.sha256)) return false;
+    if (previous !== null && compareAgentPaths(previous, entry.path) >= 0) return false;
+    previous = entry.path;
+  }
+  return true;
+}
+
+export async function buildAgentManifest(root) {
+  const files = await inspectRegularTree(root, { requireNonEmpty: true });
+  return await Promise.all(files.map(async (file) => ({ path: posixRelative(root, file), sha256: await sha256(file) })));
+}
+
+export async function verifyAgentInventory(root, manifest) {
+  if (!validateAgentManifest(manifest)) return false;
+  let actual;
+  try {
+    actual = await buildAgentManifest(root);
+  } catch {
+    return false;
+  }
+  return JSON.stringify(actual) === JSON.stringify(manifest);
+}
+
+export function isValidEccAgentProvenance(ecc) {
+  return ecc?.agentsSyncedBy === "repo-pattern-auto-cache" &&
+    ecc?.agentsSource === ECC_REPO_URL &&
+    REVISION_RE.test(ecc?.agentsRevision || "") &&
+    validateAgentManifest(ecc?.appliedAgents);
+}
+
+export async function validateEccAgentSource(eccCache) {
+  const gitDir = path.join(eccCache, ".git");
+  if (!exists(gitDir)) throw new Error("ECC cache is not a Git repository.");
+  let revision;
+  let source;
+  try {
+    revision = gitOutput(["rev-parse", "--verify", "HEAD^{commit}"], eccCache);
+    source = gitOutput(["remote", "get-url", "origin"], eccCache);
+  } catch {
+    throw new Error("ECC cache must have an origin remote and a HEAD resolved to a commit.");
+  }
+  if (source !== ECC_REPO_URL) throw new Error(`ECC cache origin must be ${ECC_REPO_URL}.`);
+  if (!REVISION_RE.test(revision)) throw new Error("ECC cache HEAD is not a full Git commit revision.");
+  const agentsRoot = path.join(eccCache, "agents");
+  await inspectRegularTree(agentsRoot, { requireNonEmpty: true });
+  return { agentsRoot, revision };
+}
+
+function assertEccSourceMatchesHead(eccCache) {
+  if (gitOutput(["status", "--porcelain", "--untracked-files=all", "--", "rules", "agents"], eccCache)) {
+    throw new Error("ECC cache rules and agents must match Git HEAD.");
+  }
+}
+
+async function snapshotFile(file) {
+  try {
+    const stat = await fs.lstat(file);
+    if (stat.isSymbolicLink() || !stat.isFile()) throw new Error(`Transaction metadata must be a regular file: ${file}`);
+    return { exists: true, content: await fs.readFile(file) };
+  } catch (error) {
+    if (error.code === "ENOENT") return { exists: false, content: null };
+    throw error;
+  }
+}
+
+async function restoreFile(file, snapshot) {
+  if (snapshot.exists) {
+    await ensureDir(path.dirname(file));
+    await fs.writeFile(file, snapshot.content);
+  } else {
+    await fs.rm(file, { force: true });
+  }
+}
+
+async function validateRuleSource(sourceRulesRoot, selectedRules) {
+  const sources = [];
+  for (const rule of selectedRules) {
+    const source = path.join(sourceRulesRoot, rule);
+    let stat;
+    try {
+      stat = await fs.lstat(source);
+    } catch (error) {
+      if (error.code === "ENOENT") throw new Error(`ECC rule pack not found in cache: ${rule}`);
+      throw error;
+    }
+    if (stat.isSymbolicLink() || !stat.isDirectory()) throw new Error(`ECC rule pack must be a directory: ${rule}`);
+    await inspectRegularTree(source, { label: `ECC rule pack ${rule}` });
+    sources.push({ rule, source });
+  }
+  return sources;
+}
+
+async function assertDestinationDirectory(destination, label) {
+  try {
+    const stat = await fs.lstat(destination);
+    if (stat.isSymbolicLink() || !stat.isDirectory()) throw new Error(`${label} must be a directory, not a symlink or file.`);
+  } catch (error) {
+    if (error.code !== "ENOENT") throw error;
+  }
+}
+
+async function copyAgentTree(source, stage, operations) {
+  const sourceFiles = await inspectRegularTree(source, { requireNonEmpty: true });
+  for (const file of sourceFiles) {
+    const destination = path.join(stage, path.relative(source, file));
+    await ensureDir(path.dirname(destination));
+    await (operations.copyFile || fs.copyFile)(file, destination);
+  }
+}
+
+async function syncEccRulesAndAgents({ target, eccCache, selectedRules, repoConfig, lock, claudeMd, nextClaudeMd, dryRun = false, operations = {} }) {
+  const claudeDir = path.join(target, ".claude");
+  const rulesDir = path.join(claudeDir, "rules");
+  const rulesDestination = path.join(rulesDir, "ecc");
+  const agentsDestination = path.join(claudeDir, "agents");
+  if (dryRun) {
+    console.log(`[dry-run] stage and atomically replace ${rulesDestination} and ${agentsDestination} from ${eccCache}`);
+    return { manifest: [], revision: "dry-run" };
+  }
+
+  const { agentsRoot, revision } = await validateEccAgentSource(eccCache);
+  const ruleSources = await validateRuleSource(path.join(eccCache, "rules"), selectedRules);
+  assertEccSourceMatchesHead(eccCache);
+  try {
+    if ((await fs.lstat(claudeDir)).isSymbolicLink()) throw new Error(".claude must not be a symlink.");
+  } catch (error) {
+    if (error.code !== "ENOENT") throw error;
+  }
+  await ensureDir(claudeDir);
+  await ensureDir(rulesDir);
+  await assertDestinationDirectory(rulesDestination, ".claude/rules/ecc");
+  await assertDestinationDirectory(agentsDestination, ".claude/agents");
+
+  const rulesBackup = path.join(rulesDir, `.ecc-backup-${process.pid}-${Date.now()}`);
+  const agentsBackup = path.join(claudeDir, `.agents-backup-${process.pid}-${Date.now()}`);
+  const configPath = repoConfigPath(target);
+  const lockPath = repoLockPath(target);
+  const gitignorePath = path.join(target, ".repo-pattern", ".gitignore");
+  const claudeMdPath = path.join(claudeDir, "CLAUDE.md");
+  const [configSnapshot, lockSnapshot, gitignoreSnapshot, claudeMdSnapshot] = await Promise.all([
+    snapshotFile(configPath),
+    snapshotFile(lockPath),
+    snapshotFile(gitignorePath),
+    snapshotFile(claudeMdPath)
+  ]);
+  let rulesStage = null;
+  let agentsStage = null;
+  let movedRules = false;
+  let movedAgents = false;
+  let promotedRules = false;
+  let promotedAgents = false;
+  try {
+    await ensureRepoPatternGitignore(target, { dryRun });
+    rulesStage = await fs.mkdtemp(path.join(rulesDir, ".ecc-stage-"));
+    agentsStage = await fs.mkdtemp(path.join(claudeDir, ".agents-stage-"));
+    for (const { rule, source } of ruleSources) {
+      await (operations.copyRules || copyRecursive)(source, path.join(rulesStage, rule));
+    }
+    await copyAgentTree(agentsRoot, agentsStage, operations);
+    const manifest = await buildAgentManifest(agentsStage);
+    await backupPaths(target, [".claude/rules/ecc"], { dryRun });
+
+    if (exists(rulesDestination)) {
+      await (operations.rename || fs.rename)(rulesDestination, rulesBackup);
+      movedRules = true;
+    }
+    if (exists(agentsDestination)) {
+      await (operations.rename || fs.rename)(agentsDestination, agentsBackup);
+      movedAgents = true;
+    }
+    await (operations.rename || fs.rename)(rulesStage, rulesDestination);
+    promotedRules = true;
+    await (operations.rename || fs.rename)(agentsStage, agentsDestination);
+    promotedAgents = true;
+
+    const nextLock = {
+      ...lock,
+      ecc: {
+        ...(lock.ecc || {}),
+        agentsSyncedBy: "repo-pattern-auto-cache",
+        agentsSource: ECC_REPO_URL,
+        agentsRevision: revision,
+        appliedAgents: manifest,
+        agentsAppliedAt: new Date().toISOString()
+      }
+    };
+    if (nextClaudeMd !== claudeMd) await (operations.writeClaudeMd || fs.writeFile)(claudeMdPath, nextClaudeMd, "utf8");
+    await (operations.writeConfig || writeJson)(configPath, repoConfig, { dryRun });
+    await (operations.writeLock || writeJson)(lockPath, nextLock, { dryRun });
+    try {
+      await Promise.all([
+        movedRules ? (operations.removeBackup || fs.rm)(rulesBackup, { recursive: true, force: true }) : undefined,
+        movedAgents ? (operations.removeBackup || fs.rm)(agentsBackup, { recursive: true, force: true }) : undefined
+      ]);
+    } catch (cleanupError) {
+      console.warn(`WARN: ECC synchronization backup cleanup failed after commit: ${cleanupError.message}`);
+    }
+    return { manifest, revision, lock: nextLock };
+  } catch (error) {
+    try {
+      if (promotedAgents) await fs.rm(agentsDestination, { recursive: true, force: true });
+      if (promotedRules) await fs.rm(rulesDestination, { recursive: true, force: true });
+      if (movedAgents && exists(agentsBackup)) await fs.rename(agentsBackup, agentsDestination);
+      if (movedRules && exists(rulesBackup)) await fs.rename(rulesBackup, rulesDestination);
+      await Promise.all([
+        restoreFile(configPath, configSnapshot),
+        restoreFile(lockPath, lockSnapshot),
+        restoreFile(gitignorePath, gitignoreSnapshot),
+        restoreFile(claudeMdPath, claudeMdSnapshot)
+      ]);
+    } catch (rollbackError) {
+      console.warn(`WARN: ECC synchronization rollback failed: ${rollbackError.message}`);
+    }
+    throw error;
+  } finally {
+    await Promise.all([
+      rulesStage ? fs.rm(rulesStage, { recursive: true, force: true }) : undefined,
+      agentsStage ? fs.rm(agentsStage, { recursive: true, force: true }) : undefined,
+      !movedRules ? fs.rm(rulesBackup, { recursive: true, force: true }) : undefined,
+      !movedAgents ? fs.rm(agentsBackup, { recursive: true, force: true }) : undefined
+    ]);
+  }
+}
+
+function clearAgentMetadata(ecc) {
+  const { agentsSyncedBy, agentsSource, agentsRevision, appliedAgents, agentsAppliedAt, ...rest } = ecc;
+  return rest;
 }
 
 export async function clearEccRules({ target, dryRun = false }) {
@@ -113,110 +395,84 @@ export async function clearEccRules({ target, dryRun = false }) {
       if (!["ENOENT", "ENOTEMPTY", "EEXIST"].includes(error.code)) throw error;
     }
   }
-
   const repoConfig = await readRepoConfig(target, {});
   if (repoConfig.ecc) {
     const { rulesSync, rulesProfile, rulesScope, copyRuntimeSurfaces, ...ecc } = repoConfig.ecc;
     repoConfig.ecc = ecc;
     await writeJson(repoConfigPath(target), repoConfig, { dryRun });
   }
-
   const lock = await readRepoLock(target, {});
   if (lock.ecc) {
-    const { rulesSyncedBy, rulesProfile, rulesScope, recommendedRules, appliedRules, detectedStack, rulesSource, rulesCache, rulesAppliedAt, ...ecc } = lock.ecc;
+    const { rulesSyncedBy, rulesProfile, rulesScope, recommendedRules, appliedRules, detectedStack, rulesSource, rulesCache, rulesAppliedAt, ...ecc } = clearAgentMetadata(lock.ecc);
     lock.ecc = { ...ecc, rulesSyncedBy: null, rulesScope: "project", recommendedRules: [], appliedRules: [] };
     await writeJson(repoLockPath(target), lock, { dryRun });
   }
 }
 
-export async function applyEccRules({ target, dryRun = false, ruleMode = "auto", rules = null }) {
+export async function applyEccRules({ target, dryRun = false, ruleMode = "auto", rules = null, operations = {} }) {
   const detection = await detectProject(target);
   const invalidRules = ruleMode === "manual" ? invalidEccRules(rules) : [];
   if (invalidRules.length > 0) throw new Error(`Unknown ECC rule pack(s): ${invalidRules.join(", ")}`);
-
   const selectedRules = ruleMode === "manual" ? normalizeEccRules(rules) : selectEccRules(detection);
-
-  printSummary("Detected stack", [
-    ["Repo type", detection.repoType],
-    ["Languages", list(detection.languages)],
-    ["Frameworks", list(detection.frameworks)],
-    ["Tools", list(detection.tools)],
-    ["Package manager", detection.packageManager || "unknown"],
-    ["Monorepo", detection.monorepo ? "yes" : "no"]
-  ]);
+  printSummary("Detected stack", [["Repo type", detection.repoType], ["Languages", list(detection.languages)], ["Frameworks", list(detection.frameworks)], ["Tools", list(detection.tools)], ["Package manager", detection.packageManager || "unknown"], ["Monorepo", detection.monorepo ? "yes" : "no"]]);
   printSummary("Selected ECC rules", [["Rules", selectedRules.join(", ")]]);
 
   const cacheRoot = path.join(target, ".repo-pattern", "cache");
   const eccCache = await ensureEccCache(target, { dryRun });
-  await ensureRepoPatternGitignore(target, { dryRun });
-  const sourceRulesRoot = path.join(eccCache, "rules");
   const destRoot = path.join(target, ".claude", "rules", "ecc");
-
-  await backupPaths(target, [".claude/rules/ecc"], { dryRun });
-  await removePath(destRoot, { dryRun });
-  await ensureDir(destRoot, { dryRun });
-
-  for (const rule of selectedRules) {
-    const src = path.join(sourceRulesRoot, rule);
-    const dest = path.join(destRoot, rule);
-
-    if (!dryRun && !exists(src)) {
-      throw new Error(`ECC rule pack not found in cache: ${rule}`);
-    }
-
-    await copyRecursive(src, dest, { dryRun });
-  }
-
   const claudeMdPath = path.join(target, ".claude", "CLAUDE.md");
   const claudeMd = exists(claudeMdPath) ? await fs.readFile(claudeMdPath, "utf8") : "";
-  if (selectedRules.includes("python") && !claudeMd.includes("<!-- USE UV:Start -->")) {
-    const separator = claudeMd ? (claudeMd.endsWith("\n") ? "\n" : "\n\n") : "";
-    if (dryRun) console.log(`[dry-run] append uv rules to ${claudeMdPath}`);
-    else await fs.writeFile(claudeMdPath, `${claudeMd}${separator}${USE_UV_RULES}\n`, "utf8");
-  }
+  const nextClaudeMd = selectedRules.includes("python") && !claudeMd.includes("<!-- USE UV:Start -->")
+    ? `${claudeMd}${claudeMd ? (claudeMd.endsWith("\n") ? "\n" : "\n\n") : ""}${USE_UV_RULES}\n`
+    : claudeMd;
+  if (dryRun && nextClaudeMd !== claudeMd) console.log(`[dry-run] append uv rules to ${claudeMdPath}`);
 
-  if (dryRun) console.log(`[dry-run] rm -rf ${cacheRoot}`);
-  else await removePath(cacheRoot);
-
-  const configPath = repoConfigPath(target);
   const repoConfig = await readRepoConfig(target, {});
-  repoConfig.ecc = {
-    ...(repoConfig.ecc || {}),
-    rulesSync: "repo-pattern-auto-cache",
-    rulesProfile: ruleMode,
-    rulesScope: "project",
-    copyRuntimeSurfaces: false
+  const nextRepoConfig = {
+    ...repoConfig,
+    ecc: {
+      ...(repoConfig.ecc || {}),
+      rulesSync: "repo-pattern-auto-cache",
+      rulesProfile: ruleMode,
+      rulesScope: "project",
+      copyRuntimeSurfaces: false
+    }
   };
-  await ensureRepoPatternGitignore(target, { dryRun });
-  await writeJson(configPath, repoConfig, { dryRun });
-
-  const lockPath = repoLockPath(target);
   const lock = await readRepoLock(target, {});
-  lock.ecc = {
-    ...(lock.ecc || {}),
-    rulesSyncedBy: "repo-pattern-auto-cache",
-    rulesProfile: ruleMode,
-    rulesScope: "project",
-    recommendedRules: selectedRules,
-    appliedRules: selectedRules,
-    detectedStack: detection,
-    rulesSource: ECC_REPO_URL,
-    rulesCache: null,
-    rulesAppliedAt: new Date().toISOString()
+  const nextLock = {
+    ...lock,
+    ecc: {
+      ...(lock.ecc || {}),
+      rulesSyncedBy: "repo-pattern-auto-cache",
+      rulesProfile: ruleMode,
+      rulesScope: "project",
+      recommendedRules: selectedRules,
+      appliedRules: selectedRules,
+      detectedStack: detection,
+      rulesSource: ECC_REPO_URL,
+      rulesCache: null,
+      rulesAppliedAt: new Date().toISOString()
+    }
   };
-  await writeJson(lockPath, lock, { dryRun });
-
-  printSummary("Applied ECC rules", [
-    ["Path", path.relative(target, destRoot)],
-    ["Rules", selectedRules.join(", ")],
-    ["Internal dir", ".repo-pattern/cache/ removed"]
-  ]);
-
-  return {
-    detection,
+  const agentResult = await syncEccRulesAndAgents({
+    target,
+    eccCache,
     selectedRules,
-    destRoot,
-    rulesSource: ECC_REPO_URL,
-    rulesCache: null
-  };
+    repoConfig: nextRepoConfig,
+    lock: nextLock,
+    claudeMd,
+    nextClaudeMd,
+    dryRun,
+    operations
+  });
+  if (!dryRun) {
+    try {
+      await removePath(cacheRoot);
+    } catch (error) {
+      console.warn(`WARN: ECC cache cleanup failed after commit: ${error.message}`);
+    }
+  } else console.log(`[dry-run] rm -rf ${cacheRoot}`);
+
+  printSummary("Applied ECC rules and agents", [["Rules", selectedRules.join(", ")], ["Agents", dryRun ? "staged preview" : `${agentResult.manifest.length} files`], ["Internal dir", ".repo-pattern/cache/ removed after commit"]]);
+  return { detection, selectedRules, destRoot, rulesSource: ECC_REPO_URL, rulesCache: null, agentsRevision: agentResult.revision, appliedAgents: agentResult.manifest };
 }

--- a/scripts/self-check.mjs
+++ b/scripts/self-check.mjs
@@ -14,7 +14,7 @@ import { applyAttributionSetting, applyLocalSettings, applyPermissionSettings, p
 import { writePrivateJson } from "./lib/fs-utils.mjs";
 import { printSummary, renderLogo, style } from "./lib/prompt.mjs";
 import { needsLocalSettingsPrompt, setupProject, setupRetryOptions } from "./lib/setup.mjs";
-import { applyEccRules, formatEccCloneError } from "./lib/rules.mjs";
+import { applyEccRules, buildAgentManifest, clearEccRules, formatEccCloneError, hasGitUpstream, validateAgentManifest } from "./lib/rules.mjs";
 import { applyOptionalSkills, applyPluginSkillSettings, expectedOptionalSkillDirs, invalidOptionalSkills, normalizeOptionalSkills, OPTIONAL_SKILLS } from "./lib/skills.mjs";
 
 const cliDir = path.dirname(fileURLToPath(import.meta.url));
@@ -405,29 +405,454 @@ try {
   await fs.rm(emptyRulesTarget, { recursive: true, force: true });
 }
 
+async function writeManagedAgentDoctorFixture(target) {
+  await writeDoctorFixture(target);
+  const agentsRoot = path.join(target, ".claude", "agents");
+  await fs.mkdir(agentsRoot, { recursive: true });
+  await fs.writeFile(path.join(agentsRoot, "agent.md"), "agent", "utf8");
+  const lockPath = path.join(target, ".repo-pattern", ".repo-pattern.lock.json");
+  const lock = JSON.parse(await fs.readFile(lockPath, "utf8"));
+  lock.ecc = {
+    ...lock.ecc,
+    agentsSyncedBy: "repo-pattern-auto-cache",
+    agentsSource: "https://github.com/affaan-m/ECC.git",
+    agentsRevision: "a".repeat(40),
+    appliedAgents: await buildAgentManifest(agentsRoot)
+  };
+  await fs.writeFile(lockPath, JSON.stringify(lock), "utf8");
+  return { agentsRoot, lockPath };
+}
+
+for (const { name, mutate } of [
+  { name: "missing directory", mutate: async ({ agentsRoot }) => fs.rm(agentsRoot, { recursive: true, force: true }) },
+  { name: "empty directory", mutate: async ({ agentsRoot }) => fs.rm(path.join(agentsRoot, "agent.md")) },
+  { name: "invalid synchronizer", mutate: async ({ lock }) => { lock.ecc.agentsSyncedBy = "manual"; } },
+  { name: "invalid source", mutate: async ({ lock }) => { lock.ecc.agentsSource = "https://example.com/ECC.git"; } },
+  { name: "invalid revision", mutate: async ({ lock }) => { lock.ecc.agentsRevision = "not-a-revision"; } },
+  { name: "invalid manifest path", mutate: async ({ lock }) => { lock.ecc.appliedAgents[0].path = "../agent.md"; } }
+]) {
+  const target = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-doctor-agents-"));
+  console.log = () => {};
+  try {
+    const fixture = await writeManagedAgentDoctorFixture(target);
+    const lock = JSON.parse(await fs.readFile(fixture.lockPath, "utf8"));
+    await mutate({ ...fixture, lock });
+    await fs.writeFile(fixture.lockPath, JSON.stringify(lock), "utf8");
+    await assert.rejects(() => doctorProject(target), /Doctor failed/, name);
+  } finally {
+    console.log = originalDoctorLog;
+    await fs.rm(target, { recursive: true, force: true });
+  }
+}
+
 const pythonRulesTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-python-rules-"));
 console.log = () => {};
 try {
   await fs.mkdir(path.join(pythonRulesTarget, ".claude"), { recursive: true });
+  await writeDoctorFixture(pythonRulesTarget, { appliedRules: ["common", "python"], createRuleDirs: true });
+  await fs.writeFile(path.join(pythonRulesTarget, ".mcp.json"), "{}", "utf8");
   await fs.writeFile(path.join(pythonRulesTarget, "pyproject.toml"), "", "utf8");
   await fs.writeFile(path.join(pythonRulesTarget, ".claude", "CLAUDE.md"), "Existing guidance\n", "utf8");
+  const pythonEccCache = path.join(pythonRulesTarget, ".repo-pattern", "cache", "ECC");
   for (const rule of ["common", "python"]) {
-    await fs.mkdir(path.join(pythonRulesTarget, ".repo-pattern", "cache", "ECC", "rules", rule), { recursive: true });
+    await fs.mkdir(path.join(pythonEccCache, "rules", rule), { recursive: true });
   }
+  await fs.mkdir(path.join(pythonEccCache, "agents", "nested"), { recursive: true });
+  await fs.writeFile(path.join(pythonEccCache, "agents", "A.md"), "upper", "utf8");
+  await fs.writeFile(path.join(pythonEccCache, "agents", "a.md"), "lower", "utf8");
+  await fs.writeFile(path.join(pythonEccCache, "agents", "nested", "agent.md"), "agent", "utf8");
+  spawnSync("git", ["init"], { cwd: pythonEccCache, stdio: "ignore" });
+  spawnSync("git", ["add", "."], { cwd: pythonEccCache, stdio: "ignore" });
+  spawnSync("git", ["-c", "user.email=test@example.com", "-c", "user.name=Test", "commit", "-m", "fixture"], { cwd: pythonEccCache, stdio: "ignore" });
+  spawnSync("git", ["remote", "add", "origin", "https://github.com/affaan-m/ECC.git"], { cwd: pythonEccCache, stdio: "ignore" });
   await applyEccRules({ target: pythonRulesTarget });
   let claudeMd = await fs.readFile(path.join(pythonRulesTarget, ".claude", "CLAUDE.md"), "utf8");
   assert.match(claudeMd, /`uv run` owns `\.venv`/);
   assert.match(claudeMd, /Existing guidance/);
+  const agentLock = JSON.parse(await fs.readFile(path.join(pythonRulesTarget, ".repo-pattern", ".repo-pattern.lock.json"), "utf8"));
+  assert.equal(agentLock.ecc.agentsSource, "https://github.com/affaan-m/ECC.git");
+  assert.match(agentLock.ecc.agentsRevision, /^[a-f0-9]{40}$/);
+  assert.deepEqual(agentLock.ecc.appliedAgents.map((entry) => entry.path), ["A.md", "a.md", "nested/agent.md"]);
+  await fs.access(path.join(pythonRulesTarget, ".claude", "agents", "nested", "agent.md"));
+  await assert.rejects(() => fs.access(path.join(pythonRulesTarget, ".claude", "skills", "ecc")), { code: "ENOENT" });
+  await doctorProject(pythonRulesTarget);
+  await fs.writeFile(path.join(pythonRulesTarget, ".claude", "agents", "extra.md"), "extra", "utf8");
+  await assert.rejects(() => doctorProject(pythonRulesTarget), /Doctor failed/);
+  await fs.rm(path.join(pythonRulesTarget, ".claude", "agents", "extra.md"));
+  await fs.writeFile(path.join(pythonRulesTarget, ".claude", "agents", "nested", "agent.md"), "changed", "utf8");
+  await assert.rejects(() => doctorProject(pythonRulesTarget), /Doctor failed/);
+  await fs.writeFile(path.join(pythonRulesTarget, ".claude", "agents", "nested", "agent.md"), "agent", "utf8");
 
   for (const rule of ["common", "python"]) {
-    await fs.mkdir(path.join(pythonRulesTarget, ".repo-pattern", "cache", "ECC", "rules", rule), { recursive: true });
+    await fs.mkdir(path.join(pythonEccCache, "rules", rule), { recursive: true });
   }
+  await fs.mkdir(path.join(pythonEccCache, "agents", "nested"), { recursive: true });
+  await fs.writeFile(path.join(pythonEccCache, "agents", "A.md"), "upper", "utf8");
+  await fs.writeFile(path.join(pythonEccCache, "agents", "a.md"), "lower", "utf8");
+  await fs.writeFile(path.join(pythonEccCache, "agents", "nested", "agent.md"), "agent", "utf8");
+  spawnSync("git", ["init"], { cwd: pythonEccCache, stdio: "ignore" });
+  spawnSync("git", ["add", "."], { cwd: pythonEccCache, stdio: "ignore" });
+  spawnSync("git", ["-c", "user.email=test@example.com", "-c", "user.name=Test", "commit", "-m", "fixture"], { cwd: pythonEccCache, stdio: "ignore" });
+  spawnSync("git", ["remote", "add", "origin", "https://github.com/affaan-m/ECC.git"], { cwd: pythonEccCache, stdio: "ignore" });
   await applyEccRules({ target: pythonRulesTarget });
   claudeMd = await fs.readFile(path.join(pythonRulesTarget, ".claude", "CLAUDE.md"), "utf8");
   assert.equal(claudeMd.split("<!-- USE UV:Start -->").length - 1, 1);
+
+  await clearEccRules({ target: pythonRulesTarget });
+  const clearedConfig = JSON.parse(await fs.readFile(path.join(pythonRulesTarget, ".repo-pattern", ".repo-pattern.json"), "utf8"));
+  const clearedLock = JSON.parse(await fs.readFile(path.join(pythonRulesTarget, ".repo-pattern", ".repo-pattern.lock.json"), "utf8"));
+  await fs.access(path.join(pythonRulesTarget, ".claude", "agents", "nested", "agent.md"));
+  await assert.rejects(() => fs.access(path.join(pythonRulesTarget, ".claude", "rules", "ecc")), { code: "ENOENT" });
+  assert.equal(clearedConfig.ecc.rulesSync, undefined);
+  assert.equal(clearedLock.ecc.rulesSyncedBy, null);
+  assert.deepEqual(clearedLock.ecc.appliedRules, []);
+  assert.equal(clearedLock.ecc.agentsSyncedBy, undefined);
+  assert.equal(clearedLock.ecc.agentsSource, undefined);
+  assert.equal(clearedLock.ecc.agentsRevision, undefined);
+  assert.equal(clearedLock.ecc.appliedAgents, undefined);
 } finally {
   console.log = originalDoctorLog;
   await fs.rm(pythonRulesTarget, { recursive: true, force: true });
+}
+
+const rollbackAgentsTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-agent-rollback-"));
+console.log = () => {};
+try {
+  const rollbackCache = path.join(rollbackAgentsTarget, ".repo-pattern", "cache", "ECC");
+  await fs.mkdir(path.join(rollbackCache, "rules", "python"), { recursive: true });
+  await fs.writeFile(path.join(rollbackCache, "rules", "python", "rule.md"), "new rule", "utf8");
+  await fs.mkdir(path.join(rollbackCache, "agents"), { recursive: true });
+  await fs.writeFile(path.join(rollbackCache, "agents", "new-agent.md"), "new", "utf8");
+  spawnSync("git", ["init"], { cwd: rollbackCache, stdio: "ignore" });
+  spawnSync("git", ["add", "."], { cwd: rollbackCache, stdio: "ignore" });
+  spawnSync("git", ["-c", "user.email=test@example.com", "-c", "user.name=Test", "commit", "-m", "fixture"], { cwd: rollbackCache, stdio: "ignore" });
+  spawnSync("git", ["remote", "add", "origin", "https://github.com/affaan-m/ECC.git"], { cwd: rollbackCache, stdio: "ignore" });
+  await fs.mkdir(path.join(rollbackAgentsTarget, ".claude", "rules", "ecc", "old"), { recursive: true });
+  await fs.writeFile(path.join(rollbackAgentsTarget, ".claude", "rules", "ecc", "old", "rule.md"), "old rule", "utf8");
+  await fs.mkdir(path.join(rollbackAgentsTarget, ".claude", "agents"), { recursive: true });
+  await fs.writeFile(path.join(rollbackAgentsTarget, ".claude", "agents", "old-agent.md"), "old", "utf8");
+  await fs.writeFile(path.join(rollbackAgentsTarget, ".claude", "CLAUDE.md"), "old guidance\n", "utf8");
+  await fs.mkdir(path.join(rollbackAgentsTarget, ".repo-pattern"), { recursive: true });
+  const rollbackConfig = "{\"before\":true}\n";
+  const rollbackLock = "{\"before\":true}\n";
+  await fs.writeFile(path.join(rollbackAgentsTarget, ".repo-pattern", ".repo-pattern.json"), rollbackConfig, "utf8");
+  await fs.writeFile(path.join(rollbackAgentsTarget, ".repo-pattern", ".repo-pattern.lock.json"), rollbackLock, "utf8");
+  await assert.rejects(
+    () => applyEccRules({
+      target: rollbackAgentsTarget,
+      ruleMode: "manual",
+      rules: ["python"],
+      operations: { writeLock: async () => { throw new Error("injected lock failure"); } }
+    }),
+    /injected lock failure/
+  );
+  assert.equal(await fs.readFile(path.join(rollbackAgentsTarget, ".claude", "rules", "ecc", "old", "rule.md"), "utf8"), "old rule");
+  await assert.rejects(() => fs.access(path.join(rollbackAgentsTarget, ".claude", "rules", "ecc", "python")), { code: "ENOENT" });
+  assert.equal(await fs.readFile(path.join(rollbackAgentsTarget, ".claude", "agents", "old-agent.md"), "utf8"), "old");
+  await assert.rejects(() => fs.access(path.join(rollbackAgentsTarget, ".claude", "agents", "new-agent.md")), { code: "ENOENT" });
+  assert.equal(await fs.readFile(path.join(rollbackAgentsTarget, ".claude", "CLAUDE.md"), "utf8"), "old guidance\n");
+  assert.equal(await fs.readFile(path.join(rollbackAgentsTarget, ".repo-pattern", ".repo-pattern.json"), "utf8"), rollbackConfig);
+  assert.equal(await fs.readFile(path.join(rollbackAgentsTarget, ".repo-pattern", ".repo-pattern.lock.json"), "utf8"), rollbackLock);
+} finally {
+  console.log = originalDoctorLog;
+  await fs.rm(rollbackAgentsTarget, { recursive: true, force: true });
+}
+
+const backupCleanupTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-backup-cleanup-"));
+const backupCleanupWarnings = [];
+const originalWarn = console.warn;
+console.log = () => {};
+console.warn = (message) => backupCleanupWarnings.push(String(message));
+try {
+  const backupCleanupCache = path.join(backupCleanupTarget, ".repo-pattern", "cache", "ECC");
+  await fs.mkdir(path.join(backupCleanupCache, "rules", "common"), { recursive: true });
+  await fs.writeFile(path.join(backupCleanupCache, "rules", "common", "rule.md"), "new rule", "utf8");
+  await fs.mkdir(path.join(backupCleanupCache, "agents"), { recursive: true });
+  await fs.writeFile(path.join(backupCleanupCache, "agents", "new-agent.md"), "new", "utf8");
+  spawnSync("git", ["init"], { cwd: backupCleanupCache, stdio: "ignore" });
+  spawnSync("git", ["add", "."], { cwd: backupCleanupCache, stdio: "ignore" });
+  spawnSync("git", ["-c", "user.email=test@example.com", "-c", "user.name=Test", "commit", "-m", "fixture"], { cwd: backupCleanupCache, stdio: "ignore" });
+  spawnSync("git", ["remote", "add", "origin", "https://github.com/affaan-m/ECC.git"], { cwd: backupCleanupCache, stdio: "ignore" });
+  await fs.mkdir(path.join(backupCleanupTarget, ".claude", "rules", "ecc", "old"), { recursive: true });
+  await fs.writeFile(path.join(backupCleanupTarget, ".claude", "rules", "ecc", "old", "rule.md"), "old rule", "utf8");
+  await fs.mkdir(path.join(backupCleanupTarget, ".claude", "agents"), { recursive: true });
+  await fs.writeFile(path.join(backupCleanupTarget, ".claude", "agents", "old-agent.md"), "old", "utf8");
+  await applyEccRules({
+    target: backupCleanupTarget,
+    ruleMode: "manual",
+    rules: ["common"],
+    operations: { removeBackup: async () => { throw new Error("injected backup cleanup failure"); } }
+  });
+  assert.equal(await fs.readFile(path.join(backupCleanupTarget, ".claude", "rules", "ecc", "common", "rule.md"), "utf8"), "new rule");
+  assert.equal(await fs.readFile(path.join(backupCleanupTarget, ".claude", "agents", "new-agent.md"), "utf8"), "new");
+  assert(backupCleanupWarnings.some((message) => message.includes("ECC synchronization backup cleanup failed")));
+} finally {
+  console.log = originalDoctorLog;
+  console.warn = originalWarn;
+  await fs.rm(backupCleanupTarget, { recursive: true, force: true });
+}
+
+for (const failure of ["rule staging", "agent staging", "rule promotion", "agent promotion", "UV guidance", "config write"]) {
+  const transactionFailureTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-transaction-failure-"));
+  console.log = () => {};
+  try {
+    const transactionFailureCache = path.join(transactionFailureTarget, ".repo-pattern", "cache", "ECC");
+    await fs.mkdir(path.join(transactionFailureCache, "rules", "python"), { recursive: true });
+    await fs.writeFile(path.join(transactionFailureCache, "rules", "python", "rule.md"), "new rule", "utf8");
+    await fs.mkdir(path.join(transactionFailureCache, "agents"), { recursive: true });
+    await fs.writeFile(path.join(transactionFailureCache, "agents", "new-agent.md"), "new", "utf8");
+    spawnSync("git", ["init"], { cwd: transactionFailureCache, stdio: "ignore" });
+    spawnSync("git", ["add", "."], { cwd: transactionFailureCache, stdio: "ignore" });
+    spawnSync("git", ["-c", "user.email=test@example.com", "-c", "user.name=Test", "commit", "-m", "fixture"], { cwd: transactionFailureCache, stdio: "ignore" });
+    spawnSync("git", ["remote", "add", "origin", "https://github.com/affaan-m/ECC.git"], { cwd: transactionFailureCache, stdio: "ignore" });
+    await fs.mkdir(path.join(transactionFailureTarget, ".claude", "rules", "ecc", "old"), { recursive: true });
+    await fs.writeFile(path.join(transactionFailureTarget, ".claude", "rules", "ecc", "old", "rule.md"), "old rule", "utf8");
+    await fs.mkdir(path.join(transactionFailureTarget, ".claude", "agents"), { recursive: true });
+    await fs.writeFile(path.join(transactionFailureTarget, ".claude", "agents", "old-agent.md"), "old", "utf8");
+    await fs.writeFile(path.join(transactionFailureTarget, ".claude", "CLAUDE.md"), "old guidance\n", "utf8");
+    await fs.mkdir(path.join(transactionFailureTarget, ".repo-pattern"), { recursive: true });
+    const transactionConfig = "{\"before\":true}\n";
+    const transactionLock = "{\"before\":true}\n";
+    await fs.writeFile(path.join(transactionFailureTarget, ".repo-pattern", ".repo-pattern.json"), transactionConfig, "utf8");
+    await fs.writeFile(path.join(transactionFailureTarget, ".repo-pattern", ".repo-pattern.lock.json"), transactionLock, "utf8");
+    const operations = {
+      ...(failure === "rule staging" ? { copyRules: async () => { throw new Error("injected rule staging failure"); } } : {}),
+      ...(failure === "agent staging" ? { copyFile: async () => { throw new Error("injected agent staging failure"); } } : {}),
+      ...(failure === "rule promotion" ? { rename: async (source, destination) => {
+        if (source.includes(".ecc-stage-")) throw new Error("injected rule promotion failure");
+        await fs.rename(source, destination);
+      } } : {}),
+      ...(failure === "agent promotion" ? { rename: async (source, destination) => {
+        if (source.includes(".agents-stage-")) throw new Error("injected agent promotion failure");
+        await fs.rename(source, destination);
+      } } : {}),
+      ...(failure === "UV guidance" ? { writeClaudeMd: async () => { throw new Error("injected UV guidance failure"); } } : {}),
+      ...(failure === "config write" ? { writeConfig: async () => { throw new Error("injected config write failure"); } } : {})
+    };
+    await assert.rejects(
+      () => applyEccRules({ target: transactionFailureTarget, ruleMode: "manual", rules: ["python"], operations }),
+      /injected/
+    );
+    assert.equal(await fs.readFile(path.join(transactionFailureTarget, ".claude", "rules", "ecc", "old", "rule.md"), "utf8"), "old rule");
+    assert.equal(await fs.readFile(path.join(transactionFailureTarget, ".claude", "agents", "old-agent.md"), "utf8"), "old");
+    assert.equal(await fs.readFile(path.join(transactionFailureTarget, ".claude", "CLAUDE.md"), "utf8"), "old guidance\n");
+    assert.equal(await fs.readFile(path.join(transactionFailureTarget, ".repo-pattern", ".repo-pattern.json"), "utf8"), transactionConfig);
+    assert.equal(await fs.readFile(path.join(transactionFailureTarget, ".repo-pattern", ".repo-pattern.lock.json"), "utf8"), transactionLock);
+  } finally {
+    console.log = originalDoctorLog;
+    await fs.rm(transactionFailureTarget, { recursive: true, force: true });
+  }
+}
+
+const metadataSnapshotFailureTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-metadata-snapshot-failure-"));
+console.log = () => {};
+try {
+  const metadataSnapshotFailureCache = await writeEccGitFixture(metadataSnapshotFailureTarget);
+  await fs.mkdir(path.join(metadataSnapshotFailureTarget, ".claude"), { recursive: true });
+  await fs.writeFile(path.join(metadataSnapshotFailureTarget, ".claude", "CLAUDE.md"), "guidance\n", "utf8");
+  await fs.mkdir(path.join(metadataSnapshotFailureTarget, ".repo-pattern"), { recursive: true });
+  await fs.symlink(".repo-pattern.json", path.join(metadataSnapshotFailureTarget, ".repo-pattern", ".repo-pattern.lock.json"));
+  await assert.rejects(
+    () => applyEccRules({ target: metadataSnapshotFailureTarget, ruleMode: "manual", rules: ["common"] }),
+    /Transaction metadata must be a regular file/
+  );
+  const claudeEntries = await fs.readdir(path.join(metadataSnapshotFailureTarget, ".claude"));
+  assert(!claudeEntries.some((entry) => entry.startsWith(".agents-stage-")));
+  const rulesEntries = await fs.readdir(path.join(metadataSnapshotFailureTarget, ".claude", "rules"));
+  assert(!rulesEntries.some((entry) => entry.startsWith(".ecc-stage-")));
+} finally {
+  console.log = originalDoctorLog;
+  await fs.rm(metadataSnapshotFailureTarget, { recursive: true, force: true });
+}
+
+const absentMetadataRollbackTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-absent-metadata-"));
+console.log = () => {};
+try {
+  const absentMetadataCache = path.join(absentMetadataRollbackTarget, ".repo-pattern", "cache", "ECC");
+  await fs.mkdir(path.join(absentMetadataCache, "rules", "python"), { recursive: true });
+  await fs.writeFile(path.join(absentMetadataCache, "rules", "python", "rule.md"), "new rule", "utf8");
+  await fs.mkdir(path.join(absentMetadataCache, "agents"), { recursive: true });
+  await fs.writeFile(path.join(absentMetadataCache, "agents", "new-agent.md"), "new", "utf8");
+  spawnSync("git", ["init"], { cwd: absentMetadataCache, stdio: "ignore" });
+  spawnSync("git", ["add", "."], { cwd: absentMetadataCache, stdio: "ignore" });
+  spawnSync("git", ["-c", "user.email=test@example.com", "-c", "user.name=Test", "commit", "-m", "fixture"], { cwd: absentMetadataCache, stdio: "ignore" });
+  spawnSync("git", ["remote", "add", "origin", "https://github.com/affaan-m/ECC.git"], { cwd: absentMetadataCache, stdio: "ignore" });
+  await assert.rejects(
+    () => applyEccRules({
+      target: absentMetadataRollbackTarget,
+      ruleMode: "manual",
+      rules: ["python"],
+      operations: { writeLock: async () => { throw new Error("injected absent metadata lock failure"); } }
+    }),
+    /injected absent metadata lock failure/
+  );
+  await assert.rejects(() => fs.access(path.join(absentMetadataRollbackTarget, ".claude", "CLAUDE.md")), { code: "ENOENT" });
+  await assert.rejects(() => fs.access(path.join(absentMetadataRollbackTarget, ".repo-pattern", ".repo-pattern.json")), { code: "ENOENT" });
+  await assert.rejects(() => fs.access(path.join(absentMetadataRollbackTarget, ".repo-pattern", ".repo-pattern.lock.json")), { code: "ENOENT" });
+} finally {
+  console.log = originalDoctorLog;
+  await fs.rm(absentMetadataRollbackTarget, { recursive: true, force: true });
+}
+
+async function writeEccGitFixture(target, { origin = "https://github.com/affaan-m/ECC.git", withAgents = true } = {}) {
+  const cache = path.join(target, ".repo-pattern", "cache", "ECC");
+  await fs.mkdir(path.join(cache, "rules", "common"), { recursive: true });
+  await fs.writeFile(path.join(cache, "rules", "common", "rule.md"), "new rule", "utf8");
+  if (withAgents) {
+    await fs.mkdir(path.join(cache, "agents"), { recursive: true });
+    await fs.writeFile(path.join(cache, "agents", "new-agent.md"), "new", "utf8");
+  }
+  spawnSync("git", ["init"], { cwd: cache, stdio: "ignore" });
+  spawnSync("git", ["add", "."], { cwd: cache, stdio: "ignore" });
+  spawnSync("git", ["-c", "user.email=test@example.com", "-c", "user.name=Test", "commit", "-m", "fixture"], { cwd: cache, stdio: "ignore" });
+  spawnSync("git", ["remote", "add", "origin", origin], { cwd: cache, stdio: "ignore" });
+  return cache;
+}
+
+async function assertInvalidEccSourcePreservesLiveState(name, configureCache, expectedError) {
+  const target = await fs.mkdtemp(path.join(os.tmpdir(), `repo-pattern-invalid-${name}-`));
+  console.log = () => {};
+  try {
+    const cache = await writeEccGitFixture(target);
+    await configureCache(cache);
+    await fs.mkdir(path.join(target, ".claude", "rules", "ecc", "old"), { recursive: true });
+    await fs.writeFile(path.join(target, ".claude", "rules", "ecc", "old", "rule.md"), "old rule", "utf8");
+    await fs.mkdir(path.join(target, ".claude", "agents"), { recursive: true });
+    await fs.writeFile(path.join(target, ".claude", "agents", "old-agent.md"), "old", "utf8");
+    await fs.writeFile(path.join(target, ".claude", "CLAUDE.md"), "old guidance\n", "utf8");
+    await fs.mkdir(path.join(target, ".repo-pattern"), { recursive: true });
+    await fs.writeFile(path.join(target, ".repo-pattern", ".repo-pattern.json"), "{\"before\":true}\n", "utf8");
+    await fs.writeFile(path.join(target, ".repo-pattern", ".repo-pattern.lock.json"), "{\"before\":true}\n", "utf8");
+    await assert.rejects(() => applyEccRules({ target, ruleMode: "manual", rules: ["common"] }), expectedError);
+    assert.equal(await fs.readFile(path.join(target, ".claude", "rules", "ecc", "old", "rule.md"), "utf8"), "old rule");
+    assert.equal(await fs.readFile(path.join(target, ".claude", "agents", "old-agent.md"), "utf8"), "old");
+    assert.equal(await fs.readFile(path.join(target, ".claude", "CLAUDE.md"), "utf8"), "old guidance\n");
+    assert.equal(await fs.readFile(path.join(target, ".repo-pattern", ".repo-pattern.json"), "utf8"), "{\"before\":true}\n");
+    assert.equal(await fs.readFile(path.join(target, ".repo-pattern", ".repo-pattern.lock.json"), "utf8"), "{\"before\":true}\n");
+    await assert.rejects(() => fs.access(path.join(target, ".repo-pattern", ".gitignore")), { code: "ENOENT" });
+  } finally {
+    console.log = originalDoctorLog;
+    await fs.rm(target, { recursive: true, force: true });
+  }
+}
+
+const invalidCacheRollbackTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-invalid-cache-"));
+console.log = () => {};
+try {
+  const invalidCache = path.join(invalidCacheRollbackTarget, ".repo-pattern", "cache", "ECC");
+  await fs.mkdir(path.join(invalidCache, "rules", "common"), { recursive: true });
+  await fs.writeFile(path.join(invalidCache, "rules", "common", "rule.md"), "new rule", "utf8");
+  await fs.mkdir(path.join(invalidCacheRollbackTarget, ".claude", "rules", "ecc", "old"), { recursive: true });
+  await fs.writeFile(path.join(invalidCacheRollbackTarget, ".claude", "rules", "ecc", "old", "rule.md"), "old rule", "utf8");
+  await assert.rejects(
+    () => applyEccRules({ target: invalidCacheRollbackTarget, ruleMode: "manual", rules: ["common"] }),
+    /ECC cache is not a Git repository/
+  );
+  assert.equal(await fs.readFile(path.join(invalidCacheRollbackTarget, ".claude", "rules", "ecc", "old", "rule.md"), "utf8"), "old rule");
+  await assert.rejects(() => fs.access(path.join(invalidCacheRollbackTarget, ".claude", "rules", "ecc", "common")), { code: "ENOENT" });
+} finally {
+  console.log = originalDoctorLog;
+  await fs.rm(invalidCacheRollbackTarget, { recursive: true, force: true });
+}
+
+await assertInvalidEccSourcePreservesLiveState("origin", async (cache) => {
+  spawnSync("git", ["remote", "set-url", "origin", "https://example.com/ECC.git"], { cwd: cache, stdio: "ignore" });
+}, /ECC cache origin must be/);
+await assertInvalidEccSourcePreservesLiveState("head", async (cache) => {
+  await fs.rm(path.join(cache, ".git", "HEAD"));
+}, /origin remote and a HEAD resolved to a commit/);
+await assertInvalidEccSourcePreservesLiveState("missing-agents", async (cache) => {
+  await fs.rm(path.join(cache, "agents"), { recursive: true, force: true });
+}, /ECC agents source not found/);
+await assertInvalidEccSourcePreservesLiveState("empty-agents", async (cache) => {
+  await fs.rm(path.join(cache, "agents", "new-agent.md"));
+}, /ECC agents source is empty/);
+await assertInvalidEccSourcePreservesLiveState("dirty-agents", async (cache) => {
+  await fs.writeFile(path.join(cache, "agents", "new-agent.md"), "tampered", "utf8");
+}, /ECC cache rules and agents must match Git HEAD/);
+await assertInvalidEccSourcePreservesLiveState("untracked-rules", async (cache) => {
+  await fs.writeFile(path.join(cache, "rules", "common", "untracked.md"), "tampered", "utf8");
+}, /ECC cache rules and agents must match Git HEAD/);
+await assertInvalidEccSourcePreservesLiveState("rule-symlink", async (cache) => {
+  await fs.rm(path.join(cache, "rules", "common", "rule.md"));
+  await fs.symlink("../../agents/new-agent.md", path.join(cache, "rules", "common", "rule.md"));
+}, /ECC rule pack common must not contain symlinks/);
+if (process.platform !== "win32") {
+  await assertInvalidEccSourcePreservesLiveState("rule-unsupported", async (cache) => {
+    await fs.rm(path.join(cache, "rules", "common", "rule.md"));
+    assert.equal(spawnSync("mkfifo", [path.join(cache, "rules", "common", "rule.pipe")]).status, 0);
+  }, /ECC rule pack common contains unsupported entry/);
+}
+await assertInvalidEccSourcePreservesLiveState("agent-symlink", async (cache) => {
+  await fs.rm(path.join(cache, "agents", "new-agent.md"));
+  await fs.symlink("../rules/common/rule.md", path.join(cache, "agents", "agent.md"));
+}, /ECC agents source must not contain symlinks/);
+if (process.platform !== "win32") {
+  await assertInvalidEccSourcePreservesLiveState("agent-unsupported", async (cache) => {
+    await fs.rm(path.join(cache, "agents", "new-agent.md"));
+    assert.equal(spawnSync("mkfifo", [path.join(cache, "agents", "agent.pipe")]).status, 0);
+  }, /ECC agents source contains unsupported entry/);
+}
+
+const manifestOrderTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-agent-manifest-order-"));
+try {
+  await fs.writeFile(path.join(manifestOrderTarget, "A.md"), "upper", "utf8");
+  await fs.writeFile(path.join(manifestOrderTarget, "a.md"), "lower", "utf8");
+  const manifest = await buildAgentManifest(manifestOrderTarget);
+  assert.deepEqual(manifest.map((entry) => entry.path), ["A.md", "a.md"]);
+  assert.equal(validateAgentManifest(manifest), true);
+} finally {
+  await fs.rm(manifestOrderTarget, { recursive: true, force: true });
+}
+
+assert.equal(validateAgentManifest([{ path: "nested/agent.md", sha256: "a".repeat(64) }]), true);
+assert.equal(validateAgentManifest([{ path: "../agent.md", sha256: "a".repeat(64) }]), false);
+assert.equal(validateAgentManifest([{ path: "agent\\\\name.md", sha256: "a".repeat(64) }]), false);
+assert.equal(validateAgentManifest([{ path: "b.md", sha256: "a".repeat(64) }, { path: "a.md", sha256: "a".repeat(64) }]), false);
+
+const provisionRollbackTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-provision-rollback-"));
+console.log = () => {};
+try {
+  const provisionRollbackCache = await writeEccGitFixture(provisionRollbackTarget);
+  await fs.mkdir(path.join(provisionRollbackCache, "rules", "common"), { recursive: true });
+  await fs.mkdir(path.join(provisionRollbackTarget, ".claude", "rules", "ecc", "old"), { recursive: true });
+  await fs.writeFile(path.join(provisionRollbackTarget, ".claude", "rules", "ecc", "old", "rule.md"), "old rule", "utf8");
+  await fs.mkdir(path.join(provisionRollbackTarget, ".claude", "agents"), { recursive: true });
+  await fs.writeFile(path.join(provisionRollbackTarget, ".claude", "agents", "old-agent.md"), "old", "utf8");
+  await fs.mkdir(path.join(provisionRollbackTarget, ".repo-pattern"), { recursive: true });
+  const provisionConfig = "{\"workflow\":\"none\"}\n";
+  const provisionLock = "{\"ecc\":{\"rulesSyncedBy\":\"repo-pattern-auto-cache\",\"agentsSyncedBy\":\"repo-pattern-auto-cache\"}}\n";
+  const provisionMcp = "{\"before\":true}\n";
+  const provisionGitignore = "old ignore\n";
+  const provisionClaudeMd = "old generated guidance\n";
+  await fs.writeFile(path.join(provisionRollbackTarget, ".claude", "CLAUDE.md"), provisionClaudeMd, "utf8");
+  await fs.writeFile(path.join(provisionRollbackTarget, ".repo-pattern", ".repo-pattern.json"), provisionConfig, "utf8");
+  await fs.writeFile(path.join(provisionRollbackTarget, ".repo-pattern", ".repo-pattern.lock.json"), provisionLock, "utf8");
+  await fs.writeFile(path.join(provisionRollbackTarget, ".repo-pattern", ".gitignore"), provisionGitignore, "utf8");
+  await fs.writeFile(path.join(provisionRollbackTarget, ".mcp.json"), provisionMcp, "utf8");
+  await assert.rejects(
+    () => provisionProject({
+      sourceRoot: repoRoot,
+      target: provisionRollbackTarget,
+      profile: "minimal",
+      setupPipeline: "none",
+      applyRules: true,
+      ruleMode: "manual",
+      rules: ["common"],
+      optionalSkills: ["nope"]
+    }),
+    /Unknown optional skill\(s\): nope/
+  );
+  assert.equal(await fs.readFile(path.join(provisionRollbackTarget, ".claude", "rules", "ecc", "old", "rule.md"), "utf8"), "old rule");
+  assert.equal(await fs.readFile(path.join(provisionRollbackTarget, ".claude", "agents", "old-agent.md"), "utf8"), "old");
+  assert.equal(await fs.readFile(path.join(provisionRollbackTarget, ".repo-pattern", ".repo-pattern.json"), "utf8"), provisionConfig);
+  assert.equal(await fs.readFile(path.join(provisionRollbackTarget, ".repo-pattern", ".repo-pattern.lock.json"), "utf8"), provisionLock);
+  assert.equal(await fs.readFile(path.join(provisionRollbackTarget, ".repo-pattern", ".gitignore"), "utf8"), provisionGitignore);
+  assert.equal(await fs.readFile(path.join(provisionRollbackTarget, ".claude", "CLAUDE.md"), "utf8"), provisionClaudeMd);
+  assert.equal(await fs.readFile(path.join(provisionRollbackTarget, ".mcp.json"), "utf8"), provisionMcp);
+} finally {
+  console.log = originalDoctorLog;
+  await fs.rm(provisionRollbackTarget, { recursive: true, force: true });
 }
 
 const cloneError = formatEccCloneError({ stderr: "fatal: unable to access: Failed to connect to github.com port 443" });
@@ -580,8 +1005,11 @@ try {
   await fs.writeFile(path.join(setupReuseTarget, ".mcp.json"), JSON.stringify({
     mcpServers: { context7: { env: { CONTEXT7_API_KEY: "persisted-setup-key" } } }
   }), "utf8");
+  const eccFixture = await writeEccGitFixture(setupReuseTarget);
+  assert.equal(hasGitUpstream(eccFixture), false);
   result = runCli(["setup", "--target", setupReuseTarget, "--profile", "minimal", "--setup-pipeline", "ecc", "--yes"]);
   assert.equal(result.status, 0, result.stderr);
+  assert.doesNotMatch(`${result.stdout}${result.stderr}`, /ECC cache exists but git pull failed/);
   assert.match(await fs.readFile(path.join(setupReuseTarget, ".mcp.json"), "utf8"), /persisted-setup-key/);
   assert.equal(JSON.parse(await fs.readFile(path.join(setupReuseTarget, ".repo-pattern", ".repo-pattern.json"), "utf8")).workflow, "ecc-native");
 } finally {
@@ -901,6 +1329,7 @@ console.log = () => {};
 try {
   process.env.REPO_PATTERN_ECC_SETUP_CMD = "true";
   process.env.REPO_PATTERN_GSTACK_SETUP_CMD = "true";
+  await writeEccGitFixture(bothProvisionTarget);
   await provisionProject({
     sourceRoot: repoRoot,
     target: bothProvisionTarget,
@@ -931,6 +1360,7 @@ try {
 const noPipelineProvisionTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-none-provision-"));
 console.log = () => {};
 try {
+  await writeEccGitFixture(noPipelineProvisionTarget);
   await provisionProject({
     sourceRoot: repoRoot,
     target: noPipelineProvisionTarget,
@@ -995,6 +1425,7 @@ try {
     }
   }), { mode: 0o600 });
   process.env.REPO_PATTERN_GSTACK_SETUP_CMD = "true";
+  await writeEccGitFixture(gstackProvisionTarget);
   await provisionProject({
     sourceRoot: repoRoot,
     target: gstackProvisionTarget,
@@ -1141,6 +1572,7 @@ try {
 const provisionTemplateTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-template-"));
 console.log = () => {};
 try {
+  await writeEccGitFixture(provisionTemplateTarget);
   await provisionProject({
     sourceRoot: repoRoot,
     target: provisionTemplateTarget,
@@ -1199,6 +1631,7 @@ try {
 
   await fs.chmod(localSettingsPath, 0o666);
   await fs.chmod(mcpConfigPath, 0o666);
+  await writeEccGitFixture(provisionTemplateTarget);
   await provisionProject({
     sourceRoot: repoRoot,
     target: provisionTemplateTarget,
@@ -1388,6 +1821,7 @@ try {
 const defaultProvisionTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-default-provision-"));
 console.log = () => {};
 try {
+  await writeEccGitFixture(defaultProvisionTarget);
   await provisionProject({
     sourceRoot: repoRoot,
     target: defaultProvisionTarget,
@@ -1430,6 +1864,7 @@ try {
 const runOnlyTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-run-only-"));
 console.log = () => {};
 try {
+  await writeEccGitFixture(runOnlyTarget);
   await provisionProject({
     sourceRoot: repoRoot,
     target: runOnlyTarget,


### PR DESCRIPTION
## Summary

Closes #30

- Synchronize upstream ECC agent definitions only while applying ECC rules. Rules and agents stage independently, promote atomically, and restore managed state if any later write fails.
- Validate the ECC cache before mutation: canonical origin, a resolved full Git revision, clean `rules`/`agents` paths, and only regular non-symlink source entries.
- Record only agent source provenance and SHA-256 inventory in the lock; do not copy ECC skills, commands, hooks, scripts, or other runtime surfaces.
- Extend `audit` and `doctor` to report and verify managed agent inventory, malformed provenance, missing files, changed files, and unexpected files.
- Add deterministic self-check regressions for malformed sources, staged/promotion/write failures, metadata rollback, mixed-case manifests, and caches without a Git upstream.
- Document the ECC agent policy and preserve unrelated `.gstack/` work by ignoring it.

## Test Coverage

`scripts/self-check.mjs` exercises the issue #30 paths end-to-end:

- invalid Git origin, unresolved HEAD, dirty cache, missing or empty agents
- symlink and unsupported-node rejection in rule and agent trees
- independent staging and promotion failures for rules and agents
- rollback of rules, agents, configuration, lock, nested ignore metadata, generated guidance, and outer provisioning state
- SHA-256 manifest ordering and doctor integrity checks for missing, modified, and unexpected files
- cache refresh behavior when no Git upstream is configured

Coverage gate: PASS. The repository uses its deterministic self-check rather than separate `*.test.*` files.

## Pre-Landing Review

No unresolved correctness findings. Manual review covered rollback ordering, path safety, source provenance, manifest validation, and audit/doctor integration. Codex adversarial review was unavailable because the Codex CLI is not installed.

## Eval Results

No prompt-related files changed. Evals skipped.

## Plan Completion

All issue #30 plan items are addressed:

- [DONE] Transactional ECC rule and agent synchronization
- [DONE] Full rollback of managed directories and metadata
- [DONE] Deterministic manifest generation and doctor validation
- [DONE] Failure-path self-check coverage and package verification

## Verification Results

- [x] `npm test` — `self-check passed`
- [x] `npm run pack:dry` — passed for `@negikirin/repo-pattern@0.1.19`
- [x] `node --check scripts/lib/rules.mjs`
- [x] `node --check scripts/lib/provision.mjs`
- [x] `node --check scripts/self-check.mjs`
- [x] `git diff --check main...HEAD`
- [x] GitNexus change analysis completed; aggregate branch impact is high because setup and provisioning flows are affected.

## Documentation

Updated README, setup guide, and third-party notices for ECC agent synchronization and integrity validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
