### PR TITLE
ci: install Bun for release checks

### DIFF
--- a/.github/workflows/nodejs-package.yml
+++ b/.github/workflows/nodejs-package.yml
@@ -18,6 +18,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -41,6 +46,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
 
       - name: Setup Node.js for npmjs
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- provision Bun 1.3.14 in build and npm publish jobs
- keep the runtime Bun requirement explicit while making release CI satisfy it

## Verification
- npm test
- npm run test:coverage
- npm run check:module-limits
- npm run pack:dry
- npm publish --dry-run
- git diff --check