### PR TITLE
feat: provision project-local gstack runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 * **Start fast** — generate `.claude/`, `.mcp.json`, and repo-pattern metadata.
 * **Stay clean** — no local skills, commands, hooks, scripts, or duplicated templates by default.
 * **Use MCP profiles** — choose `minimal`, `web`, `backend`, `research`, `full`, or `custom`.
-* **Explicit pipeline** — choose ECC (default) or the upstream global gstack installer.
+* **Explicit pipeline** — choose ECC (default) or a project-local gstack checkout.
 * **Migrate safely** — audit, cleanup, doctor, and `setup --migrate` are built in.
 
 ## Install
@@ -53,11 +53,11 @@ npx repo-pattern setup --profile web --setup-pipeline none --with-rules --yes
 Pipeline scope is explicit:
 
 - `ecc` (default) — project-scoped ECC.
-- `gstack` — user-scoped/global gstack at `~/.claude/skills/gstack`.
-- `both` — project-scoped ECC plus user-scoped/global gstack.
+- `gstack` — project-local gstack at `.claude/skills/gstack`.
+- `both` — project-scoped ECC plus project-local gstack.
 - `none` — base project metadata only.
 
-gstack requires Git and Bun v1.0+. When Bun is missing on Linux or macOS, setup downloads the official installer over TLS, validates it, and installs Bun automatically. On unsupported systems, install Bun manually before setup. Its upstream setup runs with `--quiet --no-plan-tune-hooks`, so automated setup does not show settings diffs or wait for hook confirmation.
+gstack requires Git and Bun v1.0+ on `PATH`. repo-pattern never downloads Bun and never runs the upstream `gstack/setup` script. It keeps the checkout in `.claude/skills/gstack`, runtime state in `.repo-pattern/gstack/`, and both locations gitignored. A valid existing local checkout is reused unchanged; a valid global checkout is migration-only input copied to the target without modification. Bootstrap materializes required review support files beside generated wrappers from that project-local checkout. Optional plan-tune hooks are merged only into target `.claude/settings.json`.
 
 ECC rules are independent of the ECC plugin. Whenever rules are applied, repo-pattern atomically replaces `.claude/agents/` with ECC's upstream `agents/**` tree and records the source revision plus a SHA-256 file manifest only in `.repo-pattern/.repo-pattern.lock.json`. `ecc` and `both` install auto-detected packs by default; the interactive wizard can switch to manual packs or none. `gstack` and `none` prompt whether to install rules, while scriptable setup requires `--with-rules`. Managed packs live in `.claude/rules/ecc/`; ECC skills are never copied. `doctor` verifies agent provenance and manifest integrity.
 
@@ -119,10 +119,12 @@ target-project/
 │   ├── CLAUDE.md
 │   ├── settings.json             # copied from example, gitignored
 │   ├── settings.local.json       # when local settings are provided, gitignored
+│   ├── skills/gstack/            # gstack checkout when selected, gitignored
 │   └── agents/                   # ECC agents when ECC rules are applied, gitignored
 ├── .mcp.json                     # generated, gitignored
 ├── .repo-pattern/
 │   ├── .gitignore               # *
