### PR TITLE
v0.2.2 fix: add gstack download spinner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@negikirin/repo-pattern",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@negikirin/repo-pattern",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^0.11.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@negikirin/repo-pattern",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Minimal ECC-first Claude Code project setup and migrator",
   "type": "module",
   "bin": {

--- a/scripts/lib/gstack.mjs
+++ b/scripts/lib/gstack.mjs
@@ -4,7 +4,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { appendGitignoreLine, ensureDir, exists, isTracked, readJson, removePath, writeJson, writePrivateJson } from "./fs-utils.mjs";
-import { isInteractive, printSummary, withSpinner } from "./prompt.mjs";
+import { printSummary, withSpinner } from "./prompt.mjs";
 
 const GSTACK_REPOSITORY = "https://github.com/garrytan/gstack.git";
 const GSTACK_DIAGNOSTIC_MAX_CHARS = 4000;
@@ -444,7 +444,8 @@ export async function resolveGstackCheckout({
   globalCheckout = globalGstackCheckoutPath(),
   run: runCommand = run,
   copy = fs.cp,
-  clone = (destination) => runCommand("git", ["clone", "--single-branch", "--depth", "1", GSTACK_REPOSITORY, destination], { stdio: "inherit" })
+  clone = (destination) => runCommand("git", ["clone", "--single-branch", "--depth", "1", GSTACK_REPOSITORY, destination], { stdio: ["ignore", "pipe", "pipe"], maxBuffer: Infinity }),
+  withSpinner: runWithSpinner = withSpinner
 }) {
   const localCheckout = gstackCheckoutPath(target);
   await assertNoSymlinkPath(target, path.relative(target, localCheckout));
@@ -472,7 +473,18 @@ export async function resolveGstackCheckout({
   const temporary = await fs.mkdtemp(path.join(parent, ".gstack-"));
   try {
     if (globalValid) await copy(globalCheckout, temporary, { recursive: true, force: true });
-    else await clone(temporary);
+    else await runWithSpinner("Downloading gstack", async () => {
+      try {
+        await clone(temporary);
+      } catch (error) {
+        const cloneError = new Error(error.message, { cause: error });
+        cloneError.gstackCloneFailure = true;
+        cloneError.stderr = error.stderr;
+        cloneError.stdout = error.stdout;
+        cloneError.status = error.status;
+        throw cloneError;
+      }
+    });
     if (!await isValidGstackCheckout(temporary, { run: runCommand })) {
       throw new Error("Resolved gstack checkout is invalid.");
     }
@@ -531,7 +543,7 @@ export function gstackEnvironment(bun, environment = process.env) {
   return { ...environment, PATH: `${path.dirname(bun)}${path.delimiter}${environment.PATH || ""}` };
 }
 
-export async function setupGstack({ target, dryRun = false, planTuneHooks = false }) {
+export async function setupGstack({ target, dryRun = false, planTuneHooks = false, resolveCheckout = resolveGstackCheckout }) {
   const checkout = gstackCheckoutPath(target);
   const statePath = gstackStatePath(target);
   let checkoutLease = null;
@@ -539,7 +551,7 @@ export async function setupGstack({ target, dryRun = false, planTuneHooks = fals
   try {
     if (!dryRun) ensureBun();
     const install = async () => {
-      const resolved = await resolveGstackCheckout({ target, dryRun });
+      const resolved = await resolveCheckout({ target, dryRun });
       checkoutLease = resolved;
       if (!dryRun) {
         const wrappers = await expectedGstackWrappers(target, checkout, statePath);
@@ -560,11 +572,7 @@ export async function setupGstack({ target, dryRun = false, planTuneHooks = fals
       }
       return { status: dryRun ? "dry-run" : "installed", source: resolved.source, path: checkout, statePath };
     };
-    const result = dryRun
-      ? await install()
-      : isInteractive()
-        ? await withSpinner("Installing project-local gstack", install)
-        : await install();
+    const result = await install();
     if (!dryRun) printSummary("gstack", gstackSummaryRows(target, planTuneHooks));
     return result;
   } catch (error) {
@@ -586,6 +594,10 @@ export async function setupGstack({ target, dryRun = false, planTuneHooks = fals
       } catch (rollbackError) {
         console.warn(`WARN: gstack checkout rollback failed: ${rollbackError.message}`);
       }
+    }
+    if (error.gstackCloneFailure) {
+      const stderr = String(error.stderr || "");
+      if (stderr) process.stderr.write(stderr);
     }
     return { status: "failed", path: checkout, statePath, error: redactedGstackDiagnostic(error) };
   }

--- a/scripts/self-check/gstack.mjs
+++ b/scripts/self-check/gstack.mjs
@@ -115,11 +115,17 @@ try {
     spawnSync("git", ["init"], { cwd: checkout, stdio: "ignore" });
   };
 
+  const reuseSpinnerMessages = [];
+  const recordReuseSpinner = async (message, task) => {
+    reuseSpinnerMessages.push(message);
+    return task();
+  };
   await createCheckout(localCheckout, "local");
   const reused = await resolveGstackCheckout({
     target: resolverTarget,
     globalCheckout,
-    clone: () => { throw new Error("clone should not run"); }
+    clone: () => { throw new Error("clone should not run"); },
+    withSpinner: recordReuseSpinner
   });
   assert.equal(reused.source, "local");
   assert.equal(await fs.readFile(path.join(localCheckout, "source"), "utf8"), "local");
@@ -129,21 +135,54 @@ try {
   const migrated = await resolveGstackCheckout({
     target: resolverTarget,
     globalCheckout,
-    clone: () => { throw new Error("clone should not run"); }
+    clone: () => { throw new Error("clone should not run"); },
+    withSpinner: recordReuseSpinner
   });
   assert.equal(migrated.source, "global-migration");
   assert.equal(await fs.readFile(path.join(localCheckout, "source"), "utf8"), "global");
   assert.equal(await fs.readFile(path.join(globalCheckout, "source"), "utf8"), "global");
+  assert.deepEqual(reuseSpinnerMessages, []);
 
   await fs.rm(localCheckout, { recursive: true, force: true });
   await fs.rm(globalCheckout, { recursive: true, force: true });
+  const spinnerMessages = [];
   const cloned = await resolveGstackCheckout({
-    target: resolverTarget,
-    globalCheckout,
-    clone: async (destination) => createCheckout(destination, "clone")
+    target: resolverTarget, globalCheckout, clone: async (destination) => createCheckout(destination, "clone"),
+    withSpinner: async (message, task) => { spinnerMessages.push(message); return task(); }
   });
   assert.equal(cloned.source, "clone");
   assert.equal(await fs.readFile(path.join(localCheckout, "source"), "utf8"), "clone");
+  assert.deepEqual(spinnerMessages, ["Downloading gstack"]);
+
+  await fs.rm(localCheckout, { recursive: true, force: true });
+  const defaultCloneOptions = [];
+  await assert.rejects(() => resolveGstackCheckout({
+    target: resolverTarget, globalCheckout,
+    run: (_command, _args, options) => { defaultCloneOptions.push(options); throw Object.assign(new Error("clone failed"), { stderr: "fatal: clone failed\n", status: 128 }); },
+    withSpinner: async (_message, task) => task()
+  }), /clone failed/);
+  assert.deepEqual(defaultCloneOptions[0].stdio, ["ignore", "pipe", "pipe"]);
+  assert.equal(defaultCloneOptions[0].maxBuffer, Infinity);
+
+  await fs.rm(localCheckout, { recursive: true, force: true });
+  const cloneFailure = Object.assign(new Error("clone failed"), { stderr: "fatal: complete clone stderr\nwith every line\n", status: 128 });
+  const failedSpinnerMessages = [];
+  await assert.rejects(() => resolveGstackCheckout({
+    target: resolverTarget, globalCheckout, run: () => { throw cloneFailure; },
+    withSpinner: async (message, task) => { failedSpinnerMessages.push(message); return task(); }
+  }), (error) => error.gstackCloneFailure && error.stderr === cloneFailure.stderr);
+  assert.deepEqual(failedSpinnerMessages, ["Downloading gstack"]);
+  assert.equal(await fs.access(localCheckout).then(() => true, () => false), false);
+
+  const originalStderrWrite = process.stderr.write;
+  const cloneFailureOutput = [];
+  process.stderr.write = (output) => { cloneFailureOutput.push(output); return true; };
+  try {
+    const failed = await setupGstack({ target: resolverTarget, resolveCheckout: async () => { throw Object.assign(new Error("clone failed"), { gstackCloneFailure: true, stderr: cloneFailure.stderr }); } });
+    assert.equal(failed.status, "failed");
+    assert.match(failed.error, /gstack output: \[redacted\]/);
+  } finally { process.stderr.write = originalStderrWrite; }
+  assert.deepEqual(cloneFailureOutput, [cloneFailure.stderr]);
 
   await fs.rm(localCheckout, { recursive: true, force: true });
   await assert.rejects(


### PR DESCRIPTION
## Summary

- Replace raw successful `git clone` progress with a `Downloading gstack` spinner scoped only to GitHub cloning.
- Preserve the existing shallow clone command, local/global checkout reuse, validation, bootstrap, hooks, transaction behavior, and dry-run output.
- On clone failure, stop the spinner, emit complete Git stderr verbatim, retain the `gstack setup failed` provision summary, and return the existing failed setup result.
- Bump the npm package metadata to `0.2.2` using this repository's established SemVer release format.

## Test Coverage

All new clone-path branches are covered by `scripts/self-check/gstack.mjs`, including local reuse, global migration, successful clone spinner scope, captured clone streams, unlimited stderr buffering, failure cleanup, verbatim stderr output, failed result status, and redacted returned diagnostics.

Coverage: 466/466 lines (100.0%), 69/72 functions (95.8%).

## Pre-Landing Review

No issues found.

## Design Review

No frontend files changed. Design review skipped.

## Eval Results

No prompt-related files changed. Eval suites skipped.

## Scope Drift

Scope Check: CLEAN

## Plan Completion

- [x] Capture clone output without inherited terminal streams.
- [x] Scope the spinner to GitHub cloning.
- [x] Preserve clone stderr and failed setup behavior.
- [x] Cover reuse, clone, and failure contracts.

Completion: 4/4 complete.

## Linked Spec

Closes #38

Implements the approved specification for issue #38.

## Test plan

- [x] `npm run test`
- [x] `npm run test:coverage`
- [x] `npm run check:module-limits`
- [x] `npm run pack:dry`
- [x] `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
