### PR TITLE
fix: group interactive setup progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## [0.2.9] - 2026-08-03
 
-**Interactive setup now shows one progress region, then one clear result.**
+**Interactive setup now shows three concise group spinners, then one clear result.**
 **Dry runs preview the same plan without touching the target project.**
 
-After confirming an interactive setup, users now see live setup progress followed by a compact completion panel. Setup still creates the same workspace, validates it with Doctor, preserves backups and rollback, and keeps verbose output for `--yes`, noninteractive, and redirected runs. Interactive failures clear the live display before showing the cause, rollback result, backup path when available, and recovery steps.
+After confirming an interactive setup, users now see three group spinners—ECC & gstack, Extended skills, and Setup—followed by a compact completion panel. Setup still creates the same workspace, validates it with Doctor, preserves backups and rollback, and keeps verbose output for `--yes`, noninteractive, and redirected runs. Interactive failures stop the affected group before showing the cause, rollback result, backup path when available, and recovery steps.
 
 ### The setup numbers that matter
 
@@ -13,7 +13,7 @@ These checks come from the reproducible `npm test` self-check suite, including `
 
 | Metric | Before | After | Δ |
 | --- | ---: | ---: | ---: |
-| Live progress regions after confirmation | multiple durable outputs | 1 | consolidated |
+| Interactive progress groups after confirmation | multiple durable outputs | 3 | grouped |
 | Completion-panel fields | expanded setup details | 3 required, 1 optional warning | compact |
 | Interactive dry-run filesystem writes | 0 | 0 | 0 |
 | Terminal streams required for ANSI output | 1 | 2 | +1 |
@@ -28,14 +28,14 @@ Interactive setup is easier to follow, especially for ECC, optional skills, and 
 
 ### Changed
 
-- Show confirmed interactive setup as one live progress display and a compact `Setup complete` panel.
-- Keep verbose setup, MCP, ECC, gstack, backup, and Doctor output for `--yes`, noninteractive, and redirected execution.
+- Show confirmed interactive setup as three Clack group spinners—`ECC & gstack`, `Extended skills`, and `Setup`—followed by a compact `Setup complete` panel.
+- Keep verbose setup, MCP, ECC, gstack, backup, and Doctor output for `--yes`, CI, noninteractive, and redirected execution.
 - Require both standard input and standard output to be TTYs before emitting ANSI control sequences.
 
 ### Fixed
 
 - Preserve full interactive dry-run progress while preventing filesystem writes and false backup-created messages.
-- Clear live progress before failure diagnostics, rollback results, backup locations, and recovery guidance.
+- Stop group spinners before failure diagnostics, rollback results, backup locations, and recovery guidance.
 - Persist successful setup status before rendering the visible success panel.
 - Reject destination symlinks during recursive copies so setup cannot write outside the target workspace.
 - Avoid duplicate durable `100%` progress lines when file copies finish.

--- a/scripts/lib/progress.mjs
+++ b/scripts/lib/progress.mjs
@@ -1,13 +1,14 @@
+import { spinner } from "@clack/prompts";
+
 const MILESTONES = [0, 25, 50, 75, 100];
-const REDRAW_INTERVAL_MS = 66;
+const GROUPS = [
+  { id: "components", label: "ECC & gstack" },
+  { id: "skills", label: "Extended skills" },
+  { id: "setup", label: "Setup" }
+];
 
 function clampPercent(value) {
   return Math.max(0, Math.min(100, Math.round(Number(value) || 0)));
-}
-
-function progressBar(percent, width = 20) {
-  const filled = Math.round(percent * width / 100);
-  return `${"█".repeat(filled)}${"░".repeat(width - filled)}`;
 }
 
 function operationPercent(completedUnits, totalUnits) {
@@ -37,20 +38,16 @@ function createRecord({ id, label, totalUnits = 0, unitLabel = "", weight = 1, d
   };
 }
 
-function formatInteractiveOperation(operation) {
-  const detail = operation.skipped ? "skipped" : operation.detail;
-  return `${operation.label} [${progressBar(operation.percent)}] ${operation.percent}%${detailSuffix(detail)}`;
+function groupForOperation(id) {
+  if (["ecc-cache", "ecc-sync", "ecc-backup", "gstack-checkout", "gstack-bootstrap", "gstack-hooks"].includes(id)) return "components";
+  if (id === "skills-backup" || id.startsWith("skill-git-") || id.startsWith("skill-copy-")) return "skills";
+  return "setup";
 }
 
-export function createProgressReporter({ interactive = false, ansi = false, write = null, plan = [], setupId = "setup" } = {}) {
+export function createProgressReporter({ write = null, plan = [], setupId = "setup" } = {}) {
   const operations = new Map();
-  const output = write || ((line) => process.stdout.write(interactive && ansi ? line : `${line}\n`));
+  const output = write || ((line) => process.stdout.write(`${line}\n`));
   let orderedIds = [];
-  let liveActive = false;
-  let liveLineCount = 0;
-  let lastRenderAt = 0;
-  let redrawTimer = null;
-  let dirty = false;
 
   for (const entry of plan) {
     if (entry.id && !operations.has(entry.id)) {
@@ -59,11 +56,7 @@ export function createProgressReporter({ interactive = false, ansi = false, writ
     }
   }
 
-  function orderedOperations() {
-    return orderedIds.map((id) => operations.get(id)).filter(Boolean);
-  }
-
-  function renderDurable(operation, terminal) {
+  function render(operation, terminal = false) {
     const milestones = terminal
       ? [operation.percent]
       : MILESTONES.filter((milestone) => milestone < 100 && milestone <= operation.percent && !operation.renderedMilestones.has(milestone));
@@ -73,67 +66,14 @@ export function createProgressReporter({ interactive = false, ansi = false, writ
     }
   }
 
-  function renderLive(force = false) {
-    if (!interactive || !ansi || (!dirty && !force)) return;
-    const rows = orderedOperations().map(formatInteractiveOperation);
-    const previousRows = liveLineCount;
-    const rowCount = Math.max(previousRows, rows.length);
-    const frame = liveActive
-      ? `\x1b[${previousRows}A\x1b[0G${Array.from({ length: rowCount }, (_, index) => `\x1b[2K\r${rows[index] || ""}\n`).join("")}`
-      : `${rows.map((row) => `${row}\n`).join("")}`;
-    output(frame);
-    liveActive = rows.length > 0;
-    liveLineCount = rows.length;
-    lastRenderAt = Date.now();
-    dirty = false;
-  }
-
-  function scheduleRender() {
-    if (redrawTimer !== null) return;
-    const delay = Math.max(0, REDRAW_INTERVAL_MS - (Date.now() - lastRenderAt));
-    redrawTimer = setTimeout(() => {
-      redrawTimer = null;
-      renderLive();
-    }, delay);
-  }
-
-  function render(operation, { terminal = false } = {}) {
-    if (interactive && ansi) {
-      dirty = true;
-      if (terminal) {
-        if (redrawTimer !== null) clearTimeout(redrawTimer);
-        redrawTimer = null;
-        renderLive(true);
-      } else if (!liveActive || Date.now() - lastRenderAt >= REDRAW_INTERVAL_MS) {
-        renderLive(true);
-      } else {
-        scheduleRender();
-      }
-      return;
-    }
-    renderDurable(operation, terminal);
-  }
-
   function update(operation, { completedUnits = operation.completedUnits, totalUnits = operation.totalUnits, detail, terminal = false } = {}) {
     if (operation.completed || operation.failed || operation.skipped) return operation;
     operation.totalUnits = Math.max(0, Number(totalUnits) || 0);
     operation.completedUnits = Math.max(operation.completedUnits, Math.max(0, Number(completedUnits) || 0));
     operation.percent = Math.max(operation.percent, operationPercent(operation.completedUnits, operation.totalUnits));
     if (detail !== undefined) operation.detail = detail;
-    render(operation, { terminal });
+    render(operation, terminal);
     return operation;
-  }
-
-  function flush() {
-    if (redrawTimer !== null) clearTimeout(redrawTimer);
-    redrawTimer = null;
-    if (!liveActive) return;
-    renderLive();
-    const frame = `\x1b[${liveLineCount}A\x1b[0G${Array.from({ length: liveLineCount }, () => "\x1b[2K\r\n").join("")}`.slice(0, -1);
-    output(frame);
-    liveActive = false;
-    liveLineCount = 0;
-    dirty = false;
   }
 
   function failOperation(id, detail = "failed") {
@@ -142,7 +82,7 @@ export function createProgressReporter({ interactive = false, ansi = false, writ
     operation.completed = false;
     operation.failed = true;
     operation.detail = detail;
-    render(operation, { terminal: true });
+    render(operation, true);
     return operation;
   }
 
@@ -152,7 +92,7 @@ export function createProgressReporter({ interactive = false, ansi = false, writ
     operation.skipped = true;
     operation.percent = 100;
     operation.detail = "skipped";
-    render(operation, { terminal: true });
+    render(operation, true);
     return operation;
   }
 
@@ -183,24 +123,143 @@ export function createProgressReporter({ interactive = false, ansi = false, writ
         operation.percent = 100;
         operation.completed = true;
         if (detail !== undefined) operation.detail = detail;
-        render(operation, { terminal: true });
+        render(operation, true);
         return operation;
       },
       fail({ detail = "failed" } = {}) {
         if (operation.completed || operation.failed || operation.skipped) return operation;
         operation.failed = true;
         operation.detail = detail;
-        render(operation, { terminal: true });
+        render(operation, true);
         return operation;
       }
     };
   }
 
-  return { beginOperation, failOperation, skipOperation, operations, flush };
+  return { beginOperation, failOperation, skipOperation, operations, flush() {} };
+}
+
+function createInteractiveSetupProgress(plan, { spinnerFactory = spinner, hasExtendedSkills = false } = {}) {
+  const operations = new Map(plan.map((entry) => [entry.id, { ...entry, started: false, completed: false, failed: false, skipped: false }]));
+  const groups = new Map(GROUPS.map(({ id, label }) => [id, {
+    id,
+    label,
+    spinner: spinnerFactory(),
+    operationIds: plan.filter((entry) => groupForOperation(entry.id) === id).map((entry) => entry.id),
+    hasWork: id === "setup" || (id === "skills" && hasExtendedSkills) || plan.some((entry) => groupForOperation(entry.id) === id),
+    started: false,
+    stopped: false,
+    managed: false
+  }]));
+
+  function startGroup(id) {
+    const group = groups.get(id);
+    if (!group || group.started || group.stopped) return;
+    group.spinner.start(group.label);
+    group.started = true;
+  }
+
+  function stopGroup(id, detail) {
+    const group = groups.get(id);
+    if (!group || group.stopped) return;
+    startGroup(id);
+    group.spinner.stop(`${group.label} ${detail}`);
+    group.stopped = true;
+  }
+
+  for (const group of groups.values()) {
+    if (!group.hasWork) stopGroup(group.id, "Skipped");
+  }
+
+  function finishGroupWhenReady(id) {
+    const group = groups.get(id);
+    if (!group || group.stopped || group.managed || id === "setup") return;
+    if (group.operationIds.every((operationId) => {
+      const operation = operations.get(operationId);
+      return operation?.completed || operation?.skipped;
+    })) stopGroup(id, "completed");
+  }
+
+  function failGroup(id, detail = "failed") {
+    stopGroup(id, detail === "failed" ? "failed" : `${detail} failed`);
+    stopGroup("setup", "failed");
+  }
+
+  function operationHandle(operation) {
+    return {
+      get percent() { return operation.percent || 0; },
+      get state() { return { ...operation }; },
+      update({ completedUnits = operation.completedUnits, totalUnits = operation.totalUnits } = {}) {
+        operation.totalUnits = Math.max(0, Number(totalUnits) || 0);
+        operation.completedUnits = Math.max(operation.completedUnits || 0, Math.max(0, Number(completedUnits) || 0));
+        operation.percent = Math.max(operation.percent || 0, operationPercent(operation.completedUnits, operation.totalUnits));
+        return operation;
+      },
+      complete() {
+        if (operation.completed || operation.failed || operation.skipped) return operation;
+        operation.completed = true;
+        operation.percent = 100;
+        finishGroupWhenReady(groupForOperation(operation.id));
+        return operation;
+      },
+      fail() {
+        if (operation.completed || operation.failed || operation.skipped) return operation;
+        operation.failed = true;
+        failGroup(groupForOperation(operation.id), operation.label);
+        return operation;
+      }
+    };
+  }
+
+  return {
+    beginOperation(spec) {
+      if (!spec.id) throw new Error("Progress operation id is required.");
+      const operation = operations.get(spec.id) || { ...spec, completedUnits: 0, percent: 0, completed: false, failed: false, skipped: false };
+      operation.label = spec.label || operation.label;
+      operation.started = true;
+      operation.totalUnits = Math.max(0, Number(spec.totalUnits) || 0);
+      operations.set(spec.id, operation);
+      startGroup(groupForOperation(spec.id));
+      startGroup("setup");
+      return operationHandle(operation);
+    },
+    skipOperation(id) {
+      const operation = operations.get(id);
+      if (!operation || operation.completed || operation.failed || operation.skipped) return;
+      operation.skipped = true;
+      operation.percent = 100;
+      finishGroupWhenReady(groupForOperation(id));
+    },
+    beginGroup(id) {
+      const group = groups.get(id);
+      if (group) group.managed = true;
+      startGroup(id);
+    },
+    completeGroup(id) {
+      stopGroup(id, "completed");
+    },
+    failGroup,
+    complete({ detail = "completed" } = {}) {
+      for (const group of groups.values()) {
+        if (!group.stopped && group.id !== "setup") stopGroup(group.id, "completed");
+      }
+      stopGroup("setup", detail);
+    },
+    fail() {
+      for (const group of groups.values()) {
+        if (group.id !== "setup" && group.started && !group.stopped) stopGroup(group.id, "failed");
+      }
+      stopGroup("setup", "failed");
+    },
+    flush() {},
+    operations
+  };
 }
 
 export function createSetupProgress(plan = [], options = {}) {
   if (!plan.length) return null;
+  if (options.interactive && options.ansi) return createInteractiveSetupProgress(plan, options);
+
   const reporter = createProgressReporter({ ...options, plan });
   const weights = new Map(plan.map((entry) => [entry.id, Math.max(0, Number(entry.weight) || 0)]));
   const setup = reporter.beginOperation({ id: "setup", label: "Setup", totalUnits: 100, weight: 0, detail: "preparing resources" });

--- a/scripts/lib/provision.mjs
+++ b/scripts/lib/provision.mjs
@@ -193,6 +193,7 @@ async function rejectClaudeSymlink(target, { dryRun = false } = {}) {
   const managedPaths = [
     [".claude", ".claude"],
     [".claude/settings.json", ".claude/settings.json"],
+    [".claude/settings.local.json", ".claude/settings.local.json"],
     [".repo-pattern", ".repo-pattern"],
     [".repo-pattern/.repo-pattern.json", ".repo-pattern/.repo-pattern.json"],
     [".repo-pattern/.repo-pattern.lock.json", ".repo-pattern/.repo-pattern.lock.json"]
@@ -296,6 +297,7 @@ export async function provisionProject({ sourceRoot, target, profile = "web", se
   const localOptionalSkills = optionalSkills
     .map((value) => OPTIONAL_SKILLS.find((skill) => skill.value === value))
     .filter((skill) => skill && !skill.plugin);
+  const hasPluginOnlySkills = optionalSkills.some((value) => OPTIONAL_SKILLS.find((skill) => skill.value === value)?.plugin) && localOptionalSkills.length === 0;
   const progressPlan = [
     { id: "backup", label: "Backing up workspace", weight: 1 },
     { id: "workspace", label: "Generating workspace", weight: 2 },
@@ -317,8 +319,9 @@ export async function provisionProject({ sourceRoot, target, profile = "web", se
     ] : [])
   ];
   const progress = createSetupProgress(progressPlan, {
-    interactive: Boolean(interactiveSetup && process.stdin.isTTY && process.stdout.isTTY),
-    ansi: Boolean(interactiveSetup && process.stdin.isTTY && process.stdout.isTTY && !process.env.NO_COLOR && process.env.TERM !== "dumb")
+    interactive: Boolean(interactiveSetup && process.stdin.isTTY && process.stdout.isTTY && !process.env.CI),
+    ansi: Boolean(interactiveSetup && process.stdin.isTTY && process.stdout.isTTY && !process.env.CI && !process.env.NO_COLOR && process.env.TERM !== "dumb"),
+    hasExtendedSkills: localOptionalSkills.length > 0 || hasPluginOnlySkills
   });
   const provisionSnapshot = await snapshotProvisionState(target, { dryRun });
   let backupRoot = null;
@@ -383,6 +386,7 @@ export async function provisionProject({ sourceRoot, target, profile = "web", se
       ? await applyEccRules({ target, dryRun, ruleMode, rules, progress, silent: interactiveSetup })
       : await clearEccRules({ target, dryRun, silent: interactiveSetup });
     if (eccRulesResult?.warnings) eccWarnings = eccRulesResult.warnings;
+    if (hasPluginOnlySkills) progress?.beginGroup?.("skills");
     await applyOptionalSkills({
       target,
       skills: optionalSkills,
@@ -392,6 +396,7 @@ export async function provisionProject({ sourceRoot, target, profile = "web", se
       progress,
       silent: interactiveSetup
     });
+    if (hasPluginOnlySkills) progress?.completeGroup?.("skills");
   } catch (error) {
     progress?.fail({ detail: "failed" });
     progress?.flush?.();
@@ -423,6 +428,7 @@ export async function provisionProject({ sourceRoot, target, profile = "web", se
   if (usesGstack(setupPipeline)) gstackStatus = await setupGstack({ target, dryRun, planTuneHooks, progress, silent: interactiveSetup });
   const gstackFailed = gstackStatus?.status === "failed";
   if (gstackFailed) {
+    progress?.failGroup?.("components", "Downloading gstack");
     progress?.fail({ detail: "gstack setup failed" });
     progress?.flush?.();
     const gstackError = `gstack setup failed: ${gstackStatus.error}`;
@@ -463,12 +469,7 @@ export async function provisionProject({ sourceRoot, target, profile = "web", se
   });
   await ensureRepoPatternGitignore(target, { dryRun, silent: interactiveSetup });
 
-  if (dryRun) {
-    progress?.complete({ detail: "preview" });
-  } else {
-    await doctorProject(target, { updateLock: true, dryRun, silent: interactiveSetup });
-    progress?.complete({ detail: "completed" });
-  }
+  if (!dryRun) await doctorProject(target, { updateLock: true, dryRun, silent: interactiveSetup });
 
   const warnings = [
     ...(eccStatus === "manual-plugin-install-required" ? ["ECC plugin pending: run /plugin install ecc@ecc in Claude Code"] : []),
@@ -515,5 +516,6 @@ export async function provisionProject({ sourceRoot, target, profile = "web", se
     }
     throw error;
   }
+  progress?.complete({ detail: dryRun ? "preview" : "completed" });
   printSummary("Setup complete", interactiveSetup ? compactSummary : detailedSummary, { progress });
 }

--- a/scripts/self-check/filesystem.mjs
+++ b/scripts/self-check/filesystem.mjs
@@ -214,7 +214,7 @@ const settingsSymlinkDestination = path.join(os.tmpdir(), `repo-pattern-settings
 console.log = () => {};
 try {
   await fs.mkdir(path.join(settingsSymlinkTarget, ".claude"));
-  await fs.writeFile(settingsSymlinkDestination, "unchanged", "utf8");
+  await fs.mkdir(settingsSymlinkDestination);
   await fs.symlink(settingsSymlinkDestination, path.join(settingsSymlinkTarget, ".claude", "settings.local.json"));
   await assert.rejects(
     () => provisionProject({
@@ -225,11 +225,11 @@ try {
     }),
     /settings\.local\.json.*symlink/
   );
-  assert.equal(await fs.readFile(settingsSymlinkDestination, "utf8"), "unchanged");
+  assert.deepEqual(await fs.readdir(settingsSymlinkDestination), []);
 } finally {
   console.log = originalLog;
   await fs.rm(settingsSymlinkTarget, { recursive: true, force: true });
-  await fs.rm(settingsSymlinkDestination, { force: true });
+  await fs.rm(settingsSymlinkDestination, { recursive: true, force: true });
 }
 
 const doctorLockSymlinkTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-doctor-lock-symlink-target-"));

--- a/scripts/self-check/interactive-provision.mjs
+++ b/scripts/self-check/interactive-provision.mjs
@@ -4,17 +4,21 @@ import os from "node:os";
 import path from "node:path";
 import { provisionProject } from "../lib/provision.mjs";
 
-function withInteractiveTerminal(callback, { stdinTTY = true, stdoutTTY = true } = {}) {
+function withInteractiveTerminal(callback, { stdinTTY = true, stdoutTTY = true, env = {} } = {}) {
   const originalLog = console.log;
   const originalWarn = console.warn;
   const originalStdinTty = process.stdin.isTTY;
   const originalStdoutTty = process.stdout.isTTY;
+  const originalStdinSetRawMode = process.stdin.setRawMode;
   const originalStdoutWrite = process.stdout.write;
+  const originalEnv = Object.fromEntries(Object.keys(env).map((name) => [name, process.env[name]]));
   const output = [];
   const warnings = [];
 
   Object.defineProperties(process.stdin, { isTTY: { value: stdinTTY, configurable: true } });
   Object.defineProperties(process.stdout, { isTTY: { value: stdoutTTY, configurable: true } });
+  Object.assign(process.env, env);
+  process.stdin.setRawMode = () => {};
   process.stdout.write = (chunk) => {
     output.push(String(chunk));
     return true;
@@ -26,6 +30,11 @@ function withInteractiveTerminal(callback, { stdinTTY = true, stdoutTTY = true }
     console.log = originalLog;
     console.warn = originalWarn;
     process.stdout.write = originalStdoutWrite;
+    process.stdin.setRawMode = originalStdinSetRawMode;
+    for (const [name, value] of Object.entries(originalEnv)) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
     Object.defineProperties(process.stdin, { isTTY: { value: originalStdinTty, configurable: true } });
     Object.defineProperties(process.stdout, { isTTY: { value: originalStdoutTty, configurable: true } });
   });
@@ -45,17 +54,45 @@ export async function runInteractiveProvisionChecks(repoRoot) {
         interactiveSetup: true
       });
       const rendered = output.join("");
-      assert.match(rendered, /Generating workspace/);
-      assert.match(rendered, /Generating MCP workspace/);
+      const labels = ["ECC & gstack", "Extended skills", "Setup"];
+      for (const label of labels) assert.match(rendered, new RegExp(label));
+      assert(rendered.indexOf(labels[0]) < rendered.indexOf(labels[1]));
+      assert(rendered.indexOf(labels[1]) < rendered.indexOf(labels[2]));
+      assert.match(rendered, /ECC & gstack Skipped/);
+      assert.match(rendered, /Extended skills Skipped/);
+      assert.match(rendered, /Setup preview/);
       assert.match(rendered, /Setup complete/);
       assert.match(rendered, /Status\s+preview only/);
       assert.doesNotMatch(rendered, /Warnings\s+/);
-      assert.doesNotMatch(rendered, /Provisioning target|== Audit ==|MCP generated|Detected stack|Selected ECC rules|Applied optional skills|Backup created|\[dry-run\]/);
+      assert.doesNotMatch(rendered, /Generating workspace|Generating MCP workspace|\[████|%|Provisioning target|== Audit ==|MCP generated|Detected stack|Selected ECC rules|Applied optional skills|Backup created|\[dry-run\]/);
       assert.equal(warnings.length, 0);
     });
     assert.equal((await fs.readdir(successTarget)).length, 0);
   } finally {
     await fs.rm(successTarget, { recursive: true, force: true });
+  }
+
+  const pluginTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-interactive-plugin-"));
+  try {
+    await withInteractiveTerminal(async ({ output }) => {
+      await provisionProject({
+        sourceRoot: repoRoot,
+        target: pluginTarget,
+        profile: "minimal",
+        setupPipeline: "none",
+        optionalSkills: ["taste"],
+        dryRun: true,
+        mcpValues: { CONTEXT7_API_KEY: "interactive-test-key" },
+        interactiveSetup: true
+      });
+      const rendered = output.join("");
+      assert.match(rendered, /Extended skills completed/);
+      assert.match(rendered, /Setup preview/);
+      assert.doesNotMatch(rendered, /Syncing taste|Copying taste|%|\[████/);
+    });
+    assert.equal((await fs.readdir(pluginTarget)).length, 0);
+  } finally {
+    await fs.rm(pluginTarget, { recursive: true, force: true });
   }
 
   const parityTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-interactive-parity-"));
@@ -72,31 +109,23 @@ export async function runInteractiveProvisionChecks(repoRoot) {
         interactiveSetup: true
       });
       const rendered = output.join("");
-      for (const label of [
-        "Backing up workspace",
-        "Generating workspace",
-        "Generating MCP workspace",
-        "Syncing ECC cache",
-        "Staging ECC rules and agents",
-        "Backing up ECC rules",
-        "Backing up local skills",
-        "Syncing document-specialist",
-        "Copying document-specialist",
-        "Downloading gstack",
-        "Bootstrapping gstack",
-        "Writing gstack hooks"
-      ]) {
-        assert.match(rendered, new RegExp(`${label} .*preview`));
-      }
+      for (const label of ["ECC & gstack", "Extended skills", "Setup"]) assert.match(rendered, new RegExp(label));
+      assert.match(rendered, /ECC & gstack completed/);
+      assert.match(rendered, /Extended skills completed/);
+      assert.match(rendered, /Setup preview/);
       assert.match(rendered, /Status\s+preview only/);
-      assert.doesNotMatch(rendered, /\[dry-run\]|Setup pipeline|Doctor|Applied optional skills/);
+      assert.doesNotMatch(rendered, /Backing up workspace|Generating workspace|Generating MCP workspace|Syncing ECC cache|Staging ECC rules and agents|Backing up ECC rules|Backing up local skills|Syncing document-specialist|Copying document-specialist|Downloading gstack|Bootstrapping gstack|Writing gstack hooks|\[████|%|\[dry-run\]|Setup pipeline|Doctor|Applied optional skills/);
     });
     assert.equal((await fs.readdir(parityTarget)).length, 0);
   } finally {
     await fs.rm(parityTarget, { recursive: true, force: true });
   }
 
-  for (const ttyOptions of [{ stdinTTY: true, stdoutTTY: false }, { stdinTTY: false, stdoutTTY: true }]) {
+  for (const ttyOptions of [
+    { stdinTTY: true, stdoutTTY: false },
+    { stdinTTY: false, stdoutTTY: true },
+    { env: { CI: "true" } }
+  ]) {
     const asymmetricTarget = await fs.mkdtemp(path.join(os.tmpdir(), "repo-pattern-interactive-asymmetric-"));
     try {
       await withInteractiveTerminal(async ({ output }) => {
@@ -109,7 +138,9 @@ export async function runInteractiveProvisionChecks(repoRoot) {
           mcpValues: { CONTEXT7_API_KEY: "interactive-test-key" },
           interactiveSetup: true
         });
-        assert.doesNotMatch(output.join(""), /\x1b\[/);
+        const rendered = output.join("");
+        assert.doesNotMatch(rendered, /\x1b\[/);
+        if (ttyOptions.env) assert.match(rendered, /Setup 0%/);
       }, ttyOptions);
     } finally {
       await fs.rm(asymmetricTarget, { recursive: true, force: true });
@@ -140,8 +171,7 @@ export async function runInteractiveProvisionChecks(repoRoot) {
         }
       );
       const rendered = output.join("");
-      assert.match(rendered, /Generating workspace/);
-      assert.match(rendered, /\x1b\[2K\r/);
+      assert.match(rendered, /Setup failed/);
       assert.doesNotMatch(rendered, /Setup complete/);
     });
   } finally {
@@ -197,8 +227,9 @@ export async function runInteractiveProvisionChecks(repoRoot) {
         process.env.PATH = originalPath;
       }
       const rendered = output.join("");
-      assert.match(rendered, /\x1b\[2K\r/);
-      assert.ok(rendered.indexOf("\x1b\[2K\r") < rendered.indexOf("\nERROR: gstack setup failed"));
+      assert.match(rendered, /ECC & gstack Downloading gstack failed/);
+      assert.match(rendered, /Setup failed/);
+      assert.ok(rendered.indexOf("Setup failed") < rendered.indexOf("\nERROR: gstack setup failed"));
       assert.doesNotMatch(rendered, /Setup complete/);
     });
   } finally {
@@ -235,8 +266,8 @@ export async function runInteractiveProvisionChecks(repoRoot) {
         }
       );
       const rendered = output.join("");
-      assert.match(rendered, /\x1b\[2K\r/);
-      assert.ok(rendered.indexOf("\x1b[2K\r") < rendered.indexOf("\nERROR: Unknown optional skill(s): nope"));
+      assert.match(rendered, /Setup failed/);
+      assert.ok(rendered.indexOf("Setup failed") < rendered.indexOf("\nERROR: Unknown optional skill(s): nope"));
       assert.doesNotMatch(rendered, /Setup complete/);
     });
     assert.equal(await fs.readFile(path.join(failureTarget, "CLAUDE.md"), "utf8"), "existing instructions\n");

--- a/scripts/self-check/progress.mjs
+++ b/scripts/self-check/progress.mjs
@@ -3,7 +3,7 @@ import { createProgressReporter, createSetupProgress } from "../lib/progress.mjs
 
 export async function runProgressChecks() {
   const durable = [];
-  const reporter = createProgressReporter({ interactive: false, ansi: false, write: (line) => durable.push(line) });
+  const reporter = createProgressReporter({ write: (line) => durable.push(line) });
   const operation = reporter.beginOperation({ id: "clone", label: "Downloading gstack", totalUnits: 4, unitLabel: "files", weight: 2, detail: "Starting" });
   operation.update({ completedUnits: -2, detail: "Starting" });
   operation.update({ completedUnits: 2, detail: "Receiving objects" });
@@ -18,7 +18,7 @@ export async function runProgressChecks() {
   assert.equal(operation.percent, 100);
 
   const completeAfterUpdate = [];
-  const completeAfterUpdateReporter = createProgressReporter({ interactive: false, ansi: false, write: (line) => completeAfterUpdate.push(line) });
+  const completeAfterUpdateReporter = createProgressReporter({ write: (line) => completeAfterUpdate.push(line) });
   const completeAfterUpdateOperation = completeAfterUpdateReporter.beginOperation({ id: "copy", label: "Copying files", totalUnits: 1 });
   completeAfterUpdateOperation.update({ completedUnits: 1, detail: "1/1 files" });
   completeAfterUpdateOperation.complete({ detail: "completed" });
@@ -31,148 +31,90 @@ export async function runProgressChecks() {
   ]);
 
   const failed = [];
-  const failureReporter = createProgressReporter({ interactive: false, ansi: false, write: (line) => failed.push(line) });
+  const failureReporter = createProgressReporter({ write: (line) => failed.push(line) });
   const failedOperation = failureReporter.beginOperation({ id: "copy", label: "Copying skill", totalUnits: 4 });
   failedOperation.update({ completedUnits: 3, detail: "3/4 files" });
   failedOperation.fail({ detail: "failed" });
   assert.deepEqual(failed, ["Copying skill 0%", "Copying skill 25% · 3/4 files", "Copying skill 50% · 3/4 files", "Copying skill 75% · 3/4 files", "Copying skill 75% · failed"]);
   assert.equal(failedOperation.percent, 75);
 
-  const interactive = [];
-  const interactiveReporter = createProgressReporter({ interactive: true, ansi: true, write: (line) => interactive.push(line) });
-  const interactiveOperation = interactiveReporter.beginOperation({ id: "write", label: "Generating workspace", totalUnits: 2 });
-  interactiveOperation.update({ completedUnits: 1, detail: "1/2 files" });
-  interactiveOperation.complete({ detail: "completed" });
-  assert.match(interactive.join(""), /Generating workspace \[[█░]+\] 0%/);
-  assert.match(interactive.at(-1), /Generating workspace \[[█░]+\] 100% · completed/);
-  assert(interactive.some((frame) => frame.includes("\x1b[2K\r")));
+  const calls = [];
+  let spinnerCount = 0;
+  const spinnerFactory = () => {
+    spinnerCount += 1;
+    return {
+      start(message) { calls.push(`start ${message}`); },
+      stop(message) { calls.push(`stop ${message}`); }
+    };
+  };
+  const interactive = createSetupProgress([
+    { id: "workspace", label: "Generating workspace", weight: 1 },
+    { id: "ecc-cache", label: "Syncing ECC cache", weight: 1 },
+    { id: "skills-backup", label: "Backing up local skills", weight: 1 },
+    { id: "skill-git-document-specialist", label: "Syncing document-specialist", weight: 1 }
+  ], { interactive: true, ansi: true, spinnerFactory });
+  assert.equal(spinnerCount, 3);
+  assert.deepEqual(calls, []);
+  interactive.beginOperation({ id: "workspace", label: "Generating workspace", totalUnits: 1 }).complete();
+  assert.deepEqual(calls, ["start Setup"]);
+  interactive.beginOperation({ id: "ecc-cache", label: "Syncing ECC cache", totalUnits: 1 }).complete();
+  assert.deepEqual(calls, ["start Setup", "start ECC & gstack", "stop ECC & gstack completed"]);
+  interactive.beginOperation({ id: "skills-backup", label: "Backing up local skills", totalUnits: 1 }).complete();
+  assert.deepEqual(calls, ["start Setup", "start ECC & gstack", "stop ECC & gstack completed", "start Extended skills"]);
+  interactive.beginOperation({ id: "skill-git-document-specialist", label: "Syncing document-specialist", totalUnits: 1 }).complete();
+  interactive.complete({ detail: "preview" });
+  assert.deepEqual(calls.slice(-2), ["stop Extended skills completed", "stop Setup preview"]);
+  assert(calls.includes("stop ECC & gstack completed"));
+  assert.equal(calls.some((call) => /Generating workspace|Syncing ECC cache|Backing up local skills|%|\[/.test(call)), false);
 
-  const ordered = [];
-  const orderedSetup = createSetupProgress([
-    { id: "first", label: "First operation", weight: 1 },
-    { id: "second", label: "Second operation", weight: 1 }
-  ], { interactive: true, ansi: true, write: (frame) => ordered.push(frame) });
-  const initialRows = ordered[0].split("\n").filter(Boolean).map((row) => row.replace(/\x1b\[[0-9;]*[A-Za-z]/g, "").replace(/\r/g, ""));
-  assert.deepEqual(initialRows, [
-    "First operation [░░░░░░░░░░░░░░░░░░░░] 0%",
-    "Second operation [░░░░░░░░░░░░░░░░░░░░] 0%",
-    "Setup [░░░░░░░░░░░░░░░░░░░░] 0% · preparing resources"
+  const skippedCalls = [];
+  const skipped = createSetupProgress([{ id: "workspace", label: "Generating workspace", weight: 1 }], {
+    interactive: true,
+    ansi: true,
+    spinnerFactory: () => ({ start(message) { skippedCalls.push(`start ${message}`); }, stop(message) { skippedCalls.push(`stop ${message}`); } })
+  });
+  assert.deepEqual(skippedCalls, [
+    "start ECC & gstack",
+    "stop ECC & gstack Skipped",
+    "start Extended skills",
+    "stop Extended skills Skipped"
   ]);
-  const second = orderedSetup.beginOperation({ id: "second", label: "Second operation", totalUnits: 1 });
-  second.complete({ detail: "completed" });
-  const first = orderedSetup.beginOperation({ id: "first", label: "First operation", totalUnits: 2 });
-  first.update({ completedUnits: 1, detail: "working" });
-  orderedSetup.flush();
-  const latestOrdered = ordered.at(-2);
-  assert(latestOrdered.indexOf("First operation") < latestOrdered.indexOf("Second operation"));
-  assert(latestOrdered.indexOf("Second operation") < latestOrdered.indexOf("Setup"));
-  assert.match(latestOrdered, /Second operation \[[█░]+\] 100% · completed/);
-  assert.match(latestOrdered, /First operation \[[█░]+\] 50% · working/);
-  assert.match(latestOrdered, /\x1b\[3A\x1b\[0G/);
-  assert.equal((latestOrdered.match(/\x1b\[2K\r/g) || []).length, 3);
-  const framesBeforeCleanFlush = ordered.length;
-  orderedSetup.flush();
-  assert.equal(ordered.length, framesBeforeCleanFlush);
-  assert.equal(ordered.at(-1), "\x1b[3A\x1b[0G\x1b[2K\r\n\x1b[2K\r\n\x1b[2K\r");
+  skipped.beginOperation({ id: "workspace", label: "Generating workspace", totalUnits: 1 }).complete();
+  skipped.complete();
+  assert.deepEqual(skippedCalls.slice(-2), ["start Setup", "stop Setup completed"]);
 
-  const failedRows = [];
-  const failedSetup = createSetupProgress([
-    { id: "failure", label: "Failure operation", weight: 1 },
-    { id: "skipped", label: "Skipped operation", weight: 1 }
-  ], { interactive: true, ansi: true, write: (frame) => failedRows.push(frame) });
-  const failure = failedSetup.beginOperation({ id: "failure", label: "Failure operation", totalUnits: 4 });
-  failure.update({ completedUnits: 2, detail: "halfway" });
-  failure.fail();
-  failedSetup.skipOperation("skipped");
-  const failedFrame = failedRows.at(-1);
-  assert.match(failedFrame, /Failure operation \[[█░]+\] 50% · failed/);
-  assert.match(failedFrame, /Skipped operation \[[█░]+\] 100% · skipped/);
-  assert.equal((failedFrame.match(/Skipped operation/g) || []).length, 1);
-  assert.match(failedFrame, /Setup \[[█░]+\] 25% · failed/);
+  const failureCalls = [];
+  const failure = createSetupProgress([{ id: "gstack-checkout", label: "Downloading gstack", weight: 1 }], {
+    interactive: true,
+    ansi: true,
+    spinnerFactory: () => ({ start(message) { failureCalls.push(`start ${message}`); }, stop(message) { failureCalls.push(`stop ${message}`); } })
+  });
+  failure.beginOperation({ id: "gstack-checkout", label: "Downloading gstack", totalUnits: 1 }).fail();
+  failure.flush();
+  assert.deepEqual(failureCalls.slice(-2), ["stop ECC & gstack Downloading gstack failed", "stop Setup failed"]);
+  assert.equal(failureCalls.filter((call) => call.startsWith("stop ")).length, 3);
 
-  const interleaved = [];
-  const interleavedReporter = createProgressReporter({ interactive: true, ansi: true, write: (line) => interleaved.push(line) });
-  const interleavedOperation = interleavedReporter.beginOperation({ id: "copy", label: "Copying files", totalUnits: 2 });
-  interleavedOperation.update({ completedUnits: 1, detail: "1/2 files" });
-  interleavedReporter.flush();
-  interleaved.push("ordinary output\n");
-  interleavedOperation.complete({ detail: "completed" });
-  assert.equal(interleaved[3], "ordinary output\n");
-  assert.equal(interleaved[2], "\x1b[1A\x1b[0G\x1b[2K\r");
-  assert.match(interleaved[1], /Copying files \[[█░]+\] 50% · 1\/2 files/);
-  assert.match(interleaved.at(-1), /Copying files \[[█░]+\] 100% · completed/);
+  const activeGroupFailureCalls = [];
+  const activeGroupFailure = createSetupProgress([{ id: "gstack-checkout", label: "Downloading gstack", weight: 1 }], {
+    interactive: true,
+    ansi: true,
+    spinnerFactory: () => ({ start(message) { activeGroupFailureCalls.push(`start ${message}`); }, stop(message) { activeGroupFailureCalls.push(`stop ${message}`); } })
+  });
+  activeGroupFailure.beginOperation({ id: "gstack-checkout", label: "Downloading gstack", totalUnits: 1 });
+  activeGroupFailure.fail();
+  assert.deepEqual(activeGroupFailureCalls.slice(-2), ["stop ECC & gstack failed", "stop Setup failed"]);
 
-  const stdinOnlyTty = [];
-  const stdinOnlyReporter = createProgressReporter({ interactive: false, ansi: true, write: (line) => stdinOnlyTty.push(line) });
-  stdinOnlyReporter.beginOperation({ id: "stdin-only", label: "Redirected output", totalUnits: 1 }).complete();
-  assert.equal(stdinOnlyTty.some((frame) => frame.includes("\x1b[")), false);
-
-  const stdoutOnlyTty = [];
-  const stdoutOnlyReporter = createProgressReporter({ interactive: true, ansi: false, write: (line) => stdoutOnlyTty.push(line) });
-  stdoutOnlyReporter.beginOperation({ id: "stdout-only", label: "Redirected input", totalUnits: 1 }).complete();
-  assert.equal(stdoutOnlyTty.some((frame) => frame.includes("\x1b[")), false);
-
-  const throttled = [];
-  const throttledReporter = createProgressReporter({ interactive: true, ansi: true, write: (frame) => throttled.push(frame) });
-  const throttledOperation = throttledReporter.beginOperation({ id: "throttle", label: "Throttled operation", totalUnits: 10 });
-  for (let completedUnits = 1; completedUnits <= 9; completedUnits++) throttledOperation.update({ completedUnits });
-  assert(throttled.length < 10);
-  throttledOperation.complete({ detail: "completed" });
-  assert.match(throttled.at(-1), /Throttled operation \[[█░]+\] 100% · completed/);
-  throttledOperation.update({ completedUnits: 1, detail: "late" });
-  assert.match(throttled.at(-1), /Throttled operation \[[█░]+\] 100% · completed/);
-
-  const setupLines = [];
-  const setup = createSetupProgress([
-    { id: "workspace", label: "Generating workspace", weight: 1 },
-    { id: "gstack", label: "gstack", weight: 3 }
-  ], { interactive: false, ansi: false, write: (line) => setupLines.push(line) });
-  assert(setup);
-  const workspace = setup.beginOperation({ id: "workspace", label: "Generating workspace", totalUnits: 1 });
-  const gstack = setup.beginOperation({ id: "gstack", label: "Downloading gstack", totalUnits: 4 });
-  workspace.complete({ detail: "completed" });
-  gstack.update({ completedUnits: 4, detail: "Receiving objects" });
-  assert.equal(setupLines.some((line) => line.startsWith("Setup 100%")), false);
-  gstack.complete({ detail: "completed" });
-  assert(setupLines.some((line) => line.startsWith("Setup 25% · Generating workspace")));
-  assert(setupLines.some((line) => line.startsWith("Setup 50% · Downloading gstack")));
-  setup.complete({ detail: "completed" });
-  assert.equal(setupLines.at(-1), "Setup 100% · completed");
-  assert.equal(setupLines.filter((line) => line === "Setup 100% · completed").length, 1);
-  assert.equal(setupLines.some((line) => line.startsWith("Setup 100% · completed")), true);
-  setup.complete({ detail: "completed" });
-
-  const lateFailureLines = [];
-  const lateFailure = createSetupProgress([
-    { id: "workspace", label: "Generating workspace", weight: 1 }
-  ], { interactive: false, ansi: false, write: (line) => lateFailureLines.push(line) });
-  lateFailure.beginOperation({ id: "workspace", label: "Generating workspace", totalUnits: 1 }).complete();
-  lateFailure.complete();
-  lateFailure.fail({ detail: "doctor failed" });
-  assert.equal(lateFailureLines.at(-1), "Setup 100% · doctor failed");
-
-  const interactiveSetupLines = [];
-  const interactiveSetup = createSetupProgress([
-    { id: "workspace", label: "Generating workspace", weight: 1 },
-    { id: "gstack", label: "Downloading gstack", weight: 1 }
-  ], { interactive: true, ansi: true, write: (line) => interactiveSetupLines.push(line) });
-  interactiveSetup.beginOperation({ id: "workspace", label: "Generating workspace", totalUnits: 1 }).complete();
-  assert.match(interactiveSetupLines.at(-1), /Setup \[[█░]+\] 50% · Generating workspace\n$/);
-  interactiveSetup.beginOperation({ id: "gstack", label: "Downloading gstack", totalUnits: 1 }).complete();
-  interactiveSetup.complete();
-  assert.match(interactiveSetupLines.at(-1), /Setup \[[█░]+\] 100% · completed\n$/);
-  setup.fail({ detail: "failed" });
-  assert.equal(setupLines.filter((line) => line === "Setup 100% · completed").length, 1);
-  assert.equal(setupLines.filter((line) => line === "Setup 100% · failed").length, 1);
-  const unstartedLines = [];
-  const unstarted = createSetupProgress([
-    { id: "workspace", label: "Generating workspace", weight: 1 },
-    { id: "optional-backup", label: "Backing up optional files", weight: 1 }
-  ], { interactive: false, ansi: false, write: (line) => unstartedLines.push(line) });
-  unstarted.beginOperation({ id: "workspace", label: "Generating workspace", totalUnits: 1 }).complete();
-  unstarted.skipOperation("optional-backup");
-  unstarted.complete({ detail: "completed" });
-  assert.equal(unstartedLines.at(-1), "Setup 100% · completed");
-  assert.equal(unstartedLines.filter((line) => line === "Setup 100% · completed").length, 1);
+  const pluginCalls = [];
+  const plugin = createSetupProgress([{ id: "workspace", label: "Generating workspace", weight: 1 }], {
+    interactive: true,
+    ansi: true,
+    hasExtendedSkills: true,
+    spinnerFactory: () => ({ start(message) { pluginCalls.push(`start ${message}`); }, stop(message) { pluginCalls.push(`stop ${message}`); } })
+  });
+  plugin.beginGroup("skills");
+  plugin.completeGroup("skills");
+  plugin.beginOperation({ id: "workspace", label: "Generating workspace", totalUnits: 1 }).complete();
+  plugin.complete();
+  assert(pluginCalls.includes("stop Extended skills completed"));
   assert.equal(createSetupProgress([], { write: () => {} }), null);
 }


### PR DESCRIPTION
## Summary
- replace confirmed interactive progress rows with three Clack group spinners
- retain durable progress for --yes, CI, non-TTY, NO_COLOR, and TERM=dumb runs
- cover skipped groups, plugin-only skills, failures, symlink protection, and CI fallback

## Verification
- npm test
- npm run test:coverage
- npm audit --audit-level=high
- git diff --check

Coverage: 100% lines, 98.6% functions.