### PR TITLE
chore: release v0.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@negikirin/repo-pattern",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@negikirin/repo-pattern",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^0.11.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@negikirin/repo-pattern",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Minimal ECC-first Claude Code project setup and migrator",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
- bump package metadata to v0.2.1 after repairing Bun provisioning in release CI

## Verification
- npm test
- npm run test:coverage
- npm run check:module-limits
- npm run pack:dry
- npm publish --dry-run
- git diff --check