+│   ├── gstack/                  # gstack runtime state when selected
 │   ├── .repo-pattern.json
 │   └── .repo-pattern.lock.json
 ```
@@ -149,7 +151,7 @@ Each full `repo-pattern setup` run reconciles repo-pattern-managed state to its 
 | Name | Integrated as | Source | License |
 |----|----|----|----|
 | `karpathy-guidelines` | Built-in `.claude/CLAUDE.md` guidance | https://github.com/multica-ai/andrej-karpathy-skills | MIT |
-| `gstack` | Global setup pipeline via `--setup-pipeline gstack` | https://github.com/garrytan/gstack | MIT |
+| `gstack` | Project-local checkout via `--setup-pipeline gstack` | https://github.com/garrytan/gstack | MIT |
 | `taste` | Optional Claude Code plugin via `--with-skill taste` | https://github.com/Leonxlnx/taste-skill/ | MIT |
 | `document-specialist` | Optional `.claude/skills/` install via `--with-skill document-specialist` | https://github.com/SpillwaveSolutions/document-specialist-skill/ | NOASSERTION — no upstream license declared during review on 2026-07-06 |
 | `ui-ux-pro-max` | Optional Claude Code plugin via `--with-skill ui-ux-pro-max` | https://github.com/nextlevelbuilder/ui-ux-pro-max-skill/ | MIT |

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -12,12 +12,12 @@ repo-pattern synchronizes only ECC rule packs and `agents/**` when rules are ena
 
 ## gstack
 
-repo-pattern can run gstack's upstream global setup when explicitly selected with `--setup-pipeline gstack`.
+repo-pattern can provision a project-local gstack checkout when explicitly selected with `--setup-pipeline gstack`.
 
 Source: https://github.com/garrytan/gstack
 License: MIT
 
-repo-pattern does not vendor gstack. The upstream installer manages its checkout, build output, skills, and runtime state.
+repo-pattern does not vendor gstack. It reuses or copies a valid checkout, or shallow-clones one into the target's `.claude/skills/gstack/`; runtime state is stored in `.repo-pattern/gstack/`. It never runs upstream `gstack/setup` or modifies global gstack state.
 
 ## Karpathy-inspired guidelines
 

--- a/docs/repo-pattern/setup-guide.md
+++ b/docs/repo-pattern/setup-guide.md
@@ -20,11 +20,11 @@ node scripts/repo-pattern.mjs setup --target /path/to/project --profile web --se
 Pipeline scope is explicit:
 
 - `ecc` (default) — project-scoped ECC.
-- `gstack` — user-scoped/global gstack at `~/.claude/skills/gstack`.
-- `both` — project-scoped ECC plus user-scoped/global gstack.
+- `gstack` — project-local gstack at `.claude/skills/gstack`.
+- `both` — project-scoped ECC plus project-local gstack.
 - `none` — base project metadata only.
 
-gstack requires Git and Bun v1.0+. When Bun is missing on Linux or macOS, setup downloads the official installer over TLS, validates it, and installs Bun automatically. On unsupported systems, install Bun manually before setup. Its upstream setup runs with `--quiet --no-plan-tune-hooks`, preventing settings diff previews and hook confirmation waits during automated setup. Routine upstream logs are suppressed; failures report a bounded, secret-redacted diagnostic summary.
+gstack requires Git and Bun v1.0+ on `PATH`; setup never downloads or installs Bun. repo-pattern reuses a valid project-local checkout, copies a valid global checkout as migration-only input, or shallow-clones a target-local checkout. It never runs upstream `gstack/setup` and never modifies global gstack state. Runtime state stays in `.repo-pattern/gstack/`, and bootstrap copies required review support files beside generated wrappers from the project-local checkout. Optional plan-tune hooks are merged only into the target `.claude/settings.json`. If gstack bootstrap fails, base/ECC provisioning completes, setup records the failure and prints a recovery command, and `doctor` fails until gstack is repaired.
 
 Use this when you want to initialize a new project with:
 
@@ -133,10 +133,10 @@ For non-interactive scripts, use `setup --yes`.
 12. Create `.repo-pattern/.gitignore` with `*`.
 13. Add generated setup files and basic OS/IDE noise to `.gitignore`.
 14. Write `.repo-pattern/.repo-pattern.lock.json` without credential values.
-15. Run the selected setup pipeline: ECC setup after generation, or the global gstack installer after target preflight succeeds.
+15. Run the selected setup pipeline: ECC setup after generation, or project-local gstack bootstrap after base/ECC provisioning succeeds.
 16. When rules are enabled, apply ECC rules independently of plugin installation, validate the cached ECC Git `HEAD`, and atomically promote upstream `agents/**` into `.claude/agents/`.
 17. Write ECC agent provenance and the sorted SHA-256 file inventory only to `.repo-pattern/.repo-pattern.lock.json`; rollback agents and nested metadata if promotion or metadata writes fail.
-18. Run doctor, which validates ECC agent source, revision, manifest paths, missing/extra files, and hashes.
+18. Run doctor unless gstack bootstrap failed; doctor validates ECC agent source, revision, manifest paths, missing/extra files, hashes, and local gstack surfaces.
 ```
 
 After setup, the target project should contain:
@@ -148,12 +148,16 @@ target-project/
 │   ├── CLAUDE.md
 │   ├── settings.json
 │   ├── settings.local.json  # setup only, gitignored
-│   └── agents/              # synchronized only when ECC rules are applied, gitignored
+│   ├── agents/              # synchronized only when ECC rules are applied, gitignored
+│   └── skills/
+│       ├── gstack/          # gstack/both pipelines only, gitignored
+│       └── review/          # generated gstack wrappers and review support, gitignored
 ├── .mcp.json
 ├── .repo-pattern/
 │   ├── .gitignore
 │   ├── .repo-pattern.json
-│   └── .repo-pattern.lock.json  # ECC agent source, revision, and SHA-256 inventory when rules are enabled
+│   ├── .repo-pattern.lock.json  # ECC agent source, revision, and SHA-256 inventory when rules are enabled
+│   └── gstack/              # gstack/both pipelines only, gitignored
 ```
 
 ## Root `CLAUDE.md` policy

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@negikirin/repo-pattern",
-  "version": "0.1.20",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@negikirin/repo-pattern",
-      "version": "0.1.20",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^0.11.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@negikirin/repo-pattern",
-  "version": "0.1.20",
+  "version": "0.2.0",
   "description": "Minimal ECC-first Claude Code project setup and migrator",
   "type": "module",
   "bin": {

--- a/scripts/lib/audit.mjs
+++ b/scripts/lib/audit.mjs
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { exists, isTracked, readJson, readRepoConfig, readRepoLock } from "./fs-utils.mjs";
 import { printBox, style } from "./prompt.mjs";
+import { validateProjectGstack } from "./gstack.mjs";
 import { expectedOptionalSkillDirs } from "./skills.mjs";
 
 const HARDCODED_PATH_RE = /"\/home\/|"\/Users\/|"[A-Za-z]:\\\\/;
@@ -42,9 +43,17 @@ export async function auditProject(target) {
   const repoPattern = await readRepoConfig(target, null);
   const lock = await readRepoLock(target, {});
 
-  const actualSkillDirs = await listDirNames(path.join(target, ".claude", "skills"));
-  const expectedSkillDirs = expectedOptionalSkillDirs(repoPattern?.optionalSkills || []);
-  const hasOnlyManagedSkills = JSON.stringify(actualSkillDirs) === JSON.stringify(expectedSkillDirs);
+  const workflow = repoPattern?.workflow;
+  const usesGstack = workflow === "gstack" || workflow === "ecc-gstack";
+  const gstack = usesGstack ? await validateProjectGstack(target) : null;
+  const skillsRoot = path.join(target, ".claude", "skills");
+  const actualSkillDirs = await listDirNames(skillsRoot);
+  const expectedSkillDirs = [
+    ...expectedOptionalSkillDirs(repoPattern?.optionalSkills || []),
+    ...(gstack?.wrappers || []).map((wrapper) => path.relative(skillsRoot, path.join(target, wrapper)).split(path.sep)[0]),
+    ...(usesGstack ? ["gstack"] : [])
+  ].sort();
+  const hasOnlyManagedSkills = JSON.stringify(actualSkillDirs) === JSON.stringify([...new Set(expectedSkillDirs)].sort());
   const eccRulesDir = path.join(target, ".claude", "rules", "ecc");
   const hasClaudeEccRulesDir = exists(eccRulesDir);
   const eccRulePackDirs = await listDirNames(eccRulesDir);
@@ -79,15 +88,15 @@ export async function auditProject(target) {
     hasClaudeEccRulesDir,
     eccRulePackDirs,
     hasRepoPatternJson: !!repoPattern,
-    repoPattern
+    repoPattern,
+    lock,
+    gstack
   };
 
   const allowSourceSkills = repoPattern?.mode === "template";
-  const workflow = repoPattern?.workflow;
   const usesEcc = workflow === "ecc-native" || workflow === "ecc-gstack";
-  const usesGstack = workflow === "gstack" || workflow === "ecc-gstack";
   const legacy = (
-    result.hasSettingsHooks ||
+    (result.hasSettingsHooks && !usesGstack) ||
     (result.hasClaudeSkillsDir && !repoPattern && !allowSourceSkills) ||
     result.hasClaudeCommandsDir ||
     result.hasClaudeHooksDir ||
@@ -97,7 +106,17 @@ export async function auditProject(target) {
       : !result.hasOnlyEccRulesDir))
   );
 
-  const setupComplete = !usesGstack || lock.gstack?.status === "installed";
+  const setupComplete = !usesGstack || (
+    lock.gstack?.status === "installed" &&
+    lock.gstack.installMode === "project-local" &&
+    lock.gstack.path === ".claude/skills/gstack" &&
+    lock.gstack.statePath === ".repo-pattern/gstack" &&
+    gstack.checkoutValid &&
+    gstack.stateValid &&
+    gstack.wrappersValid &&
+    gstack.assetsValid &&
+    gstack.sidecarsValid
+  );
   if (!result.hasClaudeDir && !result.hasMcpJson && !result.hasRepoPatternJson) {
     result.state = "EMPTY";
   } else if (
@@ -134,7 +153,13 @@ export function printAudit(audit) {
     [needsSetup && !audit.hasRepoPatternJson, ".repo-pattern/.repo-pattern.json missing"],
     [audit.hasHardcodedMcpPath, "hardcoded machine path in .mcp.json"],
     [audit.hasSettingsLocalTracked, ".claude/settings.local.json tracked"],
-    [audit.hasSettingsHooks, ".claude/settings.json hooks not empty"],
+    [audit.hasSettingsHooks && audit.repoPattern?.workflow !== "gstack" && audit.repoPattern?.workflow !== "ecc-gstack", ".claude/settings.json hooks not empty"],
+    [audit.gstack && !audit.gstack.checkoutValid, "project-local gstack checkout is missing or invalid"],
+    [audit.gstack && !audit.gstack.stateValid, "project-local gstack state is missing"],
+    [audit.gstack && !audit.gstack.wrappersValid, "project-local gstack wrappers have drifted"],
+    [audit.gstack && !audit.gstack.assetsValid, "project-local gstack workflow assets have drifted"],
+    [audit.gstack && !audit.gstack.sidecarsValid, "project-local gstack review sidecars have drifted"],
+    [audit.lock?.gstack?.status === "failed", "project-local gstack bootstrap failed"],
     [audit.repoPattern?.runtime?.localSkills === true && !audit.hasOnlyManagedSkills, ".claude/skills does not match managed optional skills"],
     [audit.hasClaudeSkillsDir && !audit.hasOnlyManagedSkills, ".claude/skills contains unmanaged entries"],
     [audit.hasClaudeCommandsDir, ".claude/commands present"],

--- a/scripts/lib/cleanup.mjs
+++ b/scripts/lib/cleanup.mjs
@@ -1,33 +1,54 @@
+import fs from "node:fs/promises";
 import path from "node:path";
-import { backupPaths, ensureDir, readJson, removePath, writeJson } from "./fs-utils.mjs";
+import { backupPaths, ensureDir, readJson, removePath, writePrivateJson } from "./fs-utils.mjs";
+import { gstackCheckoutPath, isValidGstackCheckout } from "./gstack.mjs";
 
-export async function cleanupProject({ sourceRoot, target, dryRun = false }) {
+export async function cleanupProject({ sourceRoot, target, dryRun = false, preserveGstack = false }) {
   console.log(`Cleaning target: ${target}`);
 
-  await backupPaths(target, [
-    ".claude/skills",
+  const claudeDir = path.join(target, ".claude");
+  if (!dryRun) {
+    try {
+      if ((await fs.lstat(claudeDir)).isSymbolicLink()) {
+        throw new Error(".claude must not be a symlink.");
+      }
+    } catch (error) {
+      if (error.code !== "ENOENT") throw error;
+    }
+  }
+  const gstackCheckout = gstackCheckoutPath(target);
+  const skillsRoot = path.dirname(gstackCheckout);
+  const preserveLocalGstack = preserveGstack &&
+    await fs.lstat(skillsRoot).then((stat) => stat.isDirectory() && !stat.isSymbolicLink()).catch(() => false) &&
+    await isValidGstackCheckout(gstackCheckout);
+  const backupList = [
     ".claude/commands",
     ".claude/hooks",
     ".claude/scripts",
     ".claude/rules",
-    ".claude/settings.json"
-  ], { dryRun });
+    ".claude/settings.json",
+    ...(preserveLocalGstack ? [] : [".claude/skills"])
+  ];
+  await backupPaths(target, backupList, { dryRun });
 
   const removeList = [
-    ".claude/skills",
     ".claude/commands",
     ".claude/hooks",
     ".claude/scripts",
-    ".claude/rules"
+    ".claude/rules",
+    ...(preserveLocalGstack ? [] : [".claude/skills"])
   ];
 
   for (const rel of removeList) {
     await removePath(path.join(target, rel), { dryRun });
   }
-
   const settings = await readJson(path.join(sourceRoot, ".claude.example", "settings.example.json"), {});
   await ensureDir(path.join(target, ".claude"), { dryRun });
-  await writeJson(path.join(target, ".claude", "settings.json"), settings, { dryRun });
+  await writePrivateJson(path.join(target, ".claude", "settings.json"), settings, {
+    dryRun,
+    label: ".claude/settings.json",
+    parentLabel: ".claude"
+  });
 
   console.log("Cleanup complete.");
 }

--- a/scripts/lib/doctor.mjs
+++ b/scripts/lib/doctor.mjs
@@ -1,7 +1,10 @@
+import { constants } from "node:fs";
+import fs from "node:fs/promises";
 import path from "node:path";
 import { auditProject } from "./audit.mjs";
-import { ensureRepoPatternGitignore, isTracked, readJson, readRepoLock, repoLockPath, writeJson } from "./fs-utils.mjs";
+import { ensureRepoPatternGitignore, isTracked, readJson, readRepoLock, repoLockPath, writePrivateJson } from "./fs-utils.mjs";
 import { printBox, style } from "./prompt.mjs";
+import { applyPlanTuneHooks, validateProjectGstack } from "./gstack.mjs";
 import { isValidEccAgentProvenance, verifyAgentInventory } from "./rules.mjs";
 
 function renderDoctor(target, checks, infoRows) {
@@ -17,7 +20,28 @@ function renderDoctor(target, checks, infoRows) {
   ]);
 }
 
+async function assertNoDoctorLockSymlink(target) {
+  const statePath = path.dirname(repoLockPath(target));
+  try {
+    if ((await fs.lstat(statePath)).isSymbolicLink()) {
+      throw new Error(".repo-pattern must not be a symlink.");
+    }
+  } catch (error) {
+    if (error.code !== "ENOENT") throw error;
+  }
+
+  const lockPath = repoLockPath(target);
+  try {
+    if ((await fs.lstat(lockPath)).isSymbolicLink()) {
+      throw new Error(".repo-pattern/.repo-pattern.lock.json must not be a symlink.");
+    }
+  } catch (error) {
+    if (error.code !== "ENOENT") throw error;
+  }
+}
+
 export async function doctorProject(target, { updateLock = false, dryRun = false } = {}) {
+  await assertNoDoctorLockSymlink(target);
   const audit = await auditProject(target);
   const checks = [];
   const infoRows = [];
@@ -37,7 +61,8 @@ export async function doctorProject(target, { updateLock = false, dryRun = false
   const usesEcc = audit.repoPattern?.workflow === "ecc-native" || audit.repoPattern?.workflow === "ecc-gstack";
   check(!audit.hasClaudeEccRulesDir || audit.hasManagedEccRules, ".claude/rules/ecc is repo-pattern-managed when present");
   check(audit.hasClaudeDir, ".claude exists");
-  check(!audit.hasSettingsHooks, ".claude/settings.json hooks is {}");
+  const usesGstack = audit.repoPattern?.workflow === "gstack" || audit.repoPattern?.workflow === "ecc-gstack";
+  check(!audit.hasSettingsHooks || usesGstack, ".claude/settings.json hooks is {} unless gstack plan-tune is enabled");
   check(!isTracked(target, ".claude/settings.json"), ".claude/settings.json is not tracked");
   check(!isTracked(target, ".claude/settings.local.json"), ".claude/settings.local.json is not tracked");
   check(!isTracked(target, ".mcp.json"), ".mcp.json is not tracked");
@@ -84,7 +109,44 @@ export async function doctorProject(target, { updateLock = false, dryRun = false
     check(isValidEccAgentProvenance(lock.ecc), ".repo-pattern/.repo-pattern.lock.json ECC agent provenance and manifest are valid");
     check(await verifyAgentInventory(path.join(target, ".claude", "agents"), lock.ecc?.appliedAgents), ".claude/agents exactly matches the locked ECC SHA-256 manifest");
   }
-  if (setupPipeline === "gstack" || setupPipeline === "both") check(lock.gstack?.status === "installed", ".repo-pattern/.repo-pattern.lock.json gstack.status=installed");
+  if (setupPipeline === "gstack" || setupPipeline === "both") {
+    const gstack = await validateProjectGstack(target);
+    const checkout = gstack.checkout;
+    const statePath = gstack.statePath;
+    const expectedSettings = applyPlanTuneHooks({ ...settings, hooks: {} }, {
+      checkout,
+      statePath,
+      enabled: Boolean(lock.gstack?.planTuneHooks)
+    });
+    const actualHooks = JSON.stringify(settings.hooks || {});
+    const expectedHooks = JSON.stringify(expectedSettings.hooks || {});
+    const hookCommands = Object.values(settings.hooks || {}).flatMap((entries) => (entries || []).flatMap((entry) => entry.hooks || [])).map((hook) => hook.command || "");
+    const hasHomePathLeak = hookCommands.some((command) => /\$HOME|~\/?\.claude\/skills\/gstack|\/\.claude\/skills\/gstack/.test(command) && !command.includes(checkout));
+    check(lock.gstack?.status === "installed", ".repo-pattern/.repo-pattern.lock.json gstack.status=installed");
+    check(lock.gstack?.installMode === "project-local", "gstack install mode is project-local");
+    check(lock.gstack?.path === ".claude/skills/gstack" && lock.gstack?.statePath === ".repo-pattern/gstack", "gstack lock paths are project-local");
+    check(gstack.checkoutValid, ".claude/skills/gstack is a valid local Git checkout");
+    check(gstack.stateValid, ".repo-pattern/gstack state exists");
+    check(gstack.wrappersValid, "gstack wrappers match local checkout state");
+    check(gstack.assetsValid, "gstack workflow assets match local checkout state");
+    check(gstack.sidecarsValid, "gstack review sidecars match local checkout state");
+    check(
+      !lock.gstack?.planTuneHooks || await Promise.all(["question-log-hook", "question-preference-hook"].map(async (hookName) => {
+        const hook = path.join(checkout, "hosts", "claude", "hooks", hookName);
+        try {
+          const stat = await fs.lstat(hook);
+          if (!stat.isFile() || stat.isSymbolicLink()) return false;
+          await fs.access(hook, constants.X_OK);
+          return true;
+        } catch {
+          return false;
+        }
+      })).then((valid) => valid.every(Boolean)),
+      "gstack plan-tune hook files are local and executable"
+    );
+    check(actualHooks === expectedHooks, "gstack plan-tune hooks match local settings");
+    check(!hasHomePathLeak, "gstack hooks do not reference home or global paths");
+  }
   if (setupPipeline === "both") infoRows.push(`ECC setup status: ${lock.ecc?.status || "unknown"}, gstack setup status: ${lock.gstack?.status || "unknown"}`);
   else if (setupPipeline !== "none") infoRows.push(`${setupPipeline === "gstack" ? "gstack" : "ECC"} setup status: ${lock[setupPipeline]?.status || "unknown"}`);
   else infoRows.push("setup pipeline: none");
@@ -98,7 +160,11 @@ export async function doctorProject(target, { updateLock = false, dryRun = false
     await ensureRepoPatternGitignore(target, { dryRun });
     lock.repoPattern = lock.repoPattern || {};
     lock.repoPattern.lastDoctorRun = new Date().toISOString();
-    await writeJson(lockPath, lock, { dryRun });
+    await writePrivateJson(lockPath, lock, {
+      dryRun,
+      label: ".repo-pattern/.repo-pattern.lock.json",
+      parentLabel: ".repo-pattern"
+    });
   }
 
   renderDoctor(target, checks, infoRows);

--- a/scripts/lib/gstack.mjs
+++ b/scripts/lib/gstack.mjs
@@ -1,32 +1,29 @@
-import { execFileSync, execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
+import { constants } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { appendGitignoreLine, ensureDir, exists, isTracked, writePrivateJson } from "./fs-utils.mjs";
+import { appendGitignoreLine, ensureDir, exists, isTracked, readJson, removePath, writeJson, writePrivateJson } from "./fs-utils.mjs";
 import { isInteractive, printSummary, withSpinner } from "./prompt.mjs";
 
 const GSTACK_REPOSITORY = "https://github.com/garrytan/gstack.git";
-const GSTACK_DIR = path.join(os.homedir(), ".claude", "skills", "gstack");
-const BUN_INSTALLER_URL = "https://bun.sh/install";
-const BUN_INSTALLER_MIN_BYTES = 1024;
-const BUN_INSTALLER_MAX_BYTES = 1024 * 1024;
-const BUN_INSTALLER_MARKERS = ["#!/usr/bin/env bash", "set -euo pipefail", "install_env=BUN_INSTALL", "github_repo=\"$GITHUB/oven-sh/bun\"", "bun_uri=$github_repo/releases/latest/download/bun-$target.zip"];
-
-export function isValidBunInstaller(source) {
-  const text = Buffer.isBuffer(source) ? source.toString("utf8") : String(source);
-  return source.length >= BUN_INSTALLER_MIN_BYTES &&
-    source.length <= BUN_INSTALLER_MAX_BYTES &&
-    text.startsWith("#!/usr/bin/env bash\n") &&
-    !text.includes("\0") &&
-    BUN_INSTALLER_MARKERS.every((marker) => text.includes(marker));
-}
-const GSTACK_SETUP_ARGS = ["--quiet"];
 const GSTACK_DIAGNOSTIC_MAX_CHARS = 4000;
-
-export function gstackSetupArgs(planTuneHooks = false) {
-  return [...GSTACK_SETUP_ARGS, planTuneHooks ? "--plan-tune-hooks" : "--no-plan-tune-hooks"];
-}
-const GSTACK_SETUP_MAX_BUFFER = 16 * 1024 * 1024;
+const GSTACK_HOOK_SOURCE = "repo-pattern-plan-tune";
+const UNSUPPORTED_SKILL_ROOTS = new Set(["codex", "node_modules", "openclaw"]);
+export const GSTACK_REVIEW_SIDECARS = [
+  "review/checklist.md",
+  "review/design-checklist.md",
+  "review/greptile-triage.md",
+  "review/TODOS-format.md",
+  "review/specialists/api-contract.md",
+  "review/specialists/data-migration.md",
+  "review/specialists/maintainability.md",
+  "review/specialists/performance.md",
+  "review/specialists/red-team.md",
+  "review/specialists/security.md",
+  "review/specialists/testing.md"
+];
+const FORBIDDEN_HOME_PATH = /(?:~|\$(?:\{HOME\}|HOME)|\/(?:home|Users)\/[^/\s]+|\/root|[A-Za-z]:[\\/]Users[\\/][^\\/\s]+)[\\/](?:\.claude|\.gstack|\.bun|\.codex|\.kiro|\.factory|\.config[\\/]opencode)(?:[\\/]|\b)/;
 
 function run(command, args, options = {}) {
   return execFileSync(command, args, { encoding: "utf8", ...options });
@@ -34,85 +31,499 @@ function run(command, args, options = {}) {
 
 function parseBunVersion(output) {
   const match = String(output).trim().match(/^(\d+)\.(\d+)\.(\d+)/);
-  if (!match || Number(match[1]) < 1) throw new Error(`Bun v1.0+ is required; found ${String(output).trim() || "an invalid version"}.`);
+  if (!match || Number(match[1]) < 1) {
+    throw new Error(`Bun v1.0+ is required; found ${String(output).trim() || "an invalid version"}. Install Bun manually and rerun setup.`);
+  }
 }
 
-function checkedBun(command, runCommand) {
-  const version = runCommand(command, ["--version"], { stdio: ["ignore", "pipe", "pipe"] });
-  parseBunVersion(version);
-  return command;
-}
-
-export async function ensureBun({
-  platform = process.platform,
-  homedir = os.homedir(),
-  tmpdir = os.tmpdir(),
-  run: runCommand = run,
-  mkdtemp = fs.mkdtemp,
-  readFile = fs.readFile,
-  rm = fs.rm
-} = {}) {
+export function ensureBun({ run: runCommand = run } = {}) {
   try {
-    return checkedBun("bun", runCommand);
+    const version = runCommand("bun", ["--version"], { stdio: ["ignore", "pipe", "pipe"] });
+    parseBunVersion(version);
+    return "bun";
   } catch (error) {
-    if (error.code !== "ENOENT") throw new Error(`Bun validation failed: ${error.message}`);
-  }
-
-  if (!["linux", "darwin"].includes(platform)) {
-    throw new Error(`Bun is missing; automatic Bun installation is supported only on Linux and macOS. Install Bun v1.0+ manually on ${platform} and rerun setup.`);
-  }
-
-  console.log("Installing Bun");
-  const installerDir = await mkdtemp(path.join(tmpdir, "repo-pattern-bun-"));
-  const installer = path.join(installerDir, "install.sh");
-  try {
-    runCommand("curl", [
-      "--fail", "--show-error", "--silent", "--location",
-      "--proto", "=https", "--proto-redir", "=https", "--tlsv1.2",
-      "--max-filesize", String(BUN_INSTALLER_MAX_BYTES), "--output", installer,
-      BUN_INSTALLER_URL
-    ], { stdio: "inherit" });
-    const source = await readFile(installer);
-    if (!isValidBunInstaller(source)) {
-      throw new Error("Downloaded Bun installer failed content validation; it was not executed.");
+    if (error.code === "ENOENT") {
+      throw new Error("Bun v1.0+ is required. Install Bun manually from https://bun.sh/docs/installation and rerun setup.");
     }
-    runCommand("bash", ["-n", installer], { stdio: "ignore" });
-    runCommand("bash", [installer], { stdio: "inherit" });
-    return checkedBun(path.join(homedir, ".bun", "bin", "bun"), runCommand);
-  } catch (error) {
-    throw new Error(`Automatic Bun installation failed: ${error.message} Install Bun v1.0+ from https://bun.sh/docs/installation and rerun setup.`);
-  } finally {
-    await rm(installerDir, { recursive: true, force: true });
+    throw new Error(`Bun validation failed: ${error.message}`);
   }
 }
 
-function withoutEccPlugin(settings = {}) {
-  const enabledPlugins = { ...(settings.enabledPlugins || {}) };
-  const extraKnownMarketplaces = { ...(settings.extraKnownMarketplaces || {}) };
-  delete enabledPlugins["ecc@ecc"];
-  delete extraKnownMarketplaces.ecc;
-  return { ...settings, enabledPlugins, extraKnownMarketplaces };
+export function gstackCheckoutPath(target) {
+  return path.join(target, ".claude", "skills", "gstack");
 }
 
-function validateGstackCheckout() {
-  if (!exists(GSTACK_DIR)) return false;
-  if (!exists(path.join(GSTACK_DIR, "setup"))) throw new Error(`Existing gstack checkout is invalid: ${GSTACK_DIR}/setup is missing.`);
+export function gstackStatePath(target) {
+  return path.join(target, ".repo-pattern", "gstack");
+}
+
+function globalGstackCheckoutPath(homedir = os.homedir()) {
+  return path.join(homedir, ".claude", "skills", "gstack");
+}
+
+async function removeLocalPath(file) {
   try {
-    execFileSync("git", ["-C", GSTACK_DIR, "rev-parse", "--is-inside-work-tree"], { stdio: "ignore" });
-  } catch {
-    throw new Error(`Existing gstack checkout is invalid: ${GSTACK_DIR} is not a Git worktree.`);
+    await fs.lstat(file);
+  } catch (error) {
+    if (error.code === "ENOENT") return;
+    throw error;
   }
-  return true;
+  await fs.rm(file, { recursive: true, force: true });
 }
 
-export async function removeEccPluginSettings({ target, dryRun = false }) {
-  if (isTracked(target, ".claude/settings.local.json")) throw new Error(".claude/settings.local.json is tracked. Untrack it before writing local plugin settings.");
-  await writePrivateJson(path.join(target, ".claude", "settings.local.json"), withoutEccPlugin, {
-    dryRun,
-    label: ".claude/settings.local.json",
-    parentLabel: ".claude"
+async function assertNoSymlinkPath(target, relativePath) {
+  const root = path.resolve(target);
+  const destination = path.resolve(root, relativePath);
+  if (destination !== root && !destination.startsWith(`${root}${path.sep}`)) {
+    throw new Error(`gstack path escapes the target: ${relativePath}`);
+  }
+
+  for (let current = root; ; current = path.dirname(current)) {
+    try {
+      if ((await fs.lstat(current)).isSymbolicLink()) {
+        throw new Error(`gstack target path contains a symlink: ${current}`);
+      }
+    } catch (error) {
+      if (error.code !== "ENOENT") throw error;
+    }
+    if (current === path.dirname(current)) break;
+  }
+
+  let current = root;
+  for (const segment of path.relative(root, destination).split(path.sep).filter(Boolean)) {
+    current = path.join(current, segment);
+    try {
+      if ((await fs.lstat(current)).isSymbolicLink()) {
+        throw new Error(`gstack target path contains a symlink: ${current}`);
+      }
+    } catch (error) {
+      if (error.code !== "ENOENT") throw error;
+    }
+  }
+}
+
+export async function isValidGstackCheckout(checkout, { run: runCommand = run } = {}) {
+  try {
+    const stat = await fs.lstat(checkout);
+    if (!stat.isDirectory() || stat.isSymbolicLink()) return false;
+    await fs.access(path.join(checkout, "setup"), constants.X_OK);
+    const insideWorkTree = runCommand("git", ["-C", checkout, "rev-parse", "--is-inside-work-tree"], { stdio: ["ignore", "pipe", "pipe"] });
+    const workTreeRoot = runCommand("git", ["-C", checkout, "rev-parse", "--show-toplevel"], { stdio: ["ignore", "pipe", "pipe"] });
+    return String(insideWorkTree).trim() === "true" &&
+      path.resolve(String(workTreeRoot).trim()) === path.resolve(checkout);
+  } catch {
+    return false;
+  }
+}
+
+function redactedGstackDiagnostic(error) {
+  const output = [error.stderr, error.stdout, error.message]
+    .map((value) => String(value || "").slice(-65536))
+    .join("\n");
+  const diagnostics = [
+    "gstack output: [redacted].",
+    ...(Number.isInteger(error.status) ? [`Exit code: ${error.status}.`] : []),
+    ...(/\b(?:bun)\b/i.test(output) ? ["Bun prerequisite failed."] : []),
+    ...(/\b(?:git|clone|checkout)\b/i.test(output) ? ["Git checkout operation failed."] : []),
+    ...(/\b(?:network|download|fetch|connection|dns|tls|certificate)\b/i.test(output) ? ["Network operation failed."] : []),
+    ...(/\b(?:permission|denied|access)\b/i.test(output) ? ["Permission or access check failed."] : []),
+    ...(/\b(?:missing|required|not found|prerequisite)\b/i.test(output) ? ["A required prerequisite is missing or invalid."] : []),
+    ...(/\b(?:error|fatal|fail(?:ed|ure)?)\b/i.test(output) ? ["gstack bootstrap failed."] : [])
+  ];
+  return diagnostics.join("\n").slice(0, GSTACK_DIAGNOSTIC_MAX_CHARS);
+}
+
+function replaceGstackPaths(source, checkout, statePath) {
+  return source
+    .replaceAll("~/.claude/skills/gstack", checkout)
+    .replaceAll("$HOME/.claude/skills/gstack", checkout)
+    .replaceAll("${GSTACK_HOME:-$HOME/.gstack}", statePath)
+    .replaceAll("${HOME}/.gstack", statePath)
+    .replaceAll("$HOME/.gstack", statePath)
+    .replaceAll("~/.gstack", statePath)
+    .replaceAll("${HOME}/.claude.json", path.join(statePath, "claude.json"))
+    .replaceAll("$HOME/.claude.json", path.join(statePath, "claude.json"))
+    .replaceAll("~/.claude.json", path.join(statePath, "claude.json"))
+    .replaceAll("${HOME}/.claude", path.join(statePath, "claude"))
+    .replaceAll("$HOME/.claude", path.join(statePath, "claude"))
+    .replaceAll("~/.claude", path.join(statePath, "claude"))
+    .replaceAll("${HOME}/.codex", path.join(statePath, "codex"))
+    .replaceAll("$HOME/.codex", path.join(statePath, "codex"))
+    .replaceAll("~/.codex", path.join(statePath, "codex"))
+    .replaceAll("${HOME}/.bun", path.join(statePath, "bun"))
+    .replaceAll("$HOME/.bun", path.join(statePath, "bun"))
+    .replaceAll("~/.bun", path.join(statePath, "bun"));
+}
+
+function shellQuote(value) {
+  return `'${String(value).replaceAll("'", `"'"'`)}'`;
+}
+
+function isInside(root, candidate) {
+  const relative = path.relative(root, candidate);
+  return relative === "" || (!relative.startsWith(`..${path.sep}`) && relative !== "..");
+}
+
+async function resolveSkillAlias(checkout, directory) {
+  let resolved;
+  try {
+    resolved = await fs.realpath(directory);
+  } catch (error) {
+    throw new Error(`gstack skill symlink is invalid: ${directory} (${error.code || error.message})`);
+  }
+  const stat = await fs.lstat(resolved);
+  if (!stat.isDirectory() || stat.isSymbolicLink()) return null;
+  if (!isInside(await fs.realpath(checkout), resolved)) {
+    throw new Error(`gstack skill symlink escapes the local checkout: ${directory}`);
+  }
+  return resolved;
+}
+
+async function skillDirectories(checkout) {
+  const directories = [];
+  async function walk(directory) {
+    const entries = await fs.readdir(directory, { withFileTypes: true });
+    if (entries.some((entry) => entry.isFile() && entry.name === "SKILL.md")) {
+      directories.push({ source: directory, relative: path.relative(checkout, directory) });
+    }
+    for (const entry of entries) {
+      const candidate = path.join(directory, entry.name);
+      const relative = path.relative(checkout, candidate);
+      const root = relative.split(path.sep)[0];
+      if (entry.name === ".git" || entry.name.startsWith(".") || UNSUPPORTED_SKILL_ROOTS.has(root)) continue;
+      if (entry.isDirectory()) await walk(candidate);
+      else if (entry.isSymbolicLink()) {
+        const resolved = await resolveSkillAlias(checkout, candidate);
+        if (!resolved) continue;
+        const resolvedEntries = await fs.readdir(resolved, { withFileTypes: true });
+        if (resolvedEntries.some((child) => child.isFile() && child.name === "SKILL.md")) {
+          directories.push({ source: resolved, relative });
+        }
+      }
+    }
+  }
+  await walk(checkout);
+  return directories;
+}
+
+function rewrittenGstackContent(source, checkout, statePath) {
+  const rewritten = replaceGstackPaths(source, checkout, statePath);
+  if (FORBIDDEN_HOME_PATH.test(rewritten)) {
+    throw new Error(`gstack skill references forbidden home-scoped state: ${rewritten.match(FORBIDDEN_HOME_PATH)?.[0]}`);
+  }
+  return rewritten;
+}
+
+function wrapperContent(source, checkout, statePath) {
+  return [
+    "<!-- Generated by repo-pattern. Project-local gstack runtime: do not edit. -->",
+    `<!-- GSTACK_HOME=${statePath} GSTACK_ROOT=${checkout} -->`,
+    rewrittenGstackContent(source, checkout, statePath)
+  ].join("\n");
+}
+
+async function writeSkillWrapper(destination, content) {
+  await ensureDir(destination);
+  await fs.writeFile(path.join(destination, "SKILL.md"), content, "utf8");
+}
+
+async function snapshotGstackArtifacts(target, wrappers, assets, sidecars, statePath) {
+  const paths = [
+    ...wrappers.map(({ wrapper }) => path.join(target, wrapper, "SKILL.md")),
+    ...assets.map(({ asset }) => path.join(target, ".claude", "skills", asset)),
+    ...sidecars.map(({ sidecar }) => path.join(target, ".claude", "skills", sidecar)),
+    path.join(statePath, "state.json"),
+    path.join(target, ".claude", "settings.json")
+  ];
+  const statePathExisted = await fs.lstat(statePath).then(() => true, (error) => {
+    if (error.code === "ENOENT") return false;
+    throw error;
   });
-  await appendGitignoreLine(target, ".claude/", { dryRun });
+  const snapshotRoot = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-gstack-transaction-"));
+  const entries = [];
+  try {
+    for (const destination of paths) {
+      await assertNoSymlinkPath(target, path.relative(target, destination));
+      try {
+        await fs.lstat(destination);
+        const snapshot = path.join(snapshotRoot, String(entries.length));
+        await fs.cp(destination, snapshot, { recursive: true, force: true });
+        entries.push({ destination, snapshot, exists: true });
+      } catch (error) {
+        if (error.code === "ENOENT") entries.push({ destination, exists: false });
+        else throw error;
+      }
+    }
+  } catch (error) {
+    await fs.rm(snapshotRoot, { recursive: true, force: true });
+    throw error;
+  }
+  return {
+    async rollback() {
+      for (const entry of [...entries].reverse()) {
+        await assertNoSymlinkPath(target, path.relative(target, entry.destination));
+        await fs.rm(entry.destination, { recursive: true, force: true });
+        if (entry.exists) await fs.cp(entry.snapshot, entry.destination, { recursive: true, force: true });
+      }
+      if (!statePathExisted) await fs.rmdir(statePath).catch((error) => {
+        if (error.code !== "ENOENT" && error.code !== "ENOTEMPTY") throw error;
+      });
+    },
+    async remove() {
+      await fs.rm(snapshotRoot, { recursive: true, force: true });
+    }
+  };
+}
+
+async function expectedGstackWrappers(target, checkout, statePath) {
+  const skillsRoot = path.dirname(checkout);
+  const skillDirs = await skillDirectories(checkout);
+  return Promise.all(skillDirs.map(async ({ source: sourceDir, relative }) => {
+    const wrapper = path.relative(target, path.join(skillsRoot, relative || "_gstack-command"));
+    const source = await fs.readFile(path.join(sourceDir, "SKILL.md"), "utf8");
+    return { wrapper, content: wrapperContent(source, checkout, statePath) };
+  })).then((wrappers) => wrappers.sort((left, right) => left.wrapper.localeCompare(right.wrapper)));
+}
+
+async function skillAssets(checkout, statePath, sourceDir, relative) {
+  const assets = [];
+  const sections = path.join(sourceDir, "sections");
+  try {
+    const stat = await fs.lstat(sections);
+    if (!stat.isDirectory() || stat.isSymbolicLink()) throw new Error(`gstack skill sections are invalid: ${sections}`);
+  } catch (error) {
+    if (error.code === "ENOENT") return assets;
+    throw error;
+  }
+  async function walk(directory) {
+    const entries = await fs.readdir(directory, { withFileTypes: true });
+    for (const entry of entries) {
+      const source = path.join(directory, entry.name);
+      if (entry.isSymbolicLink()) throw new Error(`gstack skill asset must not be a symlink: ${source}`);
+      if (entry.isDirectory()) await walk(source);
+      else if (entry.isFile()) {
+        const asset = path.join(relative || "_gstack-command", path.relative(sourceDir, source));
+        assets.push({ asset, content: rewrittenGstackContent(await fs.readFile(source, "utf8"), checkout, statePath) });
+      }
+    }
+  }
+  await walk(sections);
+  return assets;
+}
+
+async function expectedGstackAssets(target, checkout, statePath) {
+  const skillDirs = await skillDirectories(checkout);
+  const groups = await Promise.all(skillDirs.map(({ source, relative }) => skillAssets(checkout, statePath, source, relative)));
+  return groups.flat().sort((left, right) => left.asset.localeCompare(right.asset));
+}
+
+async function expectedGstackSidecars(checkout) {
+  return Promise.all(GSTACK_REVIEW_SIDECARS.map(async (sidecar) => {
+    await assertNoSymlinkPath(checkout, sidecar);
+    const source = path.join(checkout, sidecar);
+    const stat = await fs.lstat(source);
+    if (!stat.isFile() || stat.isSymbolicLink()) {
+      throw new Error(`gstack review sidecar is missing or invalid: ${sidecar}`);
+    }
+    return { sidecar, content: await fs.readFile(source, "utf8") };
+  }));
+}
+
+export async function bootstrapGstack({ target, checkout = gstackCheckoutPath(target), statePath = gstackStatePath(target), dryRun = false }) {
+  await assertNoSymlinkPath(target, path.relative(target, checkout));
+  await assertNoSymlinkPath(target, path.relative(target, statePath));
+  const wrappers = await expectedGstackWrappers(target, checkout, statePath);
+  const assets = await expectedGstackAssets(target, checkout, statePath);
+  const sidecars = await expectedGstackSidecars(checkout);
+  for (const { wrapper } of wrappers) await assertNoSymlinkPath(target, wrapper);
+  for (const { asset } of assets) await assertNoSymlinkPath(target, path.join(".claude", "skills", asset));
+  for (const { sidecar } of sidecars) await assertNoSymlinkPath(target, path.join(".claude", "skills", sidecar));
+  for (const { wrapper, content } of wrappers) {
+    const destination = path.join(target, wrapper);
+    if (dryRun) console.log(`[dry-run] write gstack skill wrapper ${destination}`);
+    else await writeSkillWrapper(destination, content);
+  }
+  for (const { asset, content } of assets) {
+    const destination = path.join(target, ".claude", "skills", asset);
+    if (dryRun) console.log(`[dry-run] write gstack skill asset ${destination}`);
+    else {
+      await ensureDir(path.dirname(destination));
+      await fs.writeFile(destination, content, "utf8");
+    }
+  }
+  for (const { sidecar, content } of sidecars) {
+    const destination = path.join(target, ".claude", "skills", sidecar);
+    if (dryRun) console.log(`[dry-run] write gstack review sidecar ${destination}`);
+    else {
+      await ensureDir(path.dirname(destination));
+      await fs.writeFile(destination, content, "utf8");
+    }
+  }
+  if (!dryRun) {
+    await ensureDir(statePath);
+    const stateFile = path.join(statePath, "state.json");
+    try {
+      if ((await fs.lstat(stateFile)).isSymbolicLink()) {
+        throw new Error(`gstack target path contains a symlink: ${stateFile}`);
+      }
+    } catch (error) {
+      if (error.code !== "ENOENT") throw error;
+    }
+    await writeJson(stateFile, {
+      checkout: path.relative(target, checkout),
+      wrappers: wrappers.map(({ wrapper }) => wrapper),
+      assets: assets.map(({ asset }) => asset),
+      sidecars: sidecars.map(({ sidecar }) => sidecar),
+      bootstrappedAt: new Date().toISOString()
+    });
+  }
+  return wrappers.map(({ wrapper }) => wrapper);
+}
+
+function hookCommand(checkout, statePath, hookName) {
+  return `GSTACK_HOME=${shellQuote(statePath)} GSTACK_ROOT=${shellQuote(checkout)} ${shellQuote(path.join(checkout, "hosts", "claude", "hooks", hookName))}`;
+}
+
+async function hasValidPlanTuneHook(checkout, hookName) {
+  try {
+    const hook = path.join(checkout, "hosts", "claude", "hooks", hookName);
+    await assertNoSymlinkPath(checkout, path.relative(checkout, hook));
+    const stat = await fs.lstat(hook);
+    if (!stat.isFile() || stat.isSymbolicLink()) return false;
+    await fs.access(hook, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function assertPlanTuneHooks(checkout) {
+  for (const hookName of ["question-log-hook", "question-preference-hook"]) {
+    if (!await hasValidPlanTuneHook(checkout, hookName)) {
+      throw new Error(`gstack plan-tune hook is missing or not executable: ${hookName}`);
+    }
+  }
+}
+
+function isManagedHook(entry) {
+  return entry?._gstack_source === GSTACK_HOOK_SOURCE;
+}
+
+export function applyPlanTuneHooks(settings = {}, { checkout, statePath, enabled }) {
+  const hooks = Object.fromEntries(Object.entries(settings.hooks || {}).map(([event, entries]) => [
+    event,
+    (entries || []).filter((entry) => !isManagedHook(entry))
+  ]).filter(([, entries]) => entries.length > 0));
+  if (enabled) {
+    for (const [event, hookName] of [["PostToolUse", "question-log-hook"], ["PreToolUse", "question-preference-hook"]]) {
+      hooks[event] = [...(hooks[event] || []), {
+        _gstack_source: GSTACK_HOOK_SOURCE,
+        hooks: [{ type: "command", command: hookCommand(checkout, statePath, hookName), timeout: 5 }]
+      }];
+    }
+  }
+  return { ...settings, hooks };
+}
+
+export async function writePlanTuneHooks({ target, planTuneHooks, dryRun = false }) {
+  const checkout = gstackCheckoutPath(target);
+  if (planTuneHooks && !dryRun) await assertPlanTuneHooks(checkout);
+  const file = path.join(target, ".claude", "settings.json");
+  await assertNoSymlinkPath(target, path.relative(target, file));
+  const settings = await readJson(file, {});
+  await writeJson(file, applyPlanTuneHooks(settings, {
+    checkout: gstackCheckoutPath(target),
+    statePath: gstackStatePath(target),
+    enabled: planTuneHooks
+  }), { dryRun });
+}
+
+export async function resolveGstackCheckout({
+  target,
+  dryRun = false,
+  globalCheckout = globalGstackCheckoutPath(),
+  run: runCommand = run,
+  copy = fs.cp,
+  clone = (destination) => runCommand("git", ["clone", "--single-branch", "--depth", "1", GSTACK_REPOSITORY, destination], { stdio: "inherit" })
+}) {
+  const localCheckout = gstackCheckoutPath(target);
+  await assertNoSymlinkPath(target, path.relative(target, localCheckout));
+  if (await isValidGstackCheckout(localCheckout, { run: runCommand })) {
+    return {
+      checkout: localCheckout,
+      source: "local",
+      async commit() {},
+      async rollback() {}
+    };
+  }
+  const globalValid = await isValidGstackCheckout(globalCheckout, { run: runCommand });
+  if (dryRun) {
+    console.log(`[dry-run] ${globalValid ? `copy ${globalCheckout} -> ${localCheckout}` : `git clone --single-branch --depth 1 ${GSTACK_REPOSITORY} ${localCheckout}`}`);
+    return {
+      checkout: localCheckout,
+      source: globalValid ? "global-migration" : "clone",
+      async commit() {},
+      async rollback() {}
+    };
+  }
+
+  const parent = path.dirname(localCheckout);
+  await ensureDir(parent);
+  const temporary = await fs.mkdtemp(path.join(parent, ".gstack-"));
+  try {
+    if (globalValid) await copy(globalCheckout, temporary, { recursive: true, force: true });
+    else await clone(temporary);
+    if (!await isValidGstackCheckout(temporary, { run: runCommand })) {
+      throw new Error("Resolved gstack checkout is invalid.");
+    }
+    const backup = await fs.mkdtemp(path.join(parent, ".gstack-backup-"));
+    await fs.rmdir(backup);
+    try {
+      try {
+        await fs.lstat(localCheckout);
+        await fs.rename(localCheckout, backup);
+      } catch (error) {
+        if (error.code !== "ENOENT") throw error;
+      }
+      await fs.rename(temporary, localCheckout);
+    } catch (error) {
+      await removeLocalPath(localCheckout);
+      try {
+        await fs.lstat(backup);
+        await fs.rename(backup, localCheckout);
+      } catch (restoreError) {
+        if (restoreError.code !== "ENOENT") throw restoreError;
+      }
+      throw error;
+    }
+    return {
+      checkout: localCheckout,
+      source: globalValid ? "global-migration" : "clone",
+      async commit() {
+        await removeLocalPath(backup);
+      },
+      async rollback() {
+        await removeLocalPath(localCheckout);
+        try {
+          await fs.lstat(backup);
+          await fs.rename(backup, localCheckout);
+        } catch (error) {
+          if (error.code !== "ENOENT") throw error;
+        }
+      }
+    };
+  } catch (error) {
+    await removePath(temporary);
+    throw error;
+  }
+}
+
+export function gstackSummaryRows(target, planTuneHooks = false) {
+  return [
+    ["Scope", "project-local .claude/skills/gstack"],
+    ["Plan-tune hooks", planTuneHooks ? "installed in .claude/settings.json" : "not installed"],
+    ["Status", "ready"]
+  ];
 }
 
 export function gstackEnvironment(bun, environment = process.env) {
@@ -120,107 +531,165 @@ export function gstackEnvironment(bun, environment = process.env) {
   return { ...environment, PATH: `${path.dirname(bun)}${path.delimiter}${environment.PATH || ""}` };
 }
 
-function redactedGstackDiagnostic(error) {
-  const output = [error.stderr, error.stdout]
-    .map((value) => String(value || "").slice(-65536))
-    .join("\n");
-  const diagnostics = [
-    "Upstream output: [redacted].",
-    ...(Number.isInteger(error.status) ? [`Exit code: ${error.status}.`] : []),
-    ...(/\b(?:bun)\b/i.test(output) ? ["Bun prerequisite or installation failed."] : []),
-    ...(/\b(?:git|clone|checkout)\b/i.test(output) ? ["Git checkout or repository operation failed."] : []),
-    ...(/\b(?:network|download|fetch|connection|dns|tls|certificate)\b/i.test(output) ? ["Network or download operation failed."] : []),
-    ...(/\b(?:permission|denied|access)\b/i.test(output) ? ["Permission or access check failed."] : []),
-    ...(/\b(?:missing|required|not found|prerequisite)\b/i.test(output) ? ["A required prerequisite is missing or invalid."] : []),
-    ...(/\b(?:unsupported)\b/i.test(output) ? ["The current environment is unsupported."] : []),
-    ...(/\b(?:settings?|hooks?)\b/i.test(output) ? ["Claude Code settings or hook setup failed."] : []),
-    ...(/\b(?:error|fatal|fail(?:ed|ure)?)\b/i.test(output) ? ["Upstream reported a setup failure."] : []),
-    ...(/\b(?:retry|rerun)\b/i.test(output) ? ["Correct the reported prerequisite and rerun setup."] : [])
-  ];
-  const summary = diagnostics.length > 0 ? diagnostics.join("\n") : "No safe upstream diagnostic was available.";
-  return summary.slice(0, GSTACK_DIAGNOSTIC_MAX_CHARS);
-}
-
-export function gstackSummaryRows(planTuneHooks = false) {
-  return [
-    ["Scope", "user-global ~/.claude/skills/gstack"],
-    ["Plan-tune hooks", planTuneHooks ? "installed in ~/.claude/settings.json" : "not installed"],
-    ["Status", "ready"]
-  ];
-}
-
-export function runGstackSetup({
-  platform = process.platform,
-  bun,
-  planTuneHooks = false,
-  run: runCommand = run,
-  log = console.error
-}) {
-  const command = platform === "win32" ? "bash" : "./setup";
-  const setupArgs = gstackSetupArgs(planTuneHooks);
-  const args = platform === "win32" ? ["./setup", ...setupArgs] : setupArgs;
-  try {
-    runCommand(command, args, {
-      cwd: GSTACK_DIR,
-      stdio: ["ignore", "pipe", "pipe"],
-      env: gstackEnvironment(bun),
-      maxBuffer: GSTACK_SETUP_MAX_BUFFER
-    });
-  } catch (error) {
-    log("gstack setup diagnostics (redacted):");
-    log(redactedGstackDiagnostic(error));
-    throw new Error("gstack setup failed; review the diagnostics above and rerun setup.");
-  }
-}
-
 export async function setupGstack({ target, dryRun = false, planTuneHooks = false }) {
-  if (isTracked(target, ".claude/settings.local.json")) throw new Error(".claude/settings.local.json is tracked. Untrack it before writing local plugin settings.");
-
-  let status = "installed";
-  if (process.env.REPO_PATTERN_GSTACK_SETUP_CMD) {
-    printSummary("gstack", [["Status", "using REPO_PATTERN_GSTACK_SETUP_CMD"]]);
-    if (dryRun) {
-      console.log(`[dry-run] REPO_PATTERN_TARGET=${target} ${process.env.REPO_PATTERN_GSTACK_SETUP_CMD}`);
-      status = "dry-run";
-    } else {
-      execSync(process.env.REPO_PATTERN_GSTACK_SETUP_CMD, {
-        cwd: target,
-        stdio: "inherit",
-        env: { ...process.env, REPO_PATTERN_TARGET: target },
-        shell: true
-      });
-    }
-  } else if (dryRun) {
-    console.log("Checking gstack prerequisites");
-    if (!exists(GSTACK_DIR)) {
-      console.log("Cloning gstack");
-      console.log(`[dry-run] git clone --single-branch --depth 1 ${GSTACK_REPOSITORY} ${GSTACK_DIR}`);
-    } else {
-      console.log("Using existing gstack checkout");
-    }
-    console.log("Running gstack setup");
-    console.log(`[dry-run] cd ${GSTACK_DIR} && ./setup ${gstackSetupArgs(planTuneHooks).join(" ")}`);
-    status = "dry-run";
-  } else {
-    const runSetup = async () => {
-      const bun = await ensureBun();
-      if (!validateGstackCheckout()) {
-        console.log("Cloning gstack");
-        await ensureDir(path.dirname(GSTACK_DIR));
-        execFileSync("git", ["clone", "--single-branch", "--depth", "1", GSTACK_REPOSITORY, GSTACK_DIR], { stdio: "inherit" });
-      } else if (!isInteractive()) {
-        console.log("Using existing gstack checkout");
+  const checkout = gstackCheckoutPath(target);
+  const statePath = gstackStatePath(target);
+  let checkoutLease = null;
+  let transaction = null;
+  try {
+    if (!dryRun) ensureBun();
+    const install = async () => {
+      const resolved = await resolveGstackCheckout({ target, dryRun });
+      checkoutLease = resolved;
+      if (!dryRun) {
+        const wrappers = await expectedGstackWrappers(target, checkout, statePath);
+        const assets = await expectedGstackAssets(target, checkout, statePath);
+        const sidecars = await expectedGstackSidecars(checkout);
+        transaction = await snapshotGstackArtifacts(target, wrappers, assets, sidecars, statePath);
+        await bootstrapGstack({ target, checkout, statePath, dryRun });
+      } else console.log(`[dry-run] write gstack skill wrapper ${path.join(path.dirname(checkout), "_gstack-command")}`);
+      await writePlanTuneHooks({ target, planTuneHooks, dryRun });
+      if (!dryRun) {
+        await checkoutLease.commit();
+        try {
+          await transaction.remove();
+        } catch (error) {
+          console.warn(`WARN: gstack rollback snapshot cleanup failed: ${error.message}`);
+        }
+        transaction = null;
       }
-      runGstackSetup({ bun, planTuneHooks });
+      return { status: dryRun ? "dry-run" : "installed", source: resolved.source, path: checkout, statePath };
     };
-    if (isInteractive()) await withSpinner("Installing global gstack", runSetup);
-    else {
-      console.log("Checking gstack prerequisites");
-      console.log("Running gstack setup");
-      await runSetup();
+    const result = dryRun
+      ? await install()
+      : isInteractive()
+        ? await withSpinner("Installing project-local gstack", install)
+        : await install();
+    if (!dryRun) printSummary("gstack", gstackSummaryRows(target, planTuneHooks));
+    return result;
+  } catch (error) {
+    if (transaction) {
+      try {
+        await transaction.rollback();
+      } catch (rollbackError) {
+        console.warn(`WARN: gstack artifact rollback failed: ${rollbackError.message}`);
+      }
+      try {
+        await transaction.remove();
+      } catch (rollbackError) {
+        console.warn(`WARN: gstack rollback snapshot cleanup failed: ${rollbackError.message}`);
+      }
     }
-    printSummary("gstack", gstackSummaryRows(planTuneHooks));
+    if (checkoutLease) {
+      try {
+        await checkoutLease.rollback();
+      } catch (rollbackError) {
+        console.warn(`WARN: gstack checkout rollback failed: ${rollbackError.message}`);
+      }
+    }
+    return { status: "failed", path: checkout, statePath, error: redactedGstackDiagnostic(error) };
   }
+}
 
-  return status;
+export async function removeEccPluginSettings({ target, dryRun = false }) {
+  if (isTracked(target, ".claude/settings.local.json")) throw new Error(".claude/settings.local.json is tracked. Untrack it before writing local plugin settings.");
+  await writePrivateJson(path.join(target, ".claude", "settings.local.json"), (settings = {}) => {
+    const enabledPlugins = { ...(settings.enabledPlugins || {}) };
+    const extraKnownMarketplaces = { ...(settings.extraKnownMarketplaces || {}) };
+    delete enabledPlugins["ecc@ecc"];
+    delete extraKnownMarketplaces.ecc;
+    return { ...settings, enabledPlugins, extraKnownMarketplaces };
+  }, { dryRun, label: ".claude/settings.local.json", parentLabel: ".claude" });
+  await appendGitignoreLine(target, ".claude/", { dryRun });
+}
+
+export async function validateProjectGstack(target) {
+  const checkout = gstackCheckoutPath(target);
+  const statePath = gstackStatePath(target);
+  let pathsValid = true;
+  try {
+    await assertNoSymlinkPath(target, path.relative(target, checkout));
+    await assertNoSymlinkPath(target, path.relative(target, statePath));
+  } catch {
+    pathsValid = false;
+  }
+  const checkoutValid = pathsValid && await isValidGstackCheckout(checkout);
+  const stateFile = path.join(statePath, "state.json");
+  let stateValid = pathsValid;
+  let wrapperState = {};
+  if (stateValid) {
+    try {
+      await assertNoSymlinkPath(target, path.relative(target, stateFile));
+      const stateStat = await fs.lstat(stateFile);
+      if (!stateStat.isFile() || stateStat.isSymbolicLink()) stateValid = false;
+      else {
+        wrapperState = await readJson(stateFile, {});
+        if (!wrapperState ||
+          !Array.isArray(wrapperState.wrappers) ||
+          !Array.isArray(wrapperState.assets) ||
+          !Array.isArray(wrapperState.sidecars) ||
+          wrapperState.checkout !== path.relative(target, checkout) ||
+          Number.isNaN(Date.parse(wrapperState.bootstrappedAt))) {
+          stateValid = false;
+          wrapperState = {};
+        }
+      }
+    } catch {
+      stateValid = false;
+    }
+  }
+  const wrappers = wrapperState.wrappers || [];
+  const assets = wrapperState.assets || [];
+  const sidecars = wrapperState.sidecars || [];
+  let expectedWrappers = [];
+  let expectedAssets = [];
+  let expectedSidecars = [];
+  if (checkoutValid) {
+    try {
+      [expectedWrappers, expectedAssets, expectedSidecars] = await Promise.all([
+        expectedGstackWrappers(target, checkout, statePath),
+        expectedGstackAssets(target, checkout, statePath),
+        expectedGstackSidecars(checkout)
+      ]);
+    } catch {
+      stateValid = false;
+    }
+  }
+  const wrappersMatch = JSON.stringify([...wrappers].sort()) === JSON.stringify(expectedWrappers.map(({ wrapper }) => wrapper));
+  const assetsMatch = JSON.stringify([...assets].sort()) === JSON.stringify(expectedAssets.map(({ asset }) => asset));
+  const sidecarsMatch = JSON.stringify([...sidecars].sort()) === JSON.stringify(expectedSidecars.map(({ sidecar }) => sidecar).sort());
+  const wrappersValid = checkoutValid && stateValid && wrappers.length > 0 && wrappersMatch && await Promise.all(expectedWrappers.map(async ({ wrapper, content }) => {
+    try {
+      const file = path.join(target, wrapper, "SKILL.md");
+      await assertNoSymlinkPath(target, path.relative(target, file));
+      return exists(file) && await fs.readFile(file, "utf8") === content;
+    } catch {
+      return false;
+    }
+  })).then((valid) => valid.every(Boolean));
+  const assetChecks = await Promise.all(expectedAssets.map(async ({ asset, content }) => {
+    try {
+      const file = path.join(target, ".claude", "skills", asset);
+      await assertNoSymlinkPath(target, path.relative(target, file));
+      const stat = await fs.lstat(file);
+      const actual = await fs.readFile(file, "utf8");
+      return stat.isFile() && !stat.isSymbolicLink() && actual === content;
+    } catch {
+      return false;
+    }
+  }));
+  const assetsValid = checkoutValid && stateValid && assetsMatch && assetChecks.every(Boolean);
+  const sidecarChecks = await Promise.all(expectedSidecars.map(async ({ sidecar, content }) => {
+    try {
+      const file = path.join(target, ".claude", "skills", sidecar);
+      await assertNoSymlinkPath(target, path.relative(target, file));
+      const stat = await fs.lstat(file);
+      const actual = await fs.readFile(file, "utf8");
+      return stat.isFile() && !stat.isSymbolicLink() && actual === content;
+    } catch {
+      return false;
+    }
+  }));
+  const sidecarsValid = checkoutValid && stateValid && sidecarsMatch && sidecarChecks.every(Boolean);
+  return { checkout, statePath, checkoutValid, stateValid, wrappers, wrappersValid, assets, assetsValid, sidecars, sidecarsValid };
 }

--- a/scripts/lib/provision.mjs
+++ b/scripts/lib/provision.mjs
@@ -5,10 +5,10 @@ import { auditProject, printAudit } from "./audit.mjs";
 import { cleanupProject } from "./cleanup.mjs";
 import { generateMcp, withoutPersistedMcpValues } from "./mcp.mjs";
 import { ECC_PLUGIN, applyEccPluginSettings, setupEcc } from "./ecc.mjs";
-import { setupGstack } from "./gstack.mjs";
+import { gstackCheckoutPath, gstackStatePath, setupGstack } from "./gstack.mjs";
 import { doctorProject } from "./doctor.mjs";
 import { applyEccRules, clearEccRules } from "./rules.mjs";
-import { appendGitignoreLine, backupPaths, copyRecursive, ensureDir, ensureRepoPatternGitignore, exists, isTracked, readJson, readRepoConfig, removePath, repoConfigPath, repoLockPath, writeJson, writeIfMissing, writePrivateJson } from "./fs-utils.mjs";
+import { appendGitignoreLine, backupPaths, copyRecursive, ensureDir, ensureRepoPatternGitignore, exists, isTracked, readJson, readPrivateJson, readRepoConfig, removePath, repoConfigPath, repoLockPath, writeIfMissing, writePrivateJson } from "./fs-utils.mjs";
 import { printSummary, style } from "./prompt.mjs";
 import { applyOptionalSkills, reconcilePluginSkillSettings } from "./skills.mjs";
 
@@ -32,8 +32,8 @@ function usesGstack(setupPipeline) {
 export function setupPipelineScope(setupPipeline) {
   return {
     ecc: "project-scoped ECC",
-    gstack: "user-scoped/global gstack at ~/.claude/skills/gstack",
-    both: "project-scoped ECC + user-scoped/global gstack at ~/.claude/skills/gstack",
+    gstack: "project-local gstack at .claude/skills/gstack",
+    both: "project-scoped ECC + project-local gstack at .claude/skills/gstack",
     none: "writes only base project metadata"
   }[setupPipeline];
 }
@@ -63,41 +63,44 @@ async function repoPatternConfig(sourceRoot, profile, setupPipeline) {
   };
 }
 
-function lockConfig(profile, setupPipeline, pipelineStatus = {}, planTuneHooks = false) {
+function lockConfig(target, profile, setupPipeline, lock = {}, pipelineStatus = {}, planTuneHooks = false) {
   const status = typeof pipelineStatus === "string" ? { ecc: pipelineStatus, gstack: pipelineStatus } : pipelineStatus;
   const eccStatus = status.ecc || "not-run";
-  const gstackStatus = status.gstack || "not-run";
+  const gstack = status.gstack || { status: "not-run" };
+  const gstackStatus = typeof gstack === "string" ? gstack : gstack.status;
+  const now = new Date().toISOString();
   return {
+    ...lock,
     repoPattern: {
+      ...(lock.repoPattern || {}),
       version: "2.0.0",
-      lastProvisionRun: new Date().toISOString(),
+      lastProvisionRun: now,
       lastDoctorRun: null
     },
     setupPipeline,
     ...(usesEcc(setupPipeline) ? {
       ecc: {
+        ...(lock.ecc || {}),
         installMode: "plugin",
         status: eccStatus,
-        rulesSyncedBy: null,
-        rulesScope: "project",
-        recommendedRules: [],
-        appliedRules: [],
-        detectedStack: null,
-        rulesAppliedAt: null,
         hooks: "plugin-managed",
-        syncedAt: eccStatus === "installed" ? new Date().toISOString() : null
+        syncedAt: eccStatus === "installed" ? now : null
       }
     } : {}),
     ...(usesGstack(setupPipeline) ? {
       gstack: {
-        installMode: "global",
+        installMode: "project-local",
         source: "https://github.com/garrytan/gstack.git",
-        planTuneHooks,
+        path: path.relative(target, gstackCheckoutPath(target)),
+        statePath: path.relative(target, gstackStatePath(target)),
+        planTuneHooks: gstackStatus === "installed" ? planTuneHooks : false,
         status: gstackStatus,
-        syncedAt: gstackStatus === "installed" ? new Date().toISOString() : null
+        ...(gstackStatus === "installed" ? { syncedAt: now } : {}),
+        ...(gstackStatus === "failed" ? { failedAt: now, error: gstack.error } : {})
       }
     } : {}),
     mcp: {
+      ...(lock.mcp || {}),
       profile,
       generatedAt: null
     }
@@ -129,24 +132,36 @@ export function applyPermissionSettings(settings, permissionConfig = { bypass: "
 async function writeClaudeSettings({ sourceRoot, target, attributionConfig, permissionConfig, dryRun }) {
   const template = await readJson(path.join(sourceRoot, ".claude.example", "settings.example.json"), {});
   const settings = applyPermissionSettings(applyAttributionSetting(template, attributionConfig), permissionConfig);
-  await writeJson(path.join(target, ".claude", "settings.json"), settings, { dryRun });
+  await writePrivateJson(path.join(target, ".claude", "settings.json"), settings, {
+    dryRun,
+    label: ".claude/settings.json",
+    parentLabel: ".claude"
+  });
 }
 
 export async function updateClaudeAttribution({ sourceRoot, target, attributionConfig, dryRun }) {
   if (isTracked(target, ".claude/settings.json")) throw new Error(".claude/settings.json is tracked. Untrack it before writing Claude Code settings.");
   const file = path.join(target, ".claude", "settings.json");
-  const current = await readJson(file, null);
+  const current = await readPrivateJson(file, null, { label: ".claude/settings.json", parentLabel: ".claude" });
   const template = await readJson(path.join(sourceRoot, ".claude.example", "settings.example.json"), {});
-  await writeJson(file, applyAttributionSetting(current || template, attributionConfig), { dryRun });
+  await writePrivateJson(file, applyAttributionSetting(current || template, attributionConfig), {
+    dryRun,
+    label: ".claude/settings.json",
+    parentLabel: ".claude"
+  });
   await appendGitignoreLine(target, ".claude/", { dryRun });
 }
 
 export async function updateClaudePermissions({ sourceRoot, target, permissionConfig, dryRun }) {
   if (isTracked(target, ".claude/settings.json")) throw new Error(".claude/settings.json is tracked. Untrack it before writing Claude Code settings.");
   const file = path.join(target, ".claude", "settings.json");
-  const current = await readJson(file, null);
+  const current = await readPrivateJson(file, null, { label: ".claude/settings.json", parentLabel: ".claude" });
   const template = await readJson(path.join(sourceRoot, ".claude.example", "settings.example.json"), {});
-  await writeJson(file, applyPermissionSettings(current || template, permissionConfig), { dryRun });
+  await writePrivateJson(file, applyPermissionSettings(current || template, permissionConfig), {
+    dryRun,
+    label: ".claude/settings.json",
+    parentLabel: ".claude"
+  });
   await appendGitignoreLine(target, ".claude/", { dryRun });
 }
 
@@ -173,14 +188,22 @@ export function reconcileLocalPluginSettings(settings = {}, { setupPipeline, opt
 
 async function rejectClaudeSymlink(target, { dryRun = false } = {}) {
   if (dryRun) return;
-  let stat;
-  try {
-    stat = await fs.lstat(path.join(target, ".claude"));
-  } catch (error) {
-    if (error.code === "ENOENT") return;
-    throw error;
+  const managedPaths = [
+    [".claude", ".claude"],
+    [".claude/settings.json", ".claude/settings.json"],
+    [".repo-pattern", ".repo-pattern"],
+    [".repo-pattern/.repo-pattern.json", ".repo-pattern/.repo-pattern.json"],
+    [".repo-pattern/.repo-pattern.lock.json", ".repo-pattern/.repo-pattern.lock.json"]
+  ];
+  for (const [relativePath, label] of managedPaths) {
+    try {
+      if ((await fs.lstat(path.join(target, relativePath))).isSymbolicLink()) {
+        throw new Error(`${label} must not be a symlink.`);
+      }
+    } catch (error) {
+      if (error.code !== "ENOENT") throw error;
+    }
   }
-  if (stat.isSymbolicLink()) throw new Error(".claude must not be a symlink.");
 }
 
 async function snapshotProvisionState(target, { dryRun = false } = {}) {
@@ -262,14 +285,20 @@ export async function provisionProject({ sourceRoot, target, profile = "web", se
   if (isTracked(target, ".repo-pattern/.repo-pattern.lock.json") || isTracked(target, ".repo-pattern.lock.json")) throw new Error("repo-pattern lock is tracked. Untrack it before writing local setup state.");
 
   const provisionSnapshot = await snapshotProvisionState(target, { dryRun });
+  const lockPath = repoLockPath(target);
   let eccStatus = null;
+  let gstackStatus = null;
   let mcpResult = null;
   try {
-    const gstackStatus = usesGstack(setupPipeline) ? await setupGstack({ target, dryRun, planTuneHooks }) : null;
     const previousRepoConfig = await readRepoConfig(target, {});
 
     if (audit.state === "LEGACY_VENDOR") {
-      await cleanupProject({ sourceRoot, target, dryRun });
+      await cleanupProject({
+        sourceRoot,
+        target,
+        dryRun,
+        preserveGstack: usesGstack(setupPipeline)
+      });
     } else {
       await backupPaths(target, ["CLAUDE.md", ".claude/CLAUDE.md", ".claude/settings.json", ".claude/rules", ".claude/agents", ".claude/skills", ".claude/commands", ".claude/hooks", ".claude/scripts", ".repo-pattern/.repo-pattern.json", ".repo-pattern/.repo-pattern.lock.json"], { dryRun });
     }
@@ -288,16 +317,15 @@ export async function provisionProject({ sourceRoot, target, profile = "web", se
 
     await writeClaudeSettings({ sourceRoot, target, attributionConfig, permissionConfig, dryRun });
     await appendGitignoreLine(target, ".claude/", { dryRun });
-
     await writeLocalSettings({ sourceRoot, target, localSettingsEnv, setupPipeline, optionalSkills, dryRun });
-
     await ensureRepoPatternGitignore(target, { dryRun });
-    const lockPath = repoLockPath(target);
     mcpResult = await generateMcp({ sourceRoot, target, profile, mcpServers, mcpValues, dryRun });
     eccStatus = usesEcc(setupPipeline) ? await setupEcc({ sourceRoot, target, dryRun, configurePlugin: false }) : null;
-    await writeJson(repoConfigPath(target), await repoPatternConfig(sourceRoot, profile, setupPipeline), { dryRun });
-    await writeJson(lockPath, lockConfig(profile, setupPipeline, { ecc: eccStatus, gstack: gstackStatus }, planTuneHooks), { dryRun });
-    await ensureRepoPatternGitignore(target, { dryRun });
+    await writePrivateJson(repoConfigPath(target), await repoPatternConfig(sourceRoot, profile, setupPipeline), {
+      dryRun,
+      label: ".repo-pattern/.repo-pattern.json",
+      parentLabel: ".repo-pattern"
+    });
     if (shouldApplyRules) await applyEccRules({ target, dryRun, ruleMode, rules });
     else await clearEccRules({ target, dryRun });
     await applyOptionalSkills({
@@ -307,12 +335,6 @@ export async function provisionProject({ sourceRoot, target, profile = "web", se
       reconcile: true,
       previousOptionalSkills: previousRepoConfig.optionalSkills
     });
-
-    if (dryRun) {
-      console.log("[dry-run] doctor skipped because no files were written.");
-    } else {
-      await doctorProject(target, { updateLock: true, dryRun });
-    }
   } catch (error) {
     try {
       await restoreProvisionState(provisionSnapshot);
@@ -328,25 +350,51 @@ export async function provisionProject({ sourceRoot, target, profile = "web", se
     }
   }
 
+  if (usesGstack(setupPipeline)) gstackStatus = await setupGstack({ target, dryRun, planTuneHooks });
+  const currentLock = await readPrivateJson(lockPath, {}, {
+    label: ".repo-pattern/.repo-pattern.lock.json",
+    parentLabel: ".repo-pattern"
+  });
+  await writePrivateJson(lockPath, lockConfig(target, profile, setupPipeline, currentLock, { ecc: eccStatus, gstack: gstackStatus }, planTuneHooks), {
+    dryRun,
+    label: ".repo-pattern/.repo-pattern.lock.json",
+    parentLabel: ".repo-pattern"
+  });
+  await ensureRepoPatternGitignore(target, { dryRun });
+
+  if (dryRun) console.log("[dry-run] doctor skipped because no files were written.");
+  else if (gstackStatus?.status === "failed") console.log("gstack doctor skipped because gstack bootstrap failed.");
+  else await doctorProject(target, { updateLock: true, dryRun });
+
   const pending = [
     ...(eccStatus === "manual-plugin-install-required" ? ["ECC plugin"] : []),
     ...(mcpResult.missingValues.length > 0 ? ["MCP values"] : [])
   ];
-  const pendingText = pending.length ? `${pending.join(", ")} pending` : style("success", "ready");
+  const gstackFailed = gstackStatus?.status === "failed";
+  const pendingText = gstackFailed
+    ? "gstack setup failed"
+    : pending.length
+      ? `${pending.join(", ")} pending`
+      : style("success", "ready");
   const next = dryRun
     ? "review output, then rerun without --dry-run"
-    : pending.length
-      ? `resolve ${pending.join(" and ")}, then run claude`
-      : `cd ${shellQuote(target)} && claude`;
+    : gstackFailed
+      ? `install Bun v1.0+ or fix gstack, then rerun repo-pattern setup --target ${shellQuote(target)} --setup-pipeline ${setupPipeline} --yes`
+      : pending.length
+        ? `resolve ${pending.join(" and ")}, then run claude`
+        : `cd ${shellQuote(target)} && claude`;
   printSummary("Setup complete", [
     ["Status", dryRun ? `preview only; ${pendingText}` : pendingText],
     ["Target", target],
     ["Setup pipeline", setupPipeline],
     ["Pipeline scope", setupPipelineScope(setupPipeline)],
-    ...(usesGstack(setupPipeline) ? [["Plan-tune hooks", planTuneHooks ? "installed in ~/.claude/settings.json" : "not installed"]] : []),
+    ...(usesGstack(setupPipeline) ? [
+      ["gstack", gstackFailed ? `FAILED — ${gstackStatus.error}` : "installed at .claude/skills/gstack"],
+      ["Plan-tune hooks", !gstackFailed && planTuneHooks ? "installed in .claude/settings.json" : "not installed"]
+    ] : []),
     ["Profile", profile],
     [dryRun ? "Would write" : "Written", `CLAUDE.md (if missing), .claude/, .mcp.json, .repo-pattern/.repo-pattern.json, .repo-pattern/.repo-pattern.lock.json${optionalSkills.length ? ", optional skill/plugin config" : ""}`],
-    ["Doctor", dryRun ? "skipped (dry-run)" : style("success", "passed")],
+    ["Doctor", dryRun ? "skipped (dry-run)" : gstackFailed ? "skipped because gstack failed" : style("success", "passed")],
     ["Next", next]
   ]);
 }

--- a/scripts/lib/setup.mjs
+++ b/scripts/lib/setup.mjs
@@ -107,7 +107,7 @@ function retryRows(setup) {
     ["Failed step", setup.failedStep || "unknown"],
     ["Error", setup.error || "unknown"],
     ["Setup pipeline", options.setupPipeline || "ecc"],
-    ...(usesGstack(options.setupPipeline) ? [["Plan-tune hooks", options.planTuneHooks ? "installed in ~/.claude/settings.json" : "not installed"]] : []),
+    ...(usesGstack(options.setupPipeline) ? [["Plan-tune hooks", options.planTuneHooks ? "installed in .claude/settings.json" : "not installed"]] : []),
     ["Profile", options.profile || "web"],
     ["MCP servers", options.mcpServers?.join(", ") || "from profile"],
     ["MCP values", options.mcpValueNames?.length ? options.mcpValueNames.join(", ") : "none"],
@@ -218,7 +218,7 @@ async function chooseSetupPipeline(initialValue = "ecc") {
     message: "Choose setup pipeline",
     options: [
       { value: "ecc", label: "ECC", description: "project-scoped plugin with optional project rules" },
-      { value: "gstack", label: "gstack", description: "user-scoped/global at ~/.claude/skills/gstack; requires Git and Bun" }
+      { value: "gstack", label: "gstack", description: "project-local at .claude/skills/gstack; requires Git and Bun" }
     ],
     initialValues: pipelineValues(initialValue)
   }));
@@ -229,8 +229,8 @@ async function choosePlanTuneHooks(setupPipeline, initialValue = false) {
   return selectOne({
     message: "Install gstack plan-tune hooks?",
     options: [
-      { value: false, label: "No", description: "keep ~/.claude/settings.json unchanged by gstack" },
-      { value: true, label: "Yes", description: "add gstack PreToolUse and PostToolUse hooks to ~/.claude/settings.json" }
+      { value: false, label: "No", description: "keep target .claude/settings.json unchanged by gstack" },
+      { value: true, label: "Yes", description: "add gstack PreToolUse and PostToolUse hooks to target .claude/settings.json" }
     ],
     initialValue
   });
@@ -349,11 +349,12 @@ function attributionSummary(attributionConfig) {
 
 async function confirmSummary({ action, setupPipeline, planTuneHooks, target, mcpConfig, mcpValues, ruleConfig, optionalSkills, localSettingsEnv, attributionConfig, permissionConfig, dryRun }) {
   const hasLocalSkill = optionalSkills.some((name) => !OPTIONAL_SKILLS.find((skill) => skill.value === name)?.plugin);
+  const writesGstack = usesGstack(setupPipeline);
   printSummary("Setup summary", [
     ["Action", action],
     ["Setup pipeline", setupPipeline],
     ["Pipeline scope", setupPipelineScope(setupPipeline)],
-    ...(usesGstack(setupPipeline) ? [["Plan-tune hooks", planTuneHooks ? "will add PreToolUse/PostToolUse hooks to ~/.claude/settings.json" : "not installed"]] : []),
+    ...(usesGstack(setupPipeline) ? [["Plan-tune hooks", planTuneHooks ? "will add PreToolUse/PostToolUse hooks to .claude/settings.json" : "not installed"]] : []),
     ["Target", target],
     ["Profile", mcpConfig.profile],
     ["MCP servers", mcpConfig.mcpServers?.join(", ") || "from profile"],
@@ -370,8 +371,8 @@ async function confirmSummary({ action, setupPipeline, planTuneHooks, target, mc
     ["Bypass permissions", permissionConfig.bypass === "allow" ? "allowed by default" : "disabled"],
     ["Commit attribution", attributionSummary(attributionConfig)],
     ["Dry-run", dryRun ? "yes" : "no"],
-    ["Will write", `CLAUDE.md (if missing), .claude/CLAUDE.md, .claude/settings.json, .claude/settings.local.json, .mcp.json, .repo-pattern/.repo-pattern.json, .repo-pattern/.repo-pattern.lock.json${optionalSkills.length ? ", optional skill/plugin config" : ""}${hasLocalSkill ? ", .claude/skills" : ""}`],
-    ["Will not write", hasLocalSkill ? ".claude/commands, .claude/hooks, .claude/scripts" : ".claude/skills, .claude/commands, .claude/hooks, .claude/scripts"]
+    ["Will write", `CLAUDE.md (if missing), .claude/CLAUDE.md, .claude/settings.json, .claude/settings.local.json, .mcp.json, .repo-pattern/.repo-pattern.json, .repo-pattern/.repo-pattern.lock.json${writesGstack ? ", .claude/skills/gstack, generated gstack wrappers, .repo-pattern/gstack" : ""}${optionalSkills.length ? ", optional skill/plugin config" : ""}${hasLocalSkill ? ", .claude/skills" : ""}`],
+    ["Will not write", hasLocalSkill || writesGstack ? ".claude/commands, .claude/hooks, .claude/scripts" : ".claude/skills, .claude/commands, .claude/hooks, .claude/scripts"]
   ]);
 
   const answer = await selectOne({

--- a/scripts/lib/skills.mjs
+++ b/scripts/lib/skills.mjs
@@ -334,7 +334,6 @@ export async function applyOptionalSkills({
         if (!["ENOENT", "ENOTEMPTY", "EEXIST"].includes(error.code)) throw error;
       }
     }
-
     const repoPatternDir = path.join(target, ".repo-pattern");
     if (dryRun) {
       console.log(`[dry-run] rm -rf ${path.join(repoPatternDir, "cache")}`);

--- a/scripts/repo-pattern.mjs
+++ b/scripts/repo-pattern.mjs
@@ -121,10 +121,10 @@ Options:
   --setup-pipeline <ecc|gstack|both|none>
                                   Setup pipeline. Default: ecc
                                   ecc: project-scoped ECC
-                                  gstack: user-scoped/global at ~/.claude/skills/gstack
-                                  both: project-scoped ECC + user-scoped/global gstack
+                                  gstack: project-local at .claude/skills/gstack
+                                  both: project-scoped ECC + project-local gstack
                                   none: base project metadata only
-  --with-plan-tune-hooks          Add gstack PreToolUse/PostToolUse hooks to ~/.claude/settings.json
+  --with-plan-tune-hooks          Add gstack PreToolUse/PostToolUse hooks to .claude/settings.json
                                   Requires --setup-pipeline gstack or both. Default: not installed
 
 Setup UI:

--- a/scripts/self-check/cli-contract.mjs
+++ b/scripts/self-check/cli-contract.mjs
@@ -8,7 +8,6 @@ import { auditProject, printAudit } from "../lib/audit.mjs";
 import { cleanupProject } from "../lib/cleanup.mjs";
 import { doctorProject } from "../lib/doctor.mjs";
 import { ECC_PLUGIN, applyEccPluginSettings, setupEcc } from "../lib/ecc.mjs";
-import { ensureBun, gstackEnvironment, gstackSummaryRows, isValidBunInstaller, removeEccPluginSettings, runGstackSetup, setupGstack } from "../lib/gstack.mjs";
 import { applyMcpValues, generateMcp, mcpSecretPrompt, persistedMcpValues, readGeneratedMcpValues, validateRelativeMcpPath } from "../lib/mcp.mjs";
 import { applyAttributionSetting, applyLocalSettings, applyPermissionSettings, provisionProject, reconcileLocalPluginSettings, setupPipelineScope, updateClaudePermissions } from "../lib/provision.mjs";
 import { writePrivateJson } from "../lib/fs-utils.mjs";
@@ -115,8 +114,8 @@ result = runCli(["help"]);
 assert.equal(result.status, 0);
 assert.match(result.stdout, /--setup-pipeline <ecc\|gstack\|both\|none>/);
 assert.match(result.stdout, /ecc: project-scoped ECC/);
-assert.match(result.stdout, /gstack: user-scoped\/global at ~\/\.claude\/skills\/gstack/);
-assert.match(result.stdout, /both: project-scoped ECC \+ user-scoped\/global gstack/);
+assert.match(result.stdout, /gstack: project-local at \.claude\/skills\/gstack/);
+assert.match(result.stdout, /both: project-scoped ECC \+ project-local gstack/);
 assert.match(result.stdout, /none: base project metadata only/);
 assert.match(result.stdout, /--with-plan-tune-hooks/);
 assert.match(result.stdout, /--with-skill <name>/);
@@ -179,11 +178,9 @@ const gstackSetupTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-
 try {
   result = runCli(["setup", "--target", gstackSetupTarget, "--profile", "minimal", "--setup-pipeline", "gstack", "--yes", "--dry-run"]);
   assert.equal(result.status, 0, result.stderr);
-  assert.match(result.stdout, /Checking gstack prerequisites/);
-  assert.match(result.stdout, /Cloning gstack|Using existing gstack checkout/);
-  assert.match(result.stdout, /Running gstack setup/);
-  assert.match(result.stdout, /\.\/setup --quiet --no-plan-tune-hooks/);
-  assert.match(result.stdout, /Pipeline scope\s+user-scoped\/global gstack at ~\/\.claude\/skills\/gstack/);
+  assert.match(result.stdout, /git clone --single-branch --depth 1|copy .*\.claude\/skills\/gstack/);
+  assert.match(result.stdout, /write gstack skill wrapper/);
+  assert.match(result.stdout, /Pipeline scope\s+project-local gstack at \.claude\/skills\/gstack/);
   assert.doesNotMatch(result.stdout, /Install ECC inside Claude Code/);
 } finally {
   await fs.rm(gstackSetupTarget, { recursive: true, force: true });
@@ -193,8 +190,8 @@ const gstackHooksSetupTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pat
 try {
   result = runCli(["setup", "--target", gstackHooksSetupTarget, "--profile", "minimal", "--setup-pipeline", "gstack", "--with-plan-tune-hooks", "--yes", "--dry-run"]);
   assert.equal(result.status, 0, result.stderr);
-  assert.match(result.stdout, /\.\/setup --quiet --plan-tune-hooks/);
-  assert.match(result.stdout, /Plan-tune hooks\s+installed in ~\/\.claude\/settings\.json/);
+  assert.match(result.stdout, /Plan-tune hooks\s+installed in \.claude\/settings\.json/);
+  assert.doesNotMatch(result.stdout, /\.\/setup|~\/\.claude\/settings\.json/);
 } finally {
   await fs.rm(gstackHooksSetupTarget, { recursive: true, force: true });
 }

--- a/scripts/self-check/credentials.mjs
+++ b/scripts/self-check/credentials.mjs
@@ -15,7 +15,6 @@ const secretSentinel = "do-not-persist-anthropic-token";
 const originalLog = console.log;
 
 export async function runCredentialChecks() {
-const originalGstackSetupCommand = process.env.REPO_PATTERN_GSTACK_SETUP_CMD;
 const pluginSettingsTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-plugin-settings-"));
 console.log = () => {};
 try {
@@ -162,7 +161,6 @@ try {
 }
 
 const trackedLockTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-tracked-lock-"));
-const gstackMarker = path.join(os.tmpdir(), `repo-pattern-gstack-marker-${process.pid}`);
 console.log = () => {};
 try {
   spawnSync("git", ["init"], { cwd: trackedLockTarget, stdio: "ignore" });
@@ -173,18 +171,13 @@ try {
     () => provisionProject({ sourceRoot: repoRoot, target: trackedLockTarget, profile: "minimal" }),
     /repo-pattern lock is tracked/,
   );
-  process.env.REPO_PATTERN_GSTACK_SETUP_CMD = `touch ${JSON.stringify(gstackMarker)}`;
   await assert.rejects(
     () => provisionProject({ sourceRoot: repoRoot, target: trackedLockTarget, profile: "minimal", setupPipeline: "gstack" }),
     /repo-pattern lock is tracked/,
   );
-  await assert.rejects(() => fs.access(gstackMarker), { code: "ENOENT" });
 } finally {
-  if (originalGstackSetupCommand === undefined) delete process.env.REPO_PATTERN_GSTACK_SETUP_CMD;
-  else process.env.REPO_PATTERN_GSTACK_SETUP_CMD = originalGstackSetupCommand;
   console.log = originalLog;
   await fs.rm(trackedLockTarget, { recursive: true, force: true });
-  await fs.rm(gstackMarker, { force: true });
 }
 
 }

--- a/scripts/self-check/ecc-source-and-transaction.mjs
+++ b/scripts/self-check/ecc-source-and-transaction.mjs
@@ -8,7 +8,6 @@ import { auditProject, printAudit } from "../lib/audit.mjs";
 import { cleanupProject } from "../lib/cleanup.mjs";
 import { doctorProject } from "../lib/doctor.mjs";
 import { ECC_PLUGIN, applyEccPluginSettings, setupEcc } from "../lib/ecc.mjs";
-import { ensureBun, gstackEnvironment, gstackSummaryRows, isValidBunInstaller, removeEccPluginSettings, runGstackSetup, setupGstack } from "../lib/gstack.mjs";
 import { applyMcpValues, generateMcp, mcpSecretPrompt, persistedMcpValues, readGeneratedMcpValues, validateRelativeMcpPath } from "../lib/mcp.mjs";
 import { applyAttributionSetting, applyLocalSettings, applyPermissionSettings, provisionProject, reconcileLocalPluginSettings, setupPipelineScope, updateClaudePermissions } from "../lib/provision.mjs";
 import { writePrivateJson } from "../lib/fs-utils.mjs";

--- a/scripts/self-check/filesystem.mjs
+++ b/scripts/self-check/filesystem.mjs
@@ -8,7 +8,6 @@ import { auditProject, printAudit } from "../lib/audit.mjs";
 import { cleanupProject } from "../lib/cleanup.mjs";
 import { doctorProject } from "../lib/doctor.mjs";
 import { ECC_PLUGIN, applyEccPluginSettings, setupEcc } from "../lib/ecc.mjs";
-import { ensureBun, gstackEnvironment, gstackSummaryRows, isValidBunInstaller, removeEccPluginSettings, runGstackSetup, setupGstack } from "../lib/gstack.mjs";
 import { applyMcpValues, generateMcp, mcpSecretPrompt, persistedMcpValues, readGeneratedMcpValues, validateRelativeMcpPath } from "../lib/mcp.mjs";
 import { applyAttributionSetting, applyLocalSettings, applyPermissionSettings, provisionProject, reconcileLocalPluginSettings, setupPipelineScope, updateClaudePermissions } from "../lib/provision.mjs";
 import { writePrivateJson } from "../lib/fs-utils.mjs";
@@ -184,6 +183,40 @@ try {
   console.log = originalLog;
   await fs.rm(settingsSymlinkTarget, { recursive: true, force: true });
   await fs.rm(settingsSymlinkDestination, { force: true });
+}
+
+const doctorLockSymlinkTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-doctor-lock-symlink-target-"));
+const doctorLockSymlinkDestination = path.join(os.tmpdir(), `repo-pattern-doctor-lock-symlink-destination-${process.pid}`);
+console.log = () => {};
+try {
+  await fs.mkdir(path.join(doctorLockSymlinkTarget, ".repo-pattern"));
+  await fs.writeFile(doctorLockSymlinkDestination, "unchanged", "utf8");
+  await fs.symlink(doctorLockSymlinkDestination, path.join(doctorLockSymlinkTarget, ".repo-pattern", ".repo-pattern.lock.json"));
+  await assert.rejects(
+    () => doctorProject(doctorLockSymlinkTarget, { updateLock: true }),
+    /\.repo-pattern\/.repo-pattern\.lock\.json.*symlink/
+  );
+  assert.equal(await fs.readFile(doctorLockSymlinkDestination, "utf8"), "unchanged");
+} finally {
+  console.log = originalLog;
+  await fs.rm(doctorLockSymlinkTarget, { recursive: true, force: true });
+  await fs.rm(doctorLockSymlinkDestination, { force: true });
+}
+
+const doctorStateSymlinkTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-doctor-state-symlink-target-"));
+const doctorStateSymlinkDestination = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-doctor-state-symlink-destination-"));
+console.log = () => {};
+try {
+  await fs.symlink(doctorStateSymlinkDestination, path.join(doctorStateSymlinkTarget, ".repo-pattern"), "dir");
+  await assert.rejects(
+    () => doctorProject(doctorStateSymlinkTarget, { updateLock: true }),
+    /\.repo-pattern.*symlink/
+  );
+  assert.equal(await fs.readdir(doctorStateSymlinkDestination).then((entries) => entries.length), 0);
+} finally {
+  console.log = originalLog;
+  await fs.rm(doctorStateSymlinkTarget, { recursive: true, force: true });
+  await fs.rm(doctorStateSymlinkDestination, { recursive: true, force: true });
 }
 
 const eccSettingsTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-ecc-settings-"));

--- a/scripts/self-check/gstack-provision.mjs
+++ b/scripts/self-check/gstack-provision.mjs
@@ -1,10 +1,12 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { auditProject } from "../lib/audit.mjs";
 import { doctorProject } from "../lib/doctor.mjs";
+import { GSTACK_REVIEW_SIDECARS } from "../lib/gstack.mjs";
 import { provisionProject } from "../lib/provision.mjs";
 import { writeEccGitFixture } from "./fixtures.mjs";
 
@@ -13,7 +15,6 @@ const repoRoot = path.dirname(path.dirname(cliDir));
 const secretSentinel = "do-not-persist-anthropic-token";
 const originalLog = console.log;
 export async function runGstackProvisionChecks() {
-const originalGstackSetupCommand = process.env.REPO_PATTERN_GSTACK_SETUP_CMD;
 const gstackProvisionTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-gstack-provision-"));
 console.log = () => {};
 try {
@@ -34,13 +35,29 @@ try {
       unknown: { source: { source: "git", url: "https://example.com/unknown.git" } }
     }
   }), { mode: 0o600 });
-  process.env.REPO_PATTERN_GSTACK_SETUP_CMD = "true";
+  const gstackCheckout = path.join(gstackProvisionTarget, ".claude", "skills", "gstack");
+  await fs.mkdir(gstackCheckout, { recursive: true });
+  await fs.writeFile(path.join(gstackCheckout, "setup"), "#!/bin/sh\n", { mode: 0o755 });
+  await fs.writeFile(path.join(gstackCheckout, "SKILL.md"), "Project-local gstack", "utf8");
+  await fs.mkdir(path.join(gstackCheckout, "review"), { recursive: true });
+  await fs.writeFile(path.join(gstackCheckout, "review", "SKILL.md"), "Review", "utf8");
+  for (const sidecar of GSTACK_REVIEW_SIDECARS) {
+    await fs.mkdir(path.dirname(path.join(gstackCheckout, sidecar)), { recursive: true });
+    await fs.writeFile(path.join(gstackCheckout, sidecar), `Fixture ${sidecar}`, "utf8");
+  }
+  spawnSync("git", ["init"], { cwd: gstackCheckout, stdio: "ignore" });
+  await fs.mkdir(path.join(gstackProvisionTarget, ".repo-pattern"), { recursive: true });
+  await fs.writeFile(path.join(gstackProvisionTarget, ".repo-pattern", ".repo-pattern.json"), JSON.stringify({
+    workflow: "gstack",
+    runtime: { localSkills: false, localCommands: false, localHooks: false, localScripts: false, localRules: false }
+  }), "utf8");
   await writeEccGitFixture(gstackProvisionTarget);
   await provisionProject({
     sourceRoot: repoRoot,
     target: gstackProvisionTarget,
     profile: "minimal",
     setupPipeline: "gstack",
+    migrate: true,
     applyRules: true
   });
   const repoConfig = JSON.parse(await fs.readFile(path.join(gstackProvisionTarget, ".repo-pattern", ".repo-pattern.json"), "utf8"));
@@ -50,6 +67,9 @@ try {
   assert.equal(lock.setupPipeline, "gstack");
   assert.equal(lock.gstack.status, "installed");
   assert.equal(lock.gstack.planTuneHooks, false);
+  for (const sidecar of GSTACK_REVIEW_SIDECARS) {
+    assert.equal(await fs.readFile(path.join(gstackProvisionTarget, ".claude", "skills", sidecar), "utf8"), `Fixture ${sidecar}`);
+  }
   assert.deepEqual(lock.ecc.appliedRules, ["common"]);
   const gstackLocalSettings = JSON.parse(await fs.readFile(path.join(gstackProvisionTarget, ".claude", "settings.local.json"), "utf8"));
   assert.equal(gstackLocalSettings.enabledPlugins["ecc@ecc"], undefined);
@@ -141,8 +161,6 @@ try {
     appliedRules: idempotentLock.ecc?.appliedRules || []
   }), idempotentSnapshot);
 } finally {
-  if (originalGstackSetupCommand === undefined) delete process.env.REPO_PATTERN_GSTACK_SETUP_CMD;
-  else process.env.REPO_PATTERN_GSTACK_SETUP_CMD = originalGstackSetupCommand;
   console.log = originalLog;
   await fs.rm(gstackProvisionTarget, { recursive: true, force: true });
 }

--- a/scripts/self-check/gstack-rollback.mjs
+++ b/scripts/self-check/gstack-rollback.mjs
@@ -1,0 +1,175 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { bootstrapGstack, GSTACK_REVIEW_SIDECARS, gstackCheckoutPath, gstackStatePath, setupGstack, validateProjectGstack } from "../lib/gstack.mjs";
+
+export async function runGstackRollbackChecks() {
+  const hookSymlinkTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-gstack-hook-symlink-"));
+  const hookSymlinkOutside = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-gstack-hook-symlink-outside-"));
+  try {
+    const checkout = gstackCheckoutPath(hookSymlinkTarget);
+    const outsideHooks = path.join(hookSymlinkOutside, "hooks");
+    await fs.mkdir(outsideHooks, { recursive: true });
+    await fs.mkdir(checkout, { recursive: true });
+    await fs.writeFile(path.join(checkout, "setup"), "#!/bin/sh\n", { mode: 0o755 });
+    await fs.writeFile(path.join(checkout, "SKILL.md"), "Project-local gstack", "utf8");
+    await fs.mkdir(path.join(checkout, "review"), { recursive: true });
+    await fs.writeFile(path.join(checkout, "review", "SKILL.md"), "Review", "utf8");
+    for (const sidecar of GSTACK_REVIEW_SIDECARS) {
+      await fs.mkdir(path.dirname(path.join(checkout, sidecar)), { recursive: true });
+      await fs.writeFile(path.join(checkout, sidecar), `Fixture ${sidecar}`, "utf8");
+    }
+    for (const hook of ["question-log-hook", "question-preference-hook"]) {
+      await fs.writeFile(path.join(outsideHooks, hook), "#!/bin/sh\n", { mode: 0o755 });
+    }
+    await fs.mkdir(path.join(checkout, "hosts", "claude"), { recursive: true });
+    await fs.symlink(outsideHooks, path.join(checkout, "hosts", "claude", "hooks"), "dir");
+    spawnSync("git", ["init"], { cwd: checkout, stdio: "ignore" });
+    const originalPath = process.env.PATH;
+    process.env.PATH = `${path.dirname(process.execPath)}:${originalPath}`;
+    const result = await setupGstack({ target: hookSymlinkTarget, planTuneHooks: true });
+    process.env.PATH = originalPath;
+    assert.equal(result.status, "failed");
+    assert.equal(await fs.access(path.join(hookSymlinkTarget, ".claude", "skills", "_gstack-command", "SKILL.md")).then(() => true, () => false), false);
+    assert.equal(await fs.access(path.join(hookSymlinkTarget, ".repo-pattern", "gstack", "state.json")).then(() => true, () => false), false);
+  } finally {
+    await fs.rm(hookSymlinkTarget, { recursive: true, force: true });
+    await fs.rm(hookSymlinkOutside, { recursive: true, force: true });
+  }
+
+  const ancillaryTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-gstack-ancillary-"));
+  try {
+    const checkout = gstackCheckoutPath(ancillaryTarget);
+    await fs.mkdir(path.join(checkout, "ship", "sections"), { recursive: true });
+    await fs.mkdir(path.join(checkout, "plan-eng-review", "sections"), { recursive: true });
+    await fs.mkdir(path.join(checkout, "open-gstack-browser"), { recursive: true });
+    await fs.writeFile(path.join(checkout, "ship", "SKILL.md"), "Ship ~/.claude/skills/gstack/ship/sections/tests.md", "utf8");
+    await fs.writeFile(path.join(checkout, "ship", "sections", "tests.md"), "Ship section $HOME/.gstack", "utf8");
+    await fs.writeFile(path.join(checkout, "plan-eng-review", "SKILL.md"), "Review", "utf8");
+    await fs.writeFile(path.join(checkout, "plan-eng-review", "sections", "review-sections.md"), "Review section", "utf8");
+    await fs.writeFile(path.join(checkout, "open-gstack-browser", "SKILL.md"), "Browser", "utf8");
+    await fs.writeFile(path.join(checkout, "setup"), "#!/bin/sh\n", { mode: 0o755 });
+    await fs.symlink("open-gstack-browser", path.join(checkout, "connect-chrome"), "dir");
+    spawnSync("git", ["init"], { cwd: checkout, stdio: "ignore" });
+    for (const sidecar of GSTACK_REVIEW_SIDECARS) {
+      await fs.mkdir(path.dirname(path.join(checkout, sidecar)), { recursive: true });
+      await fs.writeFile(path.join(checkout, sidecar), `Fixture ${sidecar}`, "utf8");
+    }
+
+    await bootstrapGstack({ target: ancillaryTarget });
+    const shipSection = path.join(ancillaryTarget, ".claude", "skills", "ship", "sections", "tests.md");
+    assert.equal(await fs.readFile(shipSection, "utf8"), `Ship section ${gstackStatePath(ancillaryTarget)}`);
+    assert.equal(await fs.readFile(path.join(ancillaryTarget, ".claude", "skills", "plan-eng-review", "sections", "review-sections.md"), "utf8"), "Review section");
+    const aliasWrapper = path.join(ancillaryTarget, ".claude", "skills", "connect-chrome", "SKILL.md");
+    assert.equal(await fs.readFile(aliasWrapper, "utf8").then(() => true, () => false), true);
+    assert.equal((await fs.lstat(path.dirname(aliasWrapper))).isSymbolicLink(), false);
+    let validation = await validateProjectGstack(ancillaryTarget);
+    assert.deepEqual(validation.assets, ["plan-eng-review/sections/review-sections.md", "ship/sections/tests.md"]);
+    assert.equal(validation.assetsValid, true);
+    await fs.writeFile(shipSection, "drifted", "utf8");
+    validation = await validateProjectGstack(ancillaryTarget);
+    assert.equal(validation.assetsValid, false);
+  } finally {
+    await fs.rm(ancillaryTarget, { recursive: true, force: true });
+  }
+
+  const escapingAliasTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-gstack-escaping-alias-"));
+  const escapingAliasOutside = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-gstack-escaping-alias-outside-"));
+  try {
+    const checkout = gstackCheckoutPath(escapingAliasTarget);
+    await fs.mkdir(checkout, { recursive: true });
+    await fs.mkdir(path.join(escapingAliasOutside, "outside-skill"), { recursive: true });
+    await fs.writeFile(path.join(escapingAliasOutside, "outside-skill", "SKILL.md"), "Outside", "utf8");
+    await fs.symlink(path.join(escapingAliasOutside, "outside-skill"), path.join(checkout, "escaping-alias"), "dir");
+    for (const sidecar of GSTACK_REVIEW_SIDECARS) {
+      await fs.mkdir(path.dirname(path.join(checkout, sidecar)), { recursive: true });
+      await fs.writeFile(path.join(checkout, sidecar), `Fixture ${sidecar}`, "utf8");
+    }
+    await assert.rejects(() => bootstrapGstack({ target: escapingAliasTarget }), /symlink.*escapes|escapes.*symlink/i);
+    assert.equal(await fs.access(path.join(escapingAliasTarget, ".claude", "skills", "escaping-alias", "SKILL.md")).then(() => true, () => false), false);
+  } finally {
+    await fs.rm(escapingAliasTarget, { recursive: true, force: true });
+    await fs.rm(escapingAliasOutside, { recursive: true, force: true });
+  }
+
+  const cyclicAliasTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-gstack-cyclic-alias-"));
+  try {
+    const checkout = gstackCheckoutPath(cyclicAliasTarget);
+    await fs.mkdir(checkout, { recursive: true });
+    await fs.symlink("second-alias", path.join(checkout, "first-alias"), "dir");
+    await fs.symlink("first-alias", path.join(checkout, "second-alias"), "dir");
+    for (const sidecar of GSTACK_REVIEW_SIDECARS) {
+      await fs.mkdir(path.dirname(path.join(checkout, sidecar)), { recursive: true });
+      await fs.writeFile(path.join(checkout, sidecar), `Fixture ${sidecar}`, "utf8");
+    }
+    await assert.rejects(() => bootstrapGstack({ target: cyclicAliasTarget }), /symlink|cycle/i);
+  } finally {
+    await fs.rm(cyclicAliasTarget, { recursive: true, force: true });
+  }
+
+  const checkoutRollbackTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-gstack-checkout-rollback-"));
+  const checkoutRollbackHome = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-gstack-checkout-rollback-home-"));
+  const checkoutRollbackOutside = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-gstack-checkout-rollback-outside-"));
+  try {
+    const previousCheckout = gstackCheckoutPath(checkoutRollbackTarget);
+    const globalCheckout = path.join(checkoutRollbackHome, ".claude", "skills", "gstack");
+    const globalHooks = path.join(globalCheckout, "hosts", "claude", "hooks");
+    await fs.mkdir(previousCheckout, { recursive: true });
+    await fs.writeFile(path.join(previousCheckout, "source"), "previous invalid checkout", "utf8");
+    await fs.mkdir(globalCheckout, { recursive: true });
+    await fs.writeFile(path.join(globalCheckout, "setup"), "#!/bin/sh\n", { mode: 0o755 });
+    await fs.writeFile(path.join(globalCheckout, "SKILL.md"), "Project-local gstack", "utf8");
+    await fs.mkdir(path.dirname(globalHooks), { recursive: true });
+    await fs.symlink(checkoutRollbackOutside, globalHooks, "dir");
+    for (const hook of ["question-log-hook", "question-preference-hook"]) {
+      await fs.writeFile(path.join(checkoutRollbackOutside, hook), "#!/bin/sh\n", { mode: 0o755 });
+    }
+    spawnSync("git", ["init"], { cwd: globalCheckout, stdio: "ignore" });
+    const originalHome = process.env.HOME;
+    process.env.HOME = checkoutRollbackHome;
+    const result = await setupGstack({ target: checkoutRollbackTarget, planTuneHooks: true });
+    process.env.HOME = originalHome;
+    assert.equal(result.status, "failed");
+    assert.equal(await fs.readFile(path.join(previousCheckout, "source"), "utf8"), "previous invalid checkout");
+  } finally {
+    await fs.rm(checkoutRollbackTarget, { recursive: true, force: true });
+    await fs.rm(checkoutRollbackHome, { recursive: true, force: true });
+    await fs.rm(checkoutRollbackOutside, { recursive: true, force: true });
+  }
+
+  const rollbackTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-gstack-rollback-"));
+  try {
+    const checkout = gstackCheckoutPath(rollbackTarget);
+    const wrapper = path.join(rollbackTarget, ".claude", "skills", "_gstack-command");
+    const review = path.join(rollbackTarget, ".claude", "skills", "review");
+    const stateFile = path.join(gstackStatePath(rollbackTarget), "state.json");
+    await fs.mkdir(path.join(checkout, "review"), { recursive: true });
+    await fs.writeFile(path.join(checkout, "setup"), "#!/bin/sh\n", { mode: 0o755 });
+    await fs.writeFile(path.join(checkout, "SKILL.md"), "Project-local gstack", "utf8");
+    await fs.writeFile(path.join(checkout, "review", "SKILL.md"), "Review", "utf8");
+    for (const sidecar of GSTACK_REVIEW_SIDECARS) {
+      await fs.mkdir(path.dirname(path.join(checkout, sidecar)), { recursive: true });
+      await fs.writeFile(path.join(checkout, sidecar), `Fixture ${sidecar}`, "utf8");
+    }
+    spawnSync("git", ["init"], { cwd: checkout, stdio: "ignore" });
+    await fs.mkdir(wrapper, { recursive: true });
+    await fs.writeFile(path.join(wrapper, "SKILL.md"), "existing wrapper", "utf8");
+    await fs.mkdir(review, { recursive: true });
+    await fs.writeFile(path.join(review, "SKILL.md"), "existing review wrapper", "utf8");
+    await fs.writeFile(path.join(review, "checklist.md"), "existing checklist", "utf8");
+    await fs.mkdir(path.dirname(stateFile), { recursive: true });
+    await fs.writeFile(stateFile, "existing state", "utf8");
+    await fs.writeFile(path.join(rollbackTarget, ".claude", "settings.json"), "{", "utf8");
+    const result = await setupGstack({ target: rollbackTarget });
+    assert.equal(result.status, "failed");
+    assert.equal(await fs.readFile(path.join(wrapper, "SKILL.md"), "utf8"), "existing wrapper");
+    assert.equal(await fs.readFile(path.join(review, "SKILL.md"), "utf8"), "existing review wrapper");
+    assert.equal(await fs.readFile(path.join(review, "checklist.md"), "utf8"), "existing checklist");
+    assert.equal(await fs.readFile(stateFile, "utf8"), "existing state");
+    assert.equal(await fs.readFile(path.join(rollbackTarget, ".claude", "settings.json"), "utf8"), "{");
+  } finally {
+    await fs.rm(rollbackTarget, { recursive: true, force: true });
+  }
+}

--- a/scripts/self-check/gstack.mjs
+++ b/scripts/self-check/gstack.mjs
@@ -8,7 +8,7 @@ import { auditProject, printAudit } from "../lib/audit.mjs";
 import { cleanupProject } from "../lib/cleanup.mjs";
 import { doctorProject } from "../lib/doctor.mjs";
 import { ECC_PLUGIN, applyEccPluginSettings, setupEcc } from "../lib/ecc.mjs";
-import { ensureBun, gstackEnvironment, gstackSummaryRows, isValidBunInstaller, removeEccPluginSettings, runGstackSetup, setupGstack } from "../lib/gstack.mjs";
+import { applyPlanTuneHooks, bootstrapGstack, ensureBun, GSTACK_REVIEW_SIDECARS, gstackCheckoutPath, gstackEnvironment, gstackStatePath, gstackSummaryRows, isValidGstackCheckout, removeEccPluginSettings, resolveGstackCheckout, setupGstack, validateProjectGstack } from "../lib/gstack.mjs";
 import { applyMcpValues, generateMcp, mcpSecretPrompt, persistedMcpValues, readGeneratedMcpValues, validateRelativeMcpPath } from "../lib/mcp.mjs";
 import { applyAttributionSetting, applyLocalSettings, applyPermissionSettings, provisionProject, reconcileLocalPluginSettings, setupPipelineScope, updateClaudePermissions } from "../lib/provision.mjs";
 import { writePrivateJson } from "../lib/fs-utils.mjs";
@@ -16,6 +16,7 @@ import { printSummary, renderLogo, style } from "../lib/prompt.mjs";
 import { needsLocalSettingsPrompt, setupProject, setupRetryOptions } from "../lib/setup.mjs";
 import { applyEccRules, buildAgentManifest, clearEccRules, formatEccCloneError, hasGitUpstream, validateAgentManifest } from "../lib/rules.mjs";
 import { applyOptionalSkills, applyPluginSkillSettings, expectedOptionalSkillDirs, invalidOptionalSkills, normalizeOptionalSkills, OPTIONAL_SKILLS } from "../lib/skills.mjs";
+import { runGstackRollbackChecks } from "./gstack-rollback.mjs";
 const cliDir = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.dirname(path.dirname(cliDir));
 const cliPath = path.join(cliDir, "..", "repo-pattern.mjs");
@@ -40,115 +41,307 @@ assert(!gitignoreLines.includes(".repo-pattern.lock.json"));
 assert(gitignoreLines.includes(".claude/"));
 
 assert.deepEqual(gstackEnvironment("bun", { PATH: "/usr/bin" }), { PATH: "/usr/bin" });
-assert.deepEqual(gstackEnvironment("/home/test/.bun/bin/bun", { PATH: "/usr/bin" }), { PATH: `/home/test/.bun/bin${path.delimiter}/usr/bin` });
-assert.deepEqual(gstackSummaryRows(), [
-  ["Scope", "user-global ~/.claude/skills/gstack"],
+assert.equal(gstackCheckoutPath("/tmp/project"), "/tmp/project/.claude/skills/gstack");
+assert.deepEqual(gstackEnvironment("/usr/local/bin/bun", { PATH: "/usr/bin" }), { PATH: `/usr/local/bin${path.delimiter}/usr/bin` });
+assert.deepEqual(gstackSummaryRows("/tmp/project"), [
+  ["Scope", "project-local .claude/skills/gstack"],
   ["Plan-tune hooks", "not installed"],
   ["Status", "ready"]
 ]);
-assert.deepEqual(gstackSummaryRows(true), [
-  ["Scope", "user-global ~/.claude/skills/gstack"],
-  ["Plan-tune hooks", "installed in ~/.claude/settings.json"],
+assert.deepEqual(gstackSummaryRows("/tmp/project", true), [
+  ["Scope", "project-local .claude/skills/gstack"],
+  ["Plan-tune hooks", "installed in .claude/settings.json"],
   ["Status", "ready"]
 ]);
 
-const gstackSetupCalls = [];
-const gstackSetupLogs = [];
-runGstackSetup({
-  platform: "linux",
-  bun: "bun",
-  run(command, args, options) {
-    gstackSetupCalls.push({ command, args, options });
-    return "generated skill output\ninstallation detail\n";
-  },
-  log: (message) => gstackSetupLogs.push(message)
-});
-assert.deepEqual(gstackSetupCalls[0].args, ["--quiet", "--no-plan-tune-hooks"]);
-assert.deepEqual(gstackSetupCalls[0].options.stdio, ["ignore", "pipe", "pipe"]);
-assert.deepEqual(gstackSetupLogs, []);
+assert.equal(gstackStatePath("/tmp/project"), "/tmp/project/.repo-pattern/gstack");
+assert.equal(ensureBun({ run: () => "1.2.0\n" }), "bun");
+assert.throws(() => ensureBun({ run: () => { throw Object.assign(new Error("missing"), { code: "ENOENT" }); } }), /Install Bun manually/);
+assert.throws(() => ensureBun({ run: () => "0.9.9\n" }), /Bun validation failed/);
 
-runGstackSetup({
-  platform: "linux",
-  bun: "bun",
-  planTuneHooks: true,
-  run(command, args) {
-    gstackSetupCalls.push({ command, args });
+const planTuneSettings = applyPlanTuneHooks({ hooks: { Stop: [{ hooks: [{ type: "command", command: "existing" }] }] } }, {
+  checkout: "/tmp/project/.claude/skills/gstack",
+  statePath: "/tmp/project/.repo-pattern/gstack",
+  enabled: true
+});
+assert.equal(planTuneSettings.hooks.Stop[0].hooks[0].command, "existing");
+assert.equal(planTuneSettings.hooks.PreToolUse[0]._gstack_source, "repo-pattern-plan-tune");
+assert.match(planTuneSettings.hooks.PreToolUse[0].hooks[0].command, /GSTACK_HOME='\/tmp\/project\/\.repo-pattern\/gstack'/);
+assert.match(planTuneSettings.hooks.PreToolUse[0].hooks[0].command, /\.claude\/skills\/gstack/);
+assert.doesNotMatch(JSON.stringify(planTuneSettings), /~\/\.claude\/skills\/gstack|\$HOME/);
+const quotedHook = applyPlanTuneHooks({}, {
+  checkout: "/tmp/$(touch injected)/.claude/skills/gstack",
+  statePath: "/tmp/$(touch injected)/.repo-pattern/gstack",
+  enabled: true
+});
+assert.match(quotedHook.hooks.PreToolUse[0].hooks[0].command, /'\/tmp\/\$\(touch injected\)/);
+assert.deepEqual(applyPlanTuneHooks(planTuneSettings, {
+  checkout: "/tmp/project/.claude/skills/gstack",
+  statePath: "/tmp/project/.repo-pattern/gstack",
+  enabled: false
+}).hooks, { Stop: [{ hooks: [{ type: "command", command: "existing" }] }] });
+
+const checkoutFixture = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-gstack-checkout-"));
+try {
+  await fs.writeFile(path.join(checkoutFixture, "setup"), "#!/bin/sh\n", { mode: 0o755 });
+  spawnSync("git", ["init"], { cwd: checkoutFixture, stdio: "ignore" });
+  assert.equal(await isValidGstackCheckout(checkoutFixture), true);
+  await fs.chmod(path.join(checkoutFixture, "setup"), 0o644);
+  assert.equal(await isValidGstackCheckout(checkoutFixture), false);
+  const bareCheckout = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-gstack-bare-"));
+  try {
+    await fs.writeFile(path.join(bareCheckout, "setup"), "#!/bin/sh\n", { mode: 0o755 });
+    spawnSync("git", ["init", "--bare"], { cwd: bareCheckout, stdio: "ignore" });
+    assert.equal(await isValidGstackCheckout(bareCheckout), false);
+  } finally {
+    await fs.rm(bareCheckout, { recursive: true, force: true });
   }
-});
-assert.deepEqual(gstackSetupCalls[1].args, ["--quiet", "--plan-tune-hooks"]);
+  const parentCheckout = path.join(checkoutFixture, "nested-checkout");
+  await fs.mkdir(parentCheckout);
+  await fs.writeFile(path.join(parentCheckout, "setup"), "#!/bin/sh\n", { mode: 0o755 });
+  assert.equal(await isValidGstackCheckout(parentCheckout), false);
+} finally {
+  await fs.rm(checkoutFixture, { recursive: true, force: true });
+}
 
-const gstackCredentialFixture = ["example", "credential", "value"].join("-");
-const gstackFailure = Object.assign(new Error("setup failed"), {
-  stdout: Buffer.from("routine output\n"),
-  stderr: Buffer.from(`${"warning: repeated diagnostic line\n".repeat(300)}fatal: setup could not complete\nAuthorization: Bearer ${gstackCredentialFixture}\nAPI_TOKEN=${gstackCredentialFixture}\ncorrect the prerequisite and retry\n`)
-});
-let gstackFailureLog = "";
-assert.throws(() => runGstackSetup({
-  platform: "win32",
-  bun: "bun",
-  run(command, args) {
-    assert.equal(command, "bash");
-    assert.deepEqual(args, ["./setup", "--quiet", "--no-plan-tune-hooks"]);
-    throw gstackFailure;
-  },
-  log: (message) => { gstackFailureLog += `${message}\n`; }
-}), /gstack setup failed; review the diagnostics above and rerun setup/);
-assert.match(gstackFailureLog, /Upstream reported a setup failure/);
-assert.match(gstackFailureLog, /A required prerequisite is missing or invalid/);
-assert.match(gstackFailureLog, /Correct the reported prerequisite and rerun setup/);
-assert.match(gstackFailureLog, /Upstream output: \[redacted\]/);
-assert.doesNotMatch(gstackFailureLog, /routine output/);
-assert.doesNotMatch(gstackFailureLog, /fatal: setup could not complete/);
-assert.doesNotMatch(gstackFailureLog, new RegExp(gstackCredentialFixture));
-assert(gstackFailureLog.length <= 4200);
+const resolverTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-gstack-resolver-"));
+const globalCheckout = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-gstack-global-"));
+try {
+  const localCheckout = gstackCheckoutPath(resolverTarget);
+  const createCheckout = async (checkout, source = "fixture") => {
+    await fs.mkdir(checkout, { recursive: true });
+    await fs.writeFile(path.join(checkout, "setup"), "#!/bin/sh\n", { mode: 0o755 });
+    await fs.writeFile(path.join(checkout, "source"), source, "utf8");
+    spawnSync("git", ["init"], { cwd: checkout, stdio: "ignore" });
+  };
 
-const validBunInstaller = Buffer.from(`#!/usr/bin/env bash
-set -euo pipefail
-install_env=BUN_INSTALL
-github_repo="\$GITHUB/oven-sh/bun"
-bun_uri=\$github_repo/releases/latest/download/bun-\$target.zip
-${"# Bun installer\n".repeat(80)}`);
-assert.equal(isValidBunInstaller(validBunInstaller), true);
-assert.equal(isValidBunInstaller(Buffer.from("<!doctype html><title>502 Bad Gateway</title>")), false);
-assert.equal(isValidBunInstaller(Buffer.from("#!/usr/bin/env bash\nset -euo pipefail\n")), false);
+  await createCheckout(localCheckout, "local");
+  const reused = await resolveGstackCheckout({
+    target: resolverTarget,
+    globalCheckout,
+    clone: () => { throw new Error("clone should not run"); }
+  });
+  assert.equal(reused.source, "local");
+  assert.equal(await fs.readFile(path.join(localCheckout, "source"), "utf8"), "local");
 
-const bunInstallCommands = [];
-let bunCheckCount = 0;
-let removedBunInstaller = false;
-const installedBun = await ensureBun({
-  platform: "linux",
-  homedir: "/home/test",
-  tmpdir: "/tmp",
-  run(command, args, options) {
-    bunInstallCommands.push({ command, args, options });
-    if (command === "bun" && bunCheckCount++ === 0) throw Object.assign(new Error("missing"), { code: "ENOENT" });
-    if (command === "/home/test/.bun/bin/bun") return "1.2.0\n";
-    return "";
-  },
-  mkdtemp: async () => "/tmp/repo-pattern-bun-installer",
-  readFile: async () => validBunInstaller,
-  rm: async () => { removedBunInstaller = true; }
-});
-assert.equal(installedBun, "/home/test/.bun/bin/bun");
-assert.deepEqual(bunInstallCommands[1].args, [
-  "--fail", "--show-error", "--silent", "--location",
-  "--proto", "=https", "--proto-redir", "=https", "--tlsv1.2",
-  "--max-filesize", "1048576", "--output", "/tmp/repo-pattern-bun-installer/install.sh",
-  "https://bun.sh/install"
-]);
-assert.deepEqual(bunInstallCommands[2].args, ["-n", "/tmp/repo-pattern-bun-installer/install.sh"]);
-assert.deepEqual(bunInstallCommands[3].args, ["/tmp/repo-pattern-bun-installer/install.sh"]);
-assert.equal(removedBunInstaller, true);
-await assert.rejects(() => ensureBun({ platform: "win32", run: () => { throw Object.assign(new Error("missing"), { code: "ENOENT" }); } }), /automatic Bun installation is supported only on Linux and macOS/);
-await assert.rejects(() => ensureBun({
-  platform: "linux",
-  run(command) {
-    if (command === "bun") throw Object.assign(new Error("missing"), { code: "ENOENT" });
-    return "";
-  },
-  mkdtemp: async () => "/tmp/repo-pattern-invalid-bun-installer",
-  readFile: async () => Buffer.from("<!doctype html><title>502 Bad Gateway</title>"),
-  rm: async () => {}
-}), /failed content validation/);
+  await fs.rm(localCheckout, { recursive: true, force: true });
+  await createCheckout(globalCheckout, "global");
+  const migrated = await resolveGstackCheckout({
+    target: resolverTarget,
+    globalCheckout,
+    clone: () => { throw new Error("clone should not run"); }
+  });
+  assert.equal(migrated.source, "global-migration");
+  assert.equal(await fs.readFile(path.join(localCheckout, "source"), "utf8"), "global");
+  assert.equal(await fs.readFile(path.join(globalCheckout, "source"), "utf8"), "global");
+
+  await fs.rm(localCheckout, { recursive: true, force: true });
+  await fs.rm(globalCheckout, { recursive: true, force: true });
+  const cloned = await resolveGstackCheckout({
+    target: resolverTarget,
+    globalCheckout,
+    clone: async (destination) => createCheckout(destination, "clone")
+  });
+  assert.equal(cloned.source, "clone");
+  assert.equal(await fs.readFile(path.join(localCheckout, "source"), "utf8"), "clone");
+
+  await fs.rm(localCheckout, { recursive: true, force: true });
+  await assert.rejects(
+    () => resolveGstackCheckout({
+      target: resolverTarget,
+      globalCheckout,
+      clone: async (destination) => fs.mkdir(destination, { recursive: true })
+    }),
+    /invalid/
+  );
+  assert.equal(await fs.access(localCheckout).then(() => true, () => false), false);
+} finally {
+  await fs.rm(resolverTarget, { recursive: true, force: true });
+  await fs.rm(globalCheckout, { recursive: true, force: true });
+}
+
+const migrationTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-gstack-migration-"));
+const migrationHome = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-gstack-migration-home-"));
+try {
+  const globalMigrationCheckout = path.join(migrationHome, ".claude", "skills", "gstack");
+  await fs.mkdir(path.join(globalMigrationCheckout, "review"), { recursive: true });
+  await fs.writeFile(path.join(globalMigrationCheckout, "setup"), "#!/bin/sh\n", { mode: 0o755 });
+  await fs.writeFile(path.join(globalMigrationCheckout, "SKILL.md"), "Project-local gstack", "utf8");
+  await fs.writeFile(path.join(globalMigrationCheckout, "review", "SKILL.md"), "Review", "utf8");
+  for (const sidecar of GSTACK_REVIEW_SIDECARS) {
+    await fs.mkdir(path.dirname(path.join(globalMigrationCheckout, sidecar)), { recursive: true });
+    await fs.writeFile(path.join(globalMigrationCheckout, sidecar), `Fixture ${sidecar}`, "utf8");
+  }
+  spawnSync("git", ["init"], { cwd: globalMigrationCheckout, stdio: "ignore" });
+  const originalHome = process.env.HOME;
+  process.env.HOME = migrationHome;
+  try {
+    const result = await setupGstack({ target: migrationTarget });
+    assert.equal(result.status, "installed");
+    assert.equal(result.source, "global-migration");
+  } finally {
+    process.env.HOME = originalHome;
+  }
+  assert.equal(await fs.readFile(path.join(globalMigrationCheckout, "SKILL.md"), "utf8"), "Project-local gstack");
+  assert.equal(await fs.access(path.join(migrationHome, ".claude", "settings.json")).then(() => true, () => false), false);
+  assert.equal(await fs.access(path.join(migrationHome, ".gstack")).then(() => true, () => false), false);
+} finally {
+  await fs.rm(migrationTarget, { recursive: true, force: true });
+  await fs.rm(migrationHome, { recursive: true, force: true });
+}
+
+const symlinkTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-gstack-symlink-"));
+const symlinkDestination = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-gstack-symlink-destination-"));
+try {
+  await fs.mkdir(path.join(symlinkTarget, ".claude"));
+  await fs.symlink(symlinkDestination, path.join(symlinkTarget, ".claude", "skills"), "dir");
+  await assert.rejects(
+    () => resolveGstackCheckout({
+      target: symlinkTarget,
+      globalCheckout: path.join(symlinkTarget, "missing-global"),
+      clone: () => { throw new Error("clone should not run"); }
+    }),
+    /symlink/
+  );
+} finally {
+  await fs.rm(symlinkTarget, { recursive: true, force: true });
+  await fs.rm(symlinkDestination, { recursive: true, force: true });
+}
+
+const missingBunTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-gstack-missing-bun-"));
+try {
+  const originalPath = process.env.PATH;
+  process.env.PATH = "";
+  const result = await setupGstack({ target: missingBunTarget });
+  assert.equal(result.status, "failed");
+  assert.equal(await fs.access(gstackCheckoutPath(missingBunTarget)).then(() => true, () => false), false);
+  process.env.PATH = originalPath;
+} finally {
+  await fs.rm(missingBunTarget, { recursive: true, force: true });
+}
+
+const wrapperTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-gstack-wrapper-"));
+try {
+  const checkout = gstackCheckoutPath(wrapperTarget);
+  await fs.mkdir(path.join(checkout, "review"), { recursive: true });
+  await fs.writeFile(path.join(checkout, "setup"), "#!/bin/sh\n", { mode: 0o755 });
+  await fs.writeFile(path.join(checkout, "SKILL.md"), "Root ~/.claude/skills/gstack $HOME/.gstack gstack-config", "utf8");
+  await fs.writeFile(path.join(checkout, "review", "SKILL.md"), "Review ~/.claude/skills/gstack $HOME/.claude.json $HOME/.claude/plans ~/.codex/plans ${HOME}/.gstack/projects", "utf8");
+  for (const sidecar of GSTACK_REVIEW_SIDECARS) {
+    await fs.mkdir(path.dirname(path.join(checkout, sidecar)), { recursive: true });
+    await fs.writeFile(path.join(checkout, sidecar), `Fixture ${sidecar}`, "utf8");
+  }
+  await fs.mkdir(path.join(checkout, "hosts", "claude", "hooks"), { recursive: true });
+  for (const hook of ["question-log-hook", "question-preference-hook"]) {
+    await fs.writeFile(path.join(checkout, "hosts", "claude", "hooks", hook), "#!/bin/sh\n", { mode: 0o755 });
+  }
+  await fs.mkdir(path.join(checkout, "setup-gbrain"), { recursive: true });
+  await fs.writeFile(path.join(checkout, "setup-gbrain", "SKILL.md"), "GBRAIN_BIN=\"$HOME/.bun/bin/gbrain\"", "utf8");
+  await fs.mkdir(path.join(checkout, "codex"), { recursive: true });
+  await fs.writeFile(path.join(checkout, "codex", "SKILL.md"), "Unsupported host integration", "utf8");
+  await fs.mkdir(path.join(checkout, ".cursor", "skills", "gstack"), { recursive: true });
+  await fs.writeFile(path.join(checkout, ".cursor", "skills", "gstack", "SKILL.md"), "Hidden integration", "utf8");
+  spawnSync("git", ["init"], { cwd: checkout, stdio: "ignore" });
+  const originalPath = process.env.PATH;
+  process.env.PATH = `${path.dirname(process.execPath)}:${originalPath}`;
+  const result = await setupGstack({ target: wrapperTarget, planTuneHooks: true });
+  process.env.PATH = originalPath;
+  assert.equal(result.status, "installed");
+  const state = await validateProjectGstack(wrapperTarget);
+  assert.equal(state.checkoutValid, true);
+  assert.equal(state.stateValid, true);
+  assert.equal(state.wrappersValid, true);
+  assert.deepEqual(state.sidecars, GSTACK_REVIEW_SIDECARS);
+  assert.equal(state.sidecarsValid, true);
+  for (const sidecar of GSTACK_REVIEW_SIDECARS) {
+    assert.equal(await fs.readFile(path.join(wrapperTarget, ".claude", "skills", sidecar), "utf8"), `Fixture ${sidecar}`);
+  }
+  const outsideState = path.join(wrapperTarget, "outside-state.json");
+  const stateFile = path.join(gstackStatePath(wrapperTarget), "state.json");
+  await fs.writeFile(outsideState, "outside", "utf8");
+  await fs.rm(stateFile);
+  await fs.symlink(outsideState, stateFile);
+  await assert.rejects(() => bootstrapGstack({ target: wrapperTarget }), /symlink/);
+  const symlinkedState = await validateProjectGstack(wrapperTarget);
+  assert.equal(symlinkedState.stateValid, false);
+  assert.equal(symlinkedState.wrappersValid, false);
+  assert.equal(symlinkedState.sidecarsValid, false);
+  assert.equal(await fs.readFile(outsideState, "utf8"), "outside");
+  await fs.rm(stateFile);
+  await fs.writeFile(stateFile, "null", "utf8");
+  const malformedState = await validateProjectGstack(wrapperTarget);
+  assert.equal(malformedState.stateValid, false);
+  assert.equal(malformedState.wrappersValid, false);
+  assert.equal(malformedState.sidecarsValid, false);
+  await fs.rm(stateFile);
+  await fs.writeFile(stateFile, JSON.stringify({
+    checkout: "wrong-checkout",
+    wrappers: state.wrappers,
+    bootstrappedAt: new Date().toISOString()
+  }), "utf8");
+  const mismatchedCheckoutState = await validateProjectGstack(wrapperTarget);
+  assert.equal(mismatchedCheckoutState.stateValid, false);
+  assert.equal(mismatchedCheckoutState.wrappersValid, false);
+  assert.equal(mismatchedCheckoutState.sidecarsValid, false);
+  await fs.writeFile(stateFile, JSON.stringify({
+    checkout: path.relative(wrapperTarget, checkout),
+    wrappers: state.wrappers,
+    sidecars: state.sidecars,
+    bootstrappedAt: new Date().toISOString()
+  }), "utf8");
+  const checklist = path.join(wrapperTarget, ".claude", "skills", "review", "checklist.md");
+  const expectedChecklist = await fs.readFile(checklist, "utf8");
+  await fs.writeFile(checklist, "drifted", "utf8");
+  assert.equal((await validateProjectGstack(wrapperTarget)).sidecarsValid, false);
+  await fs.writeFile(checklist, expectedChecklist, "utf8");
+  assert(!state.wrappers.some((wrapper) => wrapper.includes(".cursor") || wrapper.includes("codex")));
+  assert.equal(await fs.access(path.join(wrapperTarget, ".claude", "skills", ".cursor")).then(() => true, () => false), false);
+  assert.equal(await fs.access(path.join(wrapperTarget, ".claude", "skills", "codex")).then(() => true, () => false), false);
+  const rootWrapper = path.join(wrapperTarget, ".claude", "skills", "_gstack-command", "SKILL.md");
+  const expectedRootWrapper = await fs.readFile(rootWrapper, "utf8");
+  await fs.writeFile(rootWrapper, "drifted", "utf8");
+  assert.equal((await validateProjectGstack(wrapperTarget)).wrappersValid, false);
+  await fs.writeFile(rootWrapper, expectedRootWrapper, "utf8");
+  await fs.writeFile(path.join(checkout, "review", "SKILL.md"), `${os.homedir()}/.gstack`, "utf8");
+  await assert.rejects(() => bootstrapGstack({ target: wrapperTarget }), /forbidden home-scoped state/);
+  await fs.writeFile(path.join(checkout, "review", "SKILL.md"), "Review ~/.claude/skills/gstack", "utf8");
+  await fs.mkdir(path.join(checkout, "added"));
+  await fs.writeFile(path.join(checkout, "added", "SKILL.md"), "Added skill", "utf8");
+  assert.equal((await validateProjectGstack(wrapperTarget)).wrappersValid, false);
+  const wrapper = await fs.readFile(path.join(wrapperTarget, ".claude", "skills", "_gstack-command", "SKILL.md"), "utf8");
+  const reviewWrapper = await fs.readFile(path.join(wrapperTarget, ".claude", "skills", "review", "SKILL.md"), "utf8");
+  assert.match(wrapper, /GSTACK_HOME=/);
+  const gbrainWrapper = await fs.readFile(path.join(wrapperTarget, ".claude", "skills", "setup-gbrain", "SKILL.md"), "utf8");
+  assert.match(reviewWrapper, new RegExp(gstackStatePath(wrapperTarget).replaceAll("/", "\\/")));
+  assert.match(gbrainWrapper, new RegExp(path.join(gstackStatePath(wrapperTarget), "bun").replaceAll("/", "\\/")));
+  assert.doesNotMatch(wrapper, /~\/\.claude\/skills\/gstack|\$HOME/);
+  assert.doesNotMatch(reviewWrapper, /~\/\.codex|\$HOME\/\.claude/);
+  assert.doesNotMatch(gbrainWrapper, /\$HOME\/\.bun/);
+} finally {
+  await fs.rm(wrapperTarget, { recursive: true, force: true });
+}
+
+const nestedWrapperTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-gstack-nested-wrapper-"));
+const nestedWrapperOutside = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-gstack-nested-wrapper-outside-"));
+try {
+  const checkout = gstackCheckoutPath(nestedWrapperTarget);
+  await fs.mkdir(path.join(checkout, "review"), { recursive: true });
+  await fs.writeFile(path.join(checkout, "setup"), "#!/bin/sh\n", { mode: 0o755 });
+  await fs.writeFile(path.join(checkout, "review", "SKILL.md"), "Review", "utf8");
+  for (const sidecar of GSTACK_REVIEW_SIDECARS) {
+    await fs.mkdir(path.dirname(path.join(checkout, sidecar)), { recursive: true });
+    await fs.writeFile(path.join(checkout, sidecar), `Fixture ${sidecar}`, "utf8");
+  }
+  spawnSync("git", ["init"], { cwd: checkout, stdio: "ignore" });
+  await fs.symlink(nestedWrapperOutside, path.join(nestedWrapperTarget, ".claude", "skills", "review"), "dir");
+  await assert.rejects(() => bootstrapGstack({ target: nestedWrapperTarget }), /symlink/);
+  assert.equal(await fs.readdir(nestedWrapperOutside).then((entries) => entries.length), 0);
+  assert.equal((await validateProjectGstack(nestedWrapperTarget)).wrappersValid, false);
+} finally {
+  await fs.rm(nestedWrapperTarget, { recursive: true, force: true });
+  await fs.rm(nestedWrapperOutside, { recursive: true, force: true });
+}
+
+await runGstackRollbackChecks();
 
 }

--- a/scripts/self-check/mcp-and-settings.mjs
+++ b/scripts/self-check/mcp-and-settings.mjs
@@ -8,7 +8,6 @@ import { auditProject, printAudit } from "../lib/audit.mjs";
 import { cleanupProject } from "../lib/cleanup.mjs";
 import { doctorProject } from "../lib/doctor.mjs";
 import { ECC_PLUGIN, applyEccPluginSettings, setupEcc } from "../lib/ecc.mjs";
-import { ensureBun, gstackEnvironment, gstackSummaryRows, isValidBunInstaller, removeEccPluginSettings, runGstackSetup, setupGstack } from "../lib/gstack.mjs";
 import { applyMcpValues, generateMcp, mcpSecretPrompt, persistedMcpValues, readGeneratedMcpValues, validateRelativeMcpPath } from "../lib/mcp.mjs";
 import { applyAttributionSetting, applyLocalSettings, applyPermissionSettings, provisionProject, reconcileLocalPluginSettings, setupPipelineScope, updateClaudePermissions } from "../lib/provision.mjs";
 import { writePrivateJson } from "../lib/fs-utils.mjs";
@@ -185,8 +184,8 @@ assert.deepEqual({
   none: setupPipelineScope("none")
 }, {
   ecc: "project-scoped ECC",
-  gstack: "user-scoped/global gstack at ~/.claude/skills/gstack",
-  both: "project-scoped ECC + user-scoped/global gstack at ~/.claude/skills/gstack",
+  gstack: "project-local gstack at .claude/skills/gstack",
+  both: "project-scoped ECC + project-local gstack at .claude/skills/gstack",
   none: "writes only base project metadata"
 });
 assert.equal(needsLocalSettingsPrompt({ ANTHROPIC_BASE_URL: "https://example.com/v1" }), true);

--- a/scripts/self-check/provision-and-pipelines.mjs
+++ b/scripts/self-check/provision-and-pipelines.mjs
@@ -6,8 +6,8 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { auditProject } from "../lib/audit.mjs";
 import { doctorProject } from "../lib/doctor.mjs";
-import { removeEccPluginSettings, setupGstack } from "../lib/gstack.mjs";
-import { provisionProject } from "../lib/provision.mjs";
+import { GSTACK_REVIEW_SIDECARS, removeEccPluginSettings, setupGstack } from "../lib/gstack.mjs";
+import { provisionProject, updateClaudePermissions } from "../lib/provision.mjs";
 import { setupProject } from "../lib/setup.mjs";
 import { writeEccGitFixture } from "./fixtures.mjs";
 
@@ -23,7 +23,6 @@ function runCli(args, cwd = repoRoot) {
 }
 
 export async function runProvisionAndPipelineChecks() {
-const originalGstackSetupCommand = process.env.REPO_PATTERN_GSTACK_SETUP_CMD;
 let result;
 const provisionRollbackTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-provision-rollback-"));
 console.log = () => {};
@@ -80,12 +79,13 @@ try {
     env: { ANTHROPIC_AUTH_TOKEN: secretSentinel },
     enabledPlugins: { "ecc@ecc": true }
   }), { mode: 0o600 });
-  process.env.REPO_PATTERN_GSTACK_SETUP_CMD = "false";
-  await assert.rejects(() => setupGstack({ target: failedGstackTarget }), /Command failed/);
+  const originalPath = process.env.PATH;
+  process.env.PATH = "";
+  const failedGstack = await setupGstack({ target: failedGstackTarget });
+  process.env.PATH = originalPath;
+  assert.equal(failedGstack.status, "failed");
   assert.match(await fs.readFile(localSettingsPath, "utf8"), /ecc@ecc/);
 } finally {
-  if (originalGstackSetupCommand === undefined) delete process.env.REPO_PATTERN_GSTACK_SETUP_CMD;
-  else process.env.REPO_PATTERN_GSTACK_SETUP_CMD = originalGstackSetupCommand;
   console.log = originalLog;
   await fs.rm(failedGstackTarget, { recursive: true, force: true });
 }
@@ -99,37 +99,32 @@ try {
     env: { ANTHROPIC_AUTH_TOKEN: "existing-token" },
     enabledPlugins: { "ecc@ecc": true }
   }), { mode: 0o600 });
-  const existingRulePath = path.join(failedGstackProvisionTarget, ".claude", "rules", "ecc", "existing.md");
-  await fs.mkdir(path.dirname(existingRulePath), { recursive: true });
-  await fs.writeFile(existingRulePath, "existing rule\n", "utf8");
-  await fs.mkdir(path.join(failedGstackProvisionTarget, ".claude", "commands"));
-  process.env.REPO_PATTERN_GSTACK_SETUP_CMD = "false";
-  await assert.rejects(() => provisionProject({
-    sourceRoot: repoRoot,
-    target: failedGstackProvisionTarget,
-    profile: "minimal",
-    setupPipeline: "gstack",
-    localSettingsEnv: { ANTHROPIC_AUTH_TOKEN: "replacement-token" },
-    migrate: true
-  }), /Command failed/);
+  await writeEccGitFixture(failedGstackProvisionTarget);
+  const originalPath = process.env.PATH;
+  const gitPath = spawnSync("which", ["git"], { encoding: "utf8" }).stdout.trim();
+  process.env.PATH = path.dirname(gitPath);
+  try {
+    await provisionProject({
+      sourceRoot: repoRoot,
+      target: failedGstackProvisionTarget,
+      profile: "minimal",
+      setupPipeline: "both",
+      localSettingsEnv: { ANTHROPIC_AUTH_TOKEN: "replacement-token" }
+    });
+  } finally {
+    process.env.PATH = originalPath;
+  }
+  const failedLock = JSON.parse(await fs.readFile(path.join(failedGstackProvisionTarget, ".repo-pattern", ".repo-pattern.lock.json"), "utf8"));
+  assert.equal(failedLock.ecc.status, "manual-plugin-install-required");
+  assert.equal(failedLock.gstack.status, "failed");
+  assert.equal(failedLock.gstack.installMode, "project-local");
   const localSettings = await fs.readFile(localSettingsPath, "utf8");
   assert.match(localSettings, /ecc@ecc/);
-  assert.match(localSettings, /existing-token/);
-  assert.equal(await fs.readFile(existingRulePath, "utf8"), "existing rule\n");
-  process.env.REPO_PATTERN_GSTACK_SETUP_CMD = "true";
-  await provisionProject({
-    sourceRoot: repoRoot,
-    target: failedGstackProvisionTarget,
-    profile: "minimal",
-    setupPipeline: "gstack",
-    localSettingsEnv: { ANTHROPIC_AUTH_TOKEN: "replacement-token" },
-    migrate: true
-  });
-  assert.equal((await auditProject(failedGstackProvisionTarget)).state, "GSTACK_MINIMAL");
-  assert.match(await fs.readFile(localSettingsPath, "utf8"), /replacement-token/);
+  assert.match(localSettings, /replacement-token/);
+  await fs.access(path.join(failedGstackProvisionTarget, ".claude", "rules", "ecc", "common"));
+  assert.equal((await auditProject(failedGstackProvisionTarget)).state, "PARTIAL");
+  await assert.rejects(() => doctorProject(failedGstackProvisionTarget), /Doctor failed/);
 } finally {
-  if (originalGstackSetupCommand === undefined) delete process.env.REPO_PATTERN_GSTACK_SETUP_CMD;
-  else process.env.REPO_PATTERN_GSTACK_SETUP_CMD = originalGstackSetupCommand;
   console.log = originalLog;
   await fs.rm(failedGstackProvisionTarget, { recursive: true, force: true });
 }
@@ -142,13 +137,9 @@ try {
   const localSettingsPath = path.join(trackedGstackSettingsTarget, ".claude", "settings.local.json");
   await fs.writeFile(localSettingsPath, JSON.stringify({ enabledPlugins: { "ecc@ecc": true } }), { mode: 0o600 });
   spawnSync("git", ["add", ".claude/settings.local.json"], { cwd: trackedGstackSettingsTarget, stdio: "ignore" });
-  process.env.REPO_PATTERN_GSTACK_SETUP_CMD = "true";
-  await assert.rejects(() => setupGstack({ target: trackedGstackSettingsTarget }), /settings\.local\.json is tracked/);
   await assert.rejects(() => removeEccPluginSettings({ target: trackedGstackSettingsTarget }), /settings\.local\.json is tracked/);
   assert.match(await fs.readFile(localSettingsPath, "utf8"), /ecc@ecc/);
 } finally {
-  if (originalGstackSetupCommand === undefined) delete process.env.REPO_PATTERN_GSTACK_SETUP_CMD;
-  else process.env.REPO_PATTERN_GSTACK_SETUP_CMD = originalGstackSetupCommand;
   console.log = originalLog;
   await fs.rm(trackedGstackSettingsTarget, { recursive: true, force: true });
 }
@@ -185,17 +176,64 @@ await assert.rejects(
   /--with-plan-tune-hooks requires --setup-pipeline gstack or both/
 );
 
+const symlinkWriteTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-symlink-write-"));
+const symlinkWriteOutside = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-symlink-write-outside-"));
+try {
+  const settingsOutside = path.join(symlinkWriteOutside, "settings.json");
+  const repoConfigOutside = path.join(symlinkWriteOutside, "repo-config.json");
+  await fs.mkdir(path.join(symlinkWriteTarget, ".claude"));
+  await fs.writeFile(settingsOutside, "outside settings", "utf8");
+  await fs.symlink(settingsOutside, path.join(symlinkWriteTarget, ".claude", "settings.json"));
+  await assert.rejects(
+    () => updateClaudePermissions({ sourceRoot: repoRoot, target: symlinkWriteTarget, permissionConfig: { bypass: "deny" } }),
+    /settings\.json must not be a symlink/
+  );
+  assert.equal(await fs.readFile(settingsOutside, "utf8"), "outside settings");
+  await fs.rm(path.join(symlinkWriteTarget, ".claude", "settings.json"));
+
+  await fs.mkdir(path.join(symlinkWriteTarget, ".repo-pattern"));
+  await fs.writeFile(repoConfigOutside, "{}\n", "utf8");
+  await fs.symlink(repoConfigOutside, path.join(symlinkWriteTarget, ".repo-pattern", ".repo-pattern.json"));
+  await assert.rejects(
+    () => provisionProject({ sourceRoot: repoRoot, target: symlinkWriteTarget, profile: "minimal", setupPipeline: "none" }),
+    /repo-pattern\.json must not be a symlink/
+  );
+  assert.equal(await fs.readFile(repoConfigOutside, "utf8"), "{}\n");
+} finally {
+  await fs.rm(symlinkWriteTarget, { recursive: true, force: true });
+  await fs.rm(symlinkWriteOutside, { recursive: true, force: true });
+}
+
 const bothProvisionTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-both-provision-"));
 console.log = () => {};
 try {
   process.env.REPO_PATTERN_ECC_SETUP_CMD = "true";
-  process.env.REPO_PATTERN_GSTACK_SETUP_CMD = "true";
+  const gstackCheckout = path.join(bothProvisionTarget, ".claude", "skills", "gstack");
+  await fs.mkdir(path.join(gstackCheckout, "hosts", "claude", "hooks"), { recursive: true });
+  await fs.writeFile(path.join(gstackCheckout, "setup"), "#!/bin/sh\n", { mode: 0o755 });
+  await fs.writeFile(path.join(gstackCheckout, "SKILL.md"), "Project-local gstack", "utf8");
+  await fs.mkdir(path.join(gstackCheckout, "review"), { recursive: true });
+  await fs.writeFile(path.join(gstackCheckout, "review", "SKILL.md"), "Review", "utf8");
+  for (const sidecar of GSTACK_REVIEW_SIDECARS) {
+    await fs.mkdir(path.dirname(path.join(gstackCheckout, sidecar)), { recursive: true });
+    await fs.writeFile(path.join(gstackCheckout, sidecar), `Fixture ${sidecar}`, "utf8");
+  }
+  for (const hook of ["question-log-hook", "question-preference-hook"]) {
+    await fs.writeFile(path.join(gstackCheckout, "hosts", "claude", "hooks", hook), "#!/bin/sh\n", { mode: 0o755 });
+  }
+  spawnSync("git", ["init"], { cwd: gstackCheckout, stdio: "ignore" });
+  await fs.mkdir(path.join(bothProvisionTarget, ".repo-pattern"), { recursive: true });
+  await fs.writeFile(path.join(bothProvisionTarget, ".repo-pattern", ".repo-pattern.json"), JSON.stringify({
+    workflow: "gstack",
+    runtime: { localSkills: false, localCommands: false, localHooks: false, localScripts: false, localRules: false }
+  }), "utf8");
   await writeEccGitFixture(bothProvisionTarget);
   await provisionProject({
     sourceRoot: repoRoot,
     target: bothProvisionTarget,
     profile: "minimal",
     setupPipeline: "both",
+    migrate: true,
     planTuneHooks: true,
     localSettingsEnv: { ANTHROPIC_AUTH_TOKEN: secretSentinel }
   });
@@ -207,14 +245,15 @@ try {
   assert.equal(lock.ecc.status, "installed");
   assert.equal(lock.gstack.status, "installed");
   assert.equal(lock.gstack.planTuneHooks, true);
+  for (const sidecar of GSTACK_REVIEW_SIDECARS) {
+    assert.equal(await fs.readFile(path.join(bothProvisionTarget, ".claude", "skills", sidecar), "utf8"), `Fixture ${sidecar}`);
+  }
   assert.equal(localSettings.enabledPlugins["ecc@ecc"], true);
   assert.equal(localSettings.extraKnownMarketplaces.ecc.source.url, "https://github.com/affaan-m/ECC.git");
   assert.equal((await auditProject(bothProvisionTarget)).state, "ECC_GSTACK_MINIMAL");
   await doctorProject(bothProvisionTarget);
 } finally {
   delete process.env.REPO_PATTERN_ECC_SETUP_CMD;
-  if (originalGstackSetupCommand === undefined) delete process.env.REPO_PATTERN_GSTACK_SETUP_CMD;
-  else process.env.REPO_PATTERN_GSTACK_SETUP_CMD = originalGstackSetupCommand;
   console.log = originalLog;
   await fs.rm(bothProvisionTarget, { recursive: true, force: true });
 }
@@ -251,7 +290,7 @@ try {
   result = runCli(["setup", "--target", setupBothDryRunTarget, "--setup-pipeline", "both", "--yes", "--dry-run"]);
   assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /Setup pipeline\s+both/);
-  assert.match(result.stdout, /Pipeline scope\s+project-scoped ECC \+ user-scoped\/global gstack at\s+~\/\.claude\/skills\/gstack/);
+  assert.match(result.stdout, /Pipeline scope\s+project-scoped ECC \+ project-local gstack at \.claude\/skills\/gstack/);
 } finally {
   await fs.rm(setupBothDryRunTarget, { recursive: true, force: true });
 }


### PR DESCRIPTION
## Summary
- move gstack setup to a project-local checkout and state directory
- generate local wrappers, workflow assets, review sidecars, and optional plan-tune hooks without invoking upstream setup
- validate and harden project-local gstack state in audit and doctor, including symlink protections
- continue base/ECC setup if local gstack bootstrap fails
- update documentation and bump the package to 0.2.0

## Verification
- `npm test`
- `npm run test:coverage`
- `npm run check:module-limits`
- `npm run pack:dry`
- `git diff --check`
- `node .gitnexus/run.cjs detect-changes --repo repo-pattern --scope compare --base-ref main`

## Notes
- GitNexus reports CRITICAL change risk across 35 execution flows; the affected setup and self-check flows passed the checks above.
- The npm registry currently reports 0.1.19; this PR sets package metadata to 0.2.0.