### PR TITLE
chore: sync version 0.2.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.2.12] - 2026-08-05
+
+**Synchronize the package and GitHub release stream after the prior `v0.2.11` release.**
+
+### Fixed
+
+- Align the published package version with the next unreleased patch slot, `0.2.12`.
+
 ## [0.2.10] - 2026-08-05
 
 **MCP setup now starts with the profile that fits the project.**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@negikirin/repo-pattern",
-  "version": "0.2.10",
+  "version": "0.2.12",
   "description": "Minimal ECC-first Claude Code project setup and migrator",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary

- align `package.json` with the next unreleased patch version, `0.2.12`
- add the corresponding changelog entry

## Verification

- `npm test`
- `npm run pack:dry`
- `git diff --check